### PR TITLE
Changes based on swimming pool experts feedback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,13 @@ services:
     links:
       - postgres
 
+  backend-maintenance:
+    extends:
+      service: backend-base
+    entrypoint: lein run -m lipas.maintenance
+    links:
+      - postgres
+
   frontend-build:
     extends:
       service: backend-base

--- a/webapp/project.clj
+++ b/webapp/project.clj
@@ -17,7 +17,7 @@
                  [re-frame "0.10.5"]
                  [secretary "1.2.3"]
                  [ns-tracker "0.3.0"]
-                 [cljsjs/material-ui "1.2.1-0"]
+                 [cljsjs/material-ui "1.4.0-0"]
                  [tongue "0.2.4"]
                  [day8.re-frame/http-fx "0.1.6"]
                  [cljsjs/filesaverjs "1.3.3-0"]

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -169,22 +169,23 @@
              {:status 200
               :body   (core/energy-report db type-code year)}))}}]]]
 
-    {:data {:coercion   reitit.coercion.spec/coercion
-            :muuntaja   m/instance
-            :middleware [;; query-params & form-params
-                         params/wrap-params
-                         ;; content-negotiation
-                         muuntaja/format-negotiate-middleware
-                         ;; encoding response body
-                         muuntaja/format-response-middleware
-                         ;; exception handling
-                         exceptions-mw
-                         ;; decoding request body
-                         muuntaja/format-request-middleware
-                         ;; coercing response bodys
-                         coercion/coerce-response-middleware
-                         ;; coercing request parameters
-                         coercion/coerce-request-middleware]}})
+    {:data
+     {:coercion   reitit.coercion.spec/coercion
+      :muuntaja   m/instance
+      :middleware [;; query-params & form-params
+                   params/wrap-params
+                   ;; content-negotiation
+                   muuntaja/format-negotiate-middleware
+                   ;; encoding response body
+                   muuntaja/format-response-middleware
+                   ;; exception handling
+                   exceptions-mw
+                   ;; decoding request body
+                   muuntaja/format-request-middleware
+                   ;; coercing response bodys
+                   coercion/coerce-response-middleware
+                   ;; coercing request parameters
+                   coercion/coerce-request-middleware]}})
    (ring/routes
     (swagger-ui/create-swagger-ui-handler {:path "/"})
     (ring/create-default-handler))))

--- a/webapp/src/clj/lipas/maintenance.clj
+++ b/webapp/src/clj/lipas/maintenance.clj
@@ -33,12 +33,12 @@
   "Updates [:water-treatment :filtering-method] to match spec."
   [db user]
   (log/info "Starting to fix swimming pool (3110 3130) filtering methods..")
-  (let [data1   (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
-        data2   (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
-        path    [:water-treatment :filtering-methods]
-        allowed (-> swimming-pools/filtering-methods keys set)
-        spec    :lipas.swimming-pool.water-treatment/filtering-methods]
-    (->> (concat data1 data2)
+  (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
+        data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
+        path      [:water-treatment :filtering-methods]
+        allowed   (-> swimming-pools/filtering-methods keys set)
+        spec      :lipas.swimming-pool.water-treatment/filtering-methods]
+    (->> (concat data-3110 data-3130)
          (filter-valid-in path spec)
          (map #(update-in % path (partial filter allowed)))
          (map utils/clean)

--- a/webapp/src/clj/lipas/maintenance.clj
+++ b/webapp/src/clj/lipas/maintenance.clj
@@ -1,0 +1,83 @@
+(ns lipas.maintenance
+  (:require [lipas.backend.system :as backend]
+            [lipas.backend.core :as core]
+            [lipas.schema.core]
+            [lipas.utils :as utils]
+            [lipas.backend.db.db :as db]
+            [clojure.string :as string]
+            [clojure.edn :as edn]
+            [lipas.data.swimming-pools :as swimming-pools]
+            [lipas.data.materials :as materials]
+            [clojure.spec.alpha :as s]
+            [taoensso.timbre :as log]))
+
+(defn upsert-all!
+  ([db user sports-sites]
+   (upsert-all! db user :lipas/sports-site sports-sites))
+  ([db user spec sports-sites]
+   (if (utils/all-valid? spec sports-sites)
+     (if (empty? sports-sites)
+         (log/info "Collection contains 0 sports sites. Nothing to do!")
+         (do
+           (log/info "Starting to put" (count sports-sites) "records into db...")
+           (db/upsert-sports-sites! db user sports-sites)
+           (log/info "Done inserting data!")))
+     (log/error "Invalid data, check messages in STDOUT."))))
+
+(defn filter-valid-in [path spec coll]
+  (->> coll
+       (filter (comp some? #(get-in % path)))
+       (remove (comp (partial s/valid? spec) #(get-in % path)))))
+
+(defn fix-filtering-methods!
+  "Updates [:water-treatment :filtering-method] to match spec."
+  [db user]
+  (log/info "Starting to fix swimming pool (3110 3130) filtering methods..")
+  (let [data1   (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
+        data2   (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
+        path    [:water-treatment :filtering-methods]
+        allowed (-> swimming-pools/filtering-methods keys set)
+        spec    :lipas.swimming-pool.water-treatment/filtering-methods]
+    (->> (concat data1 data2)
+         (filter-valid-in path spec)
+         (map #(update-in % path (partial filter allowed)))
+         (map utils/clean)
+         (upsert-all! db user :lipas.sports-site/swimming-pool))))
+
+(defn fix-building-materials!
+  "Updates [:building :main-construction-materials] to contain only
+  allowed values."
+  [db user]
+  (log/info "Starting to fix swimming pool (3110 3130) building materials..")
+  (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
+        data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
+        path      [:building :main-construction-materials]
+        allowed   (-> materials/building-materials keys set)
+        spec      :lipas.building/main-construction-materials]
+    (->> (concat data-3110 data-3130)
+         (filter-valid-in path spec)
+         (map #(update-in % path (partial filter allowed)))
+         (map utils/clean)
+         (upsert-all! db user :lipas.sports-site/swimming-pool))))
+
+(defn print-usage! []
+  (println)
+  (println "Usage: lein run -m lipas.maintenance :task-name")
+  (println)
+  (println "Available tasks:")
+  (doseq [s [:fix-filtering-methods
+             :fix-building-materials]]
+    (println s)))
+
+(defn -main [& args]
+  (let [config (select-keys backend/default-config [:db])
+        system (backend/start-system! config)
+        db     (:db system)
+        user   (core/get-user db "import@lipas.fi")
+        task   (-> args first edn/read-string)]
+    (try
+      (case task
+        :fix-filtering-methods  (fix-filtering-methods! db user)
+        :fix-building-materials (fix-building-materials! db user)
+        (print-usage!))
+      (finally (backend/stop-system! system)))))

--- a/webapp/src/clj/lipas/migrate_data.clj
+++ b/webapp/src/clj/lipas/migrate_data.clj
@@ -461,13 +461,6 @@
       (-> (migrate-fn portal-entry lipas-entry)
           utils/clean))))
 
-(defn validate [spec data]
-  (spec/explain spec data)
-  (spec/valid? spec data))
-
-(defn all-valid? [spec data]
-  (every? true? (map (partial validate spec) data)))
-
 (defn upsert! [db user sports-sites]
   (log/info "Starting to put data into db...")
   (db/upsert-sports-sites! db user sports-sites)
@@ -480,7 +473,7 @@
         ice-stadiums (->> (->sports-sites ->ice-stadium lipas-data portal-data)
                           (remove nil?))]
 
-    (if (all-valid? :lipas.sports-site/ice-stadium ice-stadiums)
+    (if (utils/all-valid? :lipas.sports-site/ice-stadium ice-stadiums)
       (upsert! db user ice-stadiums)
       (log/error "Invalid data, check messages in STDOUT."))))
 
@@ -491,7 +484,7 @@
         swimming-pools (->> (->sports-sites ->swimming-pool lipas-data portal-data)
                             (remove nil?))]
 
-    (if (all-valid? :lipas.sports-site/swimming-pool swimming-pools)
+    (if (utils/all-valid? :lipas.sports-site/swimming-pool swimming-pools)
       (upsert! db user swimming-pools)
       (log/error "Invalid data, check messages in REPL."))))
 

--- a/webapp/src/cljc/lipas/data/materials.cljc
+++ b/webapp/src/cljc/lipas/data/materials.cljc
@@ -1,6 +1,6 @@
 (ns lipas.data.materials)
 
-;;;; Contains also structures
+;; Contains also structures
 
 (def all
   {"asphalt"          {:fi "Asfaltti"
@@ -74,8 +74,7 @@
                        :en "Composite beam"}})
 
 (def building-materials
-  (select-keys all ["concrete" "brick" "tile" "steel" "wood" "glass"
-                    "sheet-metal" "solid-rock"]))
+  (select-keys all ["concrete" "brick""steel" "wood" "solid-rock"]))
 
 (def slide-structures
   (select-keys all ["concrete" "steel" "hardened-plastic"]))
@@ -89,7 +88,7 @@
 
 (def ceiling-structures
   (select-keys all ["wood" "hollow-core-slab" "steel" "double-t-beam"
-                    "concrete" "glass" "solid-rock"]))
+                    "concrete" "glass" "solid-rock" "polyurethane-panel"]))
 
 (def base-floor-structures
   (select-keys all ["concrete" "asphalt" "sand"]))

--- a/webapp/src/cljc/lipas/data/swimming_pools.cljc
+++ b/webapp/src/cljc/lipas/data/swimming_pools.cljc
@@ -28,9 +28,6 @@
    "therapy-pool"      {:fi "Terapia-allas"
                         :se nil
                         :en "Therapy pool"}
-   "outdoor-pool"      {:fi "Ulkoallas"
-                        :se nil
-                        :en "Outdoor pool"}
    "other-pool"        {:fi "Muu allas"
                         :se nil
                         :en "Other pool"}

--- a/webapp/src/cljc/lipas/data/swimming_pools.cljc
+++ b/webapp/src/cljc/lipas/data/swimming_pools.cljc
@@ -39,15 +39,9 @@
                         :en "Fitness pool"}})
 
 (def filtering-methods
-  {"pressure-suction"      {:fi "Paineimu"
-                            :se nil
-                            :en "Pressure suction"}
-   "pressure-sand"         {:fi "Painehiekka"
+  {"pressure-sand"         {:fi "Painehiekka"
                             :se nil
                             :en "Pressure sand"}
-   "suction-sand"          {:fi "Imuhiekka"
-                            :se nil
-                            :en "Suction sand"}
    "open-sand"             {:fi "Avohiekka"
                             :se nil
                             :en "Open sand"}
@@ -63,12 +57,12 @@
    "precipitation"         {:fi "Saostus"
                             :se nil
                             :en "Precipitation"}
-   "sand"                  {:fi "Hiekka"
-                            :se nil
-                            :en "Sand"}
    "activated-carbon"      {:fi "Aktiivihiili"
                             :se nil
-                            :en "Activated carbon"}})
+                            :en "Activated carbon"}
+   "membrane-filtration"   {:fi "Kalvosuodatus"
+                            :se nil
+                            :en "Membrane filtration"}})
 
 (def sauna-types
   {"steam-sauna"    {:fi "Höyrysauna"
@@ -79,7 +73,10 @@
                      :en "Sauna"}
    "infrared-sauna" {:fi "Infrapunasauna"
                      :se nil
-                     :en "Infrared sauna"}})
+                     :en "Infrared sauna"}
+   "other-sauna"    {:fi "Muu sauna"
+                     :se nil
+                     :en "Other sauna"}})
 
 (def heat-sources
   {"private-power-station" {:fi "Oma voimalaitos"

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -91,16 +91,17 @@
     :select-rink    "Select stadium"}
 
    :lipas.energy-consumption
-   {:headline          "Energy consumption"
-    :headline-year     "Energy consumption in {1}"
-    :electricity       "Electricity MWh"
-    :heat              "Heat (acquired) MWh"
-    :cold              "Cold energy (acquired) Mwh"
-    :water             "Water m³"
-    :yearly            "Yearly energy consumption"
-    :monthly?          "I want to report monthly energy consumption"
-    :reported-for-year "Energy consumption reported for {1}"
-    :report            "Report consumption"}
+   {:headline                  "Energy consumption"
+    :headline-year             "Energy consumption in {1}"
+    :electricity               "Electricity MWh"
+    :heat                      "Heat (acquired) MWh"
+    :cold                      "Cold energy (acquired) Mwh"
+    :water                     "Water m³"
+    :yearly                    "Yearly energy consumption"
+    :monthly?                  "I want to report monthly energy consumption"
+    :reported-for-year         "Energy consumption reported for {1}"
+    :report                    "Report consumption"
+    :contains-other-buildings? "Readings contain also other buildings or spaces"}
 
    :lipas.energy-stats
    {:headline            "Energy consumption in {1}"

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -289,7 +289,7 @@
     :filtering-methods "Filtering methods"}
 
    :lipas.swimming-pool.pool
-   {:outdoor-pool? "Outdoor pool?"}
+   {:outdoor-pool? "Outdoor pool"}
 
    :lipas.swimming-pool.pools
    {:headline  "Pools"
@@ -303,11 +303,12 @@
     :edit-slide "Edit slide"}
 
    :lipas.swimming-pool.saunas
-   {:headline   "Saunas"
-    :add-sauna  "Add sauna"
-    :edit-sauna "Edit sauna"
-    :women?     "Women"
-    :men?       "Men"}
+   {:headline    "Saunas"
+    :add-sauna   "Add sauna"
+    :edit-sauna  "Edit sauna"
+    :women?      "Women"
+    :men?        "Men"
+    :accessible? "Accessible"}
 
    :lipas.swimming-pool.facilities
    {:headline                       "Other services"

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -288,6 +288,9 @@
     :activated-carbon? "Activated carbon"
     :filtering-methods "Filtering methods"}
 
+   :lipas.swimming-pool.pool
+   {:outdoor-pool? "Outdoor pool?"}
+
    :lipas.swimming-pool.pools
    {:headline  "Pools"
     :add-pool  "Add pool"

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -107,7 +107,7 @@
     :disclaimer          "*Based on reported consumption in {1}"
     :electricity-mwh     "Electricity MWh"
     :heat-mwh            "Heat MWh"
-    :water-m3            "Water M³"
+    :water-m3            "Water m³"
     :hall-missing?       "Is your data missing from the diagram?"
     :report              "Report consumption"
     :energy-reported-for "Electricity, heat and water consumption reported for {1}"}

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -121,7 +121,20 @@
    :lipas.swimming-pool.conditions
    {:headline          "Open hours"
     :daily-open-hours  "Daily open hours"
-    :open-days-in-year "Open days in year"}
+    :open-days-in-year "Open days in year"
+    :open-hours-mon    "Mondays"
+    :open-hours-tue    "Tuesdays"
+    :open-hours-wed    "Wednesdays"
+    :open-hours-thu    "Thursdays"
+    :open-hours-fri    "Fridays"
+    :open-hours-sat    "Saturdays"
+    :open-hours-sun    "Sundays"}
+
+   :lipas.swimming-pool.energy-saving
+   {:headline                    "Energy saving"
+    :shower-water-heat-recovery? "Shower water heat recovery?"
+    :filter-rinse-water-heat-recovery?
+    "Filter rinse water heat recovery?"}
 
    :swim
    {:headline       "Swimming pools"
@@ -371,8 +384,8 @@
     :long-time-ago      "Long time ago"}
 
    :duration
-   {:hour  "Hours"
-    :month "Months"}
+   {:hour  "hours"
+    :month "months"}
 
    :actions
    {:add               "Add"

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -87,16 +87,18 @@
    {:headline "Hallien vertailu"}
 
    :lipas.energy-consumption
-   {:headline          "Energiankulutus"
-    :headline-year     "Energiankulutus vuonna {1}"
-    :electricity       "Sähköenergia MWh"
-    :heat              "Lämpöenergia (ostettu) MWh"
-    :cold              "Kylmäenergia (ostettu) Mwh"
-    :water             "Vesi m³"
-    :yearly            "Energiankulutus vuositasolla"
-    :monthly?          "Haluan ilmoittaa energiankulutuksen kuukausitasolla"
-    :reported-for-year "Vuoden {1} energiankulutus ilmoitettu"
-    :report            "Ilmoita kulutus"}
+   {:headline                  "Energiankulutus"
+    :headline-year             "Energiankulutus vuonna {1}"
+    :electricity               "Sähköenergia MWh"
+    :heat                      "Lämpöenergia (ostettu) MWh"
+    :cold                      "Kylmäenergia (ostettu) Mwh"
+    :water                     "Vesi m³"
+    :yearly                    "Hallin energiankulutus vuositasolla"
+    :monthly?                  "Haluan ilmoittaa energiankulutuksen kuukausitasolla"
+    :reported-for-year         "Vuoden {1} energiankulutus ilmoitettu"
+    :report                    "Ilmoita kulutus"
+    :contains-other-buildings? "Lukemat sisältävät myös muita
+    rakennuksia tai tiloja"}
 
    :lipas.energy-stats
    {:headline            "Hallien energiankulutus vuonna {1}"

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -289,7 +289,7 @@
     :filtering-methods "Suodatustapa"}
 
    :lipas.swimming-pool.pool
-   {:outdoor-pool? "Ulkoallas?"}
+   {:outdoor-pool? "Ulkoallas"}
 
    :lipas.swimming-pool.pools
    {:headline  "Altaat"
@@ -303,11 +303,12 @@
     :edit-slide "Muokkaa liukumäkeä"}
 
    :lipas.swimming-pool.saunas
-   {:headline   "Saunat"
-    :add-sauna  "Lisää sauna"
-    :edit-sauna "Muokkaa saunaa"
-    :women?     "Naiset"
-    :men?       "Miehet"}
+   {:headline    "Saunat"
+    :add-sauna   "Lisää sauna"
+    :edit-sauna  "Muokkaa saunaa"
+    :women?      "Naiset"
+    :men?        "Miehet"
+    :accessible? "Esteetön"}
 
    :lipas.swimming-pool.facilities
    {:headline                       "Muut palvelut"

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -288,6 +288,9 @@
     :activated-carbon? "Aktiivihiili"
     :filtering-methods "Suodatustapa"}
 
+   :lipas.swimming-pool.pool
+   {:outdoor-pool? "Ulkoallas?"}
+
    :lipas.swimming-pool.pools
    {:headline  "Altaat"
     :add-pool  "Lisää allas"

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -103,7 +103,7 @@
     :disclaimer          "*Perustuu ilmoitettuihin kulutuksiin vuonna {1}"
     :electricity-mwh     "Sähkö MWh"
     :heat-mwh            "Lämpö MWh"
-    :water-m3            "Vesi M³"
+    :water-m3            "Vesi m³"
     :hall-missing?       "Puuttuvatko hallisi tiedot kuvasta?"
     :report              "Ilmoita tiedot"
     :energy-reported-for "Sähkön-, lämmön- ja vedenkulutus ilmoitettu vuodelta {1}"}

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -116,7 +116,20 @@
    :lipas.swimming-pool.conditions
    {:headline          "Aukiolo"
     :daily-open-hours  "Aukiolotunnit päivässä"
-    :open-days-in-year "Aukiolopäivät vuodessa"}
+    :open-days-in-year "Aukiolopäivät vuodessa"
+    :open-hours-mon    "Maanantaisin"
+    :open-hours-tue    "Tiistaisin"
+    :open-hours-wed    "Keskiviikkoisin"
+    :open-hours-thu    "Torstaisin"
+    :open-hours-fri    "Perjantaisin"
+    :open-hours-sat    "Lauantaisin"
+    :open-hours-sun    "Sunnuntaisin"}
+
+   :lipas.swimming-pool.energy-saving
+   {:headline                    "Energiansäästö"
+    :shower-water-heat-recovery? "Suihkuveden lämmöntalteenotto"
+    :filter-rinse-water-heat-recovery?
+    "Suodattimien huuhteluveden lämmöntalteenotto"}
 
    :swim
    {:headline       "Uimahalliportaali"

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -468,12 +468,14 @@
 ;; TODO find out realistic limits for cold energy
 (s/def :lipas.energy-consumption/cold-mwh (s/int-in 0 100000))
 (s/def :lipas.energy-consumption/water-m3 (s/int-in 0 500000))
+(s/def :lipas.energy-consumption/contains-other-buildings? boolean?)
 
 (s/def :lipas/energy-consumption
   (s/keys :opt-un [:lipas.energy-consumption/electricity-mwh
                    :lipas.energy-consumption/cold-mwh
                    :lipas.energy-consumption/heat-mwh
-                   :lipas.energy-consumption/water-m3]))
+                   :lipas.energy-consumption/water-m3
+                   :lipas.energy-consumption/contains-other-buildings?]))
 
 (def months #{:jan :feb :mar :apr :may :jun :jul :aug :sep :oct :nov :dec})
 

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -597,13 +597,15 @@
 
 (s/def :lipas.swimming-pool.sauna/men? boolean?)
 (s/def :lipas.swimming-pool.sauna/women? boolean?)
+(s/def :lipas.swimming-pool.sauna/accessible? boolean?)
 (s/def :lipas.swimming-pool.sauna/type
   (into #{} (keys swimming-pools/sauna-types)))
 
 (s/def :lipas.swimming-pool/sauna
   (s/keys :req-un [:lipas.swimming-pool.sauna/type]
           :opt-un [:lipas.swimming-pool.sauna/men?
-                   :lipas.swimming-pool.sauna/women?]))
+                   :lipas.swimming-pool.sauna/women?
+                   :lipas.swimming-pool.sauna/accessible?]))
 
 (s/def :lipas.swimming-pool/saunas
   (s/coll-of :lipas.swimming-pool/sauna

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -98,6 +98,8 @@
 (s/def :lipas/email-type (s/and string? #(re-matches email-regex %)))
 (s/def :lipas/email (s/with-gen :lipas/email-type email-gen))
 
+(s/def :lipas/hours-in-day (number-in :min 0 :max (inc 24)))
+
 ;;; User ;;;
 
 (s/def :lipas.user/id uuid?)
@@ -390,7 +392,7 @@
 (s/def :lipas.ice-stadium.conditions/air-humidity-min (s/int-in 0 (inc 100)))
 (s/def :lipas.ice-stadium.conditions/air-humidity-max (s/int-in 0 (inc 100)))
 (s/def :lipas.ice-stadium.conditions/stand-temperature-c (s/int-in -10 (inc 50)))
-(s/def :lipas.ice-stadium.conditions/daily-open-hours (s/int-in 0 (inc 24)))
+(s/def :lipas.ice-stadium.conditions/daily-open-hours :lipas/hours-in-day)
 (s/def :lipas.ice-stadium.conditions/open-months (s/int-in 0 (inc 12)))
 
 (s/def :lipas.ice-stadium.conditions/ice-surface-temperature-c
@@ -644,8 +646,25 @@
 ;; Conditions ;;
 
 (s/def :lipas.swimming-pool.conditions/open-days-in-year (s/int-in 0 (inc 365)))
+(s/def :lipas.swimming-pool.conditions/daily-open-hours :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-mon :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-tue :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-wed :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-thu :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-fri :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-sat :lipas/hours-in-day)
+(s/def :lipas.swimming-pool.conditions/open-hours-sun :lipas/hours-in-day)
+
 (s/def :lipas.swimming-pool/conditions
   (s/keys :opt-un [:lipas.swimming-pool.conditions/open-days-in-year
+                   :lipas.swimming-pool.conditions/open-hours-in-day
+                   :lipas.swimming-pool.conditions/open-hours-mon
+                   :lipas.swimming-pool.conditions/open-hours-tue
+                   :lipas.swimming-pool.conditions/open-hours-wed
+                   :lipas.swimming-pool.conditions/open-hours-thu
+                   :lipas.swimming-pool.conditions/open-hours-fri
+                   :lipas.swimming-pool.conditions/open-hours-sat
+                   :lipas.swimming-pool.conditions/open-hours-sun
                    :lipas.swimming-pool.conditions/total-visitors-count]))
 
 (s/def :lipas.swimming-pool.type/type-code #{3110 3120 3130})
@@ -653,6 +672,18 @@
   (s/merge
    :lipas.sports-site/type
    (s/keys :req-un [:lipas.swimming-pool.type/type-code])))
+
+;; Energy saving ;;
+(s/def :lipas.swimming-pool.energy-saving/shower-water-heat-recovery?
+  boolean?)
+
+(s/def :lipas.swimming-pool.energy-saving/filter-rinse-water-recovery?
+  boolean?)
+
+(s/def :lipas.swimming-pool/energy-saving
+  (s/keys :opt-un
+          [:lipas.swimming-pool.energy-saving/shower-water-heat-recovery?
+           :lipas.swimming-pool.energy-saving/filter-rinse-water-recovery?]))
 
 ;; Visitors ;;
 (s/def :lipas.swimming-pool.visitors/total-count (s/int-in 0 1000000))
@@ -672,6 +703,7 @@
                     :lipas.swimming-pool/slides
                     :lipas.swimming-pool/conditions
                     :lipas.swimming-pool/visitors
+                    :lipas.swimming-pool/energy-saving
                     :lipas/energy-consumption])))
 
 (s/def :lipas.sports-site/swimming-pools

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -556,9 +556,11 @@
 (s/def :lipas.swimming-pool.pool/depth-min-m (number-in :min 0 :max 10))
 (s/def :lipas.swimming-pool.pool/depth-max-m (number-in :min 0 :max 10))
 (s/def :lipas.swimming-pool.pool/type (into #{} (keys swimming-pools/pool-types)))
+(s/def :lipas.swimming-pool.pool/outdoor-pool? boolean?)
 
 (s/def :lipas.swimming-pool/pool
   (s/keys :opt-un [:lipas.swimming-pool.pool/type
+                   :lipas.swimming-pool.pool/outdoor-pool?
                    :lipas.swimming-pool.pool/temperature-c
                    :lipas.swimming-pool.pool/volume-m3
                    :lipas.swimming-pool.pool/area-m2

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -270,7 +270,13 @@
 
 ;;; Building ;;;
 
-(s/def :lipas.building/material (into #{} (keys materials/all)))
+(s/def :lipas.building/main-construction-material
+  (into #{} (keys materials/building-materials)))
+(s/def :lipas.building/supporting-structure
+  (into #{} (keys materials/supporting-structures)))
+(s/def :lipas.building/ceiling-structure
+  (into #{} (keys materials/ceiling-structures)))
+
 (s/def :lipas.building/construction-year :lipas.sports-site/construction-year)
 (s/def :lipas.building/main-designers (str-in 2 100))
 (s/def :lipas.building/total-surface-area-m2 (number-in :min 100 :max (inc 50000)))
@@ -286,23 +292,23 @@
 (s/def :lipas.building/ventilation-units-count (s/int-in 0 (inc 100)))
 
 (s/def :lipas.building/main-construction-materials
-  (s/coll-of :lipas.building/material
+  (s/coll-of :lipas.building/main-construction-material
              :min-count 0
-             :max-count 10
+             :max-count (count materials/building-materials)
              :distinct true
              :into []))
 
 (s/def :lipas.building/supporting-structures
-  (s/coll-of :lipas.building/material
+  (s/coll-of :lipas.building/supporting-structure
              :min-count 0
-             :max-count 10
+             :max-count (count materials/supporting-structures)
              :distinct true
              :into []))
 
 (s/def :lipas.building/ceiling-structures
-  (s/coll-of :lipas.building/material
+  (s/coll-of :lipas.building/ceiling-structure
              :min-count 0
-             :max-count 10
+             :max-count (count materials/ceiling-structures)
              :distinct true
              :into []))
 

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -1,5 +1,6 @@
 (ns lipas.utils
   (:require [clojure.walk :as walk]
+            [clojure.spec.alpha :as s]
             #?(:cljs [cljs.reader :refer [read-string]])
             #?(:cljs [goog.string :as gstring])
             #?(:cljs [goog.string.format])))
@@ -89,3 +90,10 @@
    :mean   (mean coll)
    :median (median coll)
    :mode   (mode coll)})
+
+(defn validate-noisy [spec data]
+  (s/explain spec data)
+  (s/valid? spec data))
+
+(defn all-valid? [spec data]
+  (every? true? (map (partial validate-noisy spec) data)))

--- a/webapp/src/cljs/lipas/ui/charts.cljs
+++ b/webapp/src/cljs/lipas/ui/charts.cljs
@@ -1,5 +1,6 @@
 (ns lipas.ui.charts
-  (:require ["recharts" :as rc]))
+  (:require ["recharts" :as rc]
+            [clojure.set :refer [rename-keys]]))
 
 (def colors
   {:electricity-mwh "#FFBD00"
@@ -7,11 +8,12 @@
    :water-m3        "#0a9bff"})
 
 (defn energy-chart [{:keys [data energy energy-label]}]
-  [:> rc/ResponsiveContainer {:width "100%" :height 300}
-   [:> rc/BarChart {:data data}
-    [:> rc/CartesianGrid]
-    [:> rc/Legend]
-    [:> rc/Tooltip]
-    [:> rc/YAxis]
-    [:> rc/XAxis {:dataKey :name :label false :tick false}]
-    [:> rc/Bar {:dataKey (name energy) :label false :fill (get colors energy)}]]])
+  (let [data (map #(rename-keys % {energy energy-label}) data)]
+   [:> rc/ResponsiveContainer {:width "100%" :height 300}
+    [:> rc/BarChart {:data data}
+     [:> rc/CartesianGrid]
+     [:> rc/Legend]
+     [:> rc/Tooltip]
+     [:> rc/YAxis]
+     [:> rc/XAxis {:dataKey :name :label false :tick false}]
+     [:> rc/Bar {:dataKey energy-label :label false :fill (get colors energy)}]]]))

--- a/webapp/src/cljs/lipas/ui/db.cljs
+++ b/webapp/src/cljs/lipas/ui/db.cljs
@@ -54,7 +54,6 @@
     :sauna-types       swimming-pools/sauna-types
     :filtering-methods swimming-pools/filtering-methods
     :heat-sources      swimming-pools/heat-sources
-    :slide-structures  materials/slide-structures
     :pool-structures   materials/pool-structures
     :editing           nil
     :editing?          false

--- a/webapp/src/cljs/lipas/ui/energy/events.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/events.cljs
@@ -27,11 +27,13 @@
          (assoc-in [:energy-consumption :year] year)
          (assoc-in [:sports-sites lipas-id :editing] rev)))))
 
-(defn- calculate-totals [data]
-  {:electricity-mwh (reduce + (map :electricity-mwh (vals data)))
-   :heat-mwh        (reduce + (map :heat-mwh (vals data)))
-   :cold-mwh        (reduce + (map :cold-mwh (vals data)))
-   :water-m3        (reduce + (map :water-m3 (vals data)))})
+(defn- calculate-totals [yearly-data monthly-data]
+  (merge
+   yearly-data
+   {:electricity-mwh (reduce + (map :electricity-mwh (vals monthly-data)))
+    :heat-mwh        (reduce + (map :heat-mwh (vals monthly-data)))
+    :cold-mwh        (reduce + (map :cold-mwh (vals monthly-data)))
+    :water-m3        (reduce + (map :water-m3 (vals monthly-data)))}))
 
 (re-frame/reg-event-db
  ::calculate-total-energy-consumption
@@ -41,7 +43,7 @@
          monthly-path (conj base-path :energy-consumption-monthly)
          monthly-data (get-in db monthly-path)]
      (if monthly-data
-       (update-in db yearly-path #(calculate-totals monthly-data))
+       (update-in db yearly-path #(calculate-totals % monthly-data))
        db))))
 
 (re-frame/reg-event-fx

--- a/webapp/src/cljs/lipas/ui/energy/events.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/events.cljs
@@ -74,7 +74,6 @@
 (re-frame/reg-event-fx
  ::fetch-energy-report
  (fn [{:keys [db]} [_ year type-code]]
-   ;; (prn "Get by type-code!")
    {:http-xhrio
     {:method          :post
      :params          {:type-code type-code

--- a/webapp/src/cljs/lipas/ui/energy/views.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/views.cljs
@@ -4,7 +4,7 @@
             [lipas.ui.energy.events :as events]
             [lipas.ui.energy.subs :as subs]
             [lipas.ui.mui :as mui]
-            [lipas.ui.utils :refer [<== ==>]]
+            [lipas.ui.utils :refer [<== ==>] :as utils]
             [reagent.core :as r]))
 
 (defn form [{:keys [tr data on-change disabled? cold?]}]
@@ -246,10 +246,11 @@
                          :xs    12 :md 12 :lg 12}
           [mui/form-group
            [lui/select
-            {:label     (tr :actions/select-year)
-             :value     year
-             :items     years
-             :on-change #(==> [::events/select-energy-consumption-year %])}]]])
+            {:label         (tr :actions/select-year)
+             :value         year
+             :items         years
+             :sort-cmp      utils/reverse-cmp
+             :on-change     #(==> [::events/select-energy-consumption-year %])}]]])
 
        (when (and sites site year)
          [energy-form

--- a/webapp/src/cljs/lipas/ui/energy/views.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/views.cljs
@@ -11,41 +11,52 @@
   [mui/form-group
 
    ;; Electricity Mwh
-   [lui/text-field {:label     (tr :lipas.energy-consumption/electricity)
-                    :disabled  disabled?
-                    :type      "number"
-                    :value     (:electricity-mwh data)
-                    :spec      :lipas.energy-consumption/electricity-mwh
-                    :adornment (tr :physical-units/mwh)
-                    :on-change #(on-change :electricity-mwh %)}]
+   [lui/text-field
+    {:label     (tr :lipas.energy-consumption/electricity)
+     :disabled  disabled?
+     :type      "number"
+     :value     (:electricity-mwh data)
+     :spec      :lipas.energy-consumption/electricity-mwh
+     :adornment (tr :physical-units/mwh)
+     :on-change #(on-change :electricity-mwh %)}]
 
    ;; Heat Mwh
-   [lui/text-field {:label     (tr :lipas.energy-consumption/heat)
-                    :disabled  disabled?
-                    :type      "number"
-                    :spec      :lipas.energy-consumption/heat-mwh
-                    :adornment (tr :physical-units/mwh)
-                    :value     (:heat-mwh data)
-                    :on-change #(on-change :heat-mwh %)}]
+   [lui/text-field
+    {:label     (tr :lipas.energy-consumption/heat)
+     :disabled  disabled?
+     :type      "number"
+     :spec      :lipas.energy-consumption/heat-mwh
+     :adornment (tr :physical-units/mwh)
+     :value     (:heat-mwh data)
+     :on-change #(on-change :heat-mwh %)}]
 
    ;; Cold Mwh
    (when cold?
-     [lui/text-field {:label     (tr :lipas.energy-consumption/cold)
-                      :disabled  disabled?
-                      :type      "number"
-                      :spec      :lipas.energy-consumption/cold-mwh
-                      :adornment (tr :physical-units/mwh)
-                      :value     (:cold-mwh data)
-                      :on-change #(on-change :cold-mwh %)}])
+     [lui/text-field
+      {:label     (tr :lipas.energy-consumption/cold)
+       :disabled  disabled?
+       :type      "number"
+       :spec      :lipas.energy-consumption/cold-mwh
+       :adornment (tr :physical-units/mwh)
+       :value     (:cold-mwh data)
+       :on-change #(on-change :cold-mwh %)}])
 
    ;; Water m³
-   [lui/text-field {:label     (tr :lipas.energy-consumption/water)
-                    :disabled  disabled?
-                    :type      "number"
-                    :spec      :lipas.energy-consumption/water-m3
-                    :adornment (tr :physical-units/m3)
-                    :value     (:water-m3 data)
-                    :on-change #(on-change :water-m3 %)}]])
+   [lui/text-field
+    {:label     (tr :lipas.energy-consumption/water)
+     :disabled  disabled?
+     :type      "number"
+     :spec      :lipas.energy-consumption/water-m3
+     :adornment (tr :physical-units/m3)
+     :value     (:water-m3 data)
+     :on-change #(on-change :water-m3 %)}]
+
+   ;; Contains other buildings?
+   [:span {:style {:margin-top "1em"}}
+    [lui/checkbox
+     {:label     (tr :lipas.energy-consumption/contains-other-buildings?)
+      :value     (:contains-other-buildings? data)
+      :on-change #(on-change :contains-other-buildings? %)}]]])
 
 (comment ;; Example data grid
   {:jan {:electricity-mwh 1233 :heat-mwh 2323 :cold-mwh 2323 :water-m3 5533}

--- a/webapp/src/cljs/lipas/ui/energy/views.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/views.cljs
@@ -260,7 +260,7 @@
            :monthly?  monthly?
            :cold?     cold?}])])))
 
-(defn energy-stats [{:keys [tr year stats]}]
+(defn energy-stats [{:keys [tr year stats link]}]
   (let [energy-type (<== [::subs/chart-energy-type])]
     [mui/grid {:container true}
 
@@ -298,7 +298,7 @@
         [mui/button {:color   :secondary
                      :size    :large
                      :variant :flat
-                     :href    "/#/uimahalliportaali/ilmoita-tiedot"}
+                     :href    link}
          (str "> " (tr :lipas.energy-stats/report))]]]]
 
      ;;; Hall of Fame (all energy info for previous year reported)

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
@@ -19,6 +19,7 @@
     [energy/energy-stats
      {:tr    tr
       :year  year
+      :link  "/#/jaahalliportaali/ilmoita-tiedot"
       :stats stats}]))
 
 (defn toggle-dialog

--- a/webapp/src/cljs/lipas/ui/sports_sites/events.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/events.cljs
@@ -67,12 +67,15 @@
  (fn [{:keys [db]} [_ result]]
    (let [tr     (:translator db)
          status (:status result)
-         type   (-> result :type :type-code)]
-     {:db       (utils/commit-edits db result) ;; Clear client side temp state
-      :dispatch [:lipas.ui.events/set-active-notification
-                 {:message  (tr :notifications/save-success)
-                  :success? true}]
-      :ga/event ["save-sports-site" status type]})))
+         type   (-> result :type :type-code)
+         year   (dec utils/this-year)]
+     {:db         (utils/commit-edits db result) ;; Clear client side temp state
+      :dispatch-n [[:lipas.ui.events/set-active-notification
+                    {:message  (tr :notifications/save-success)
+                     :success? true}]
+                   (when (#{2510 2520 3110 3130} type)
+                     [:lipas.ui.energy.events/fetch-energy-report year type])]
+      :ga/event   ["save-sports-site" status type]})))
 
 (re-frame/reg-event-fx
  ::save-failure

--- a/webapp/src/cljs/lipas/ui/swimming_pools/pools.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/pools.cljs
@@ -16,6 +16,12 @@
         locale          (tr)]
     [mui/form-group
 
+     ;; Outdoor pool?
+     [lui/checkbox
+      {:label     (tr :lipas.swimming-pool.pool/outdoor-pool?)
+       :value     (:outdoor-pool? data)
+       :on-change #(set-field :outdoor-pool? %)}]
+
      ;; Pool type
      [lui/select
       {:required  true
@@ -117,6 +123,7 @@
 
 (defn- make-headers [tr]
   [[:type (tr :general/type)]
+   [:outdoor-pool? (tr :lipas.swimming-pool.pool/outdoor-pool?)]
    [:temperature-c (tr :physical-units/temperature-c)]
    [:volume-m3 (tr :dimensions/volume-m3)]
    [:area-m2 (tr :dimensions/surface-area-m2)]

--- a/webapp/src/cljs/lipas/ui/swimming_pools/saunas.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/saunas.cljs
@@ -32,7 +32,12 @@
      ;; Men?
      [lui/checkbox {:label     (tr :lipas.swimming-pool.saunas/men?)
                     :on-change #(set-field :men? %)
-                    :value     (:men? data)}]]))
+                    :value     (:men? data)}]
+
+     ;; Accessible?
+     [lui/checkbox {:label     (tr :lipas.swimming-pool.saunas/accessible?)
+                    :on-change #(set-field :accessible? %)
+                    :value     (:accessible? data)}]]))
 
 (defn dialog [{:keys [tr lipas-id]}]
   (let [data    (<== [::subs/sauna-form])
@@ -54,7 +59,8 @@
 (defn- make-headers [tr]
   [[:type (tr :general/type)]
    [:women? (tr :lipas.swimming-pool.saunas/women?)]
-   [:men? (tr :lipas.swimming-pool.saunas/men?)]])
+   [:men? (tr :lipas.swimming-pool.saunas/men?)]
+   [:accessible? (tr :lipas.swimming-pool.saunas/accessible?)]])
 
 (defn table [{:keys [tr items lipas-id]}]
   (let [localize (partial localize-field tr :type :sauna-types)]

--- a/webapp/src/cljs/lipas/ui/swimming_pools/slides.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/slides.cljs
@@ -10,23 +10,15 @@
   (#(==> [::events/set-dialog-field dialog field value])))
 
 (defn form [{:keys [tr data]}]
-  (let [structures (<== [::subs/slide-structures])
-        set-field  (partial set-field :slide)
-        locale     (tr)]
+  (let [set-field  (partial set-field :slide)]
     [mui/form-group
-     [lui/select {:required  true
-                  :label     (tr :general/structure)
-                  :value     (:structure data)
-                  :items     structures
-                  :label-fn  (comp locale second)
-                  :value-fn  first
-                  :on-change #(set-field :structure %)}]
-     [lui/text-field {:label     (tr :dimensions/length-m)
-                      :adornment (tr :physical-units/m)
-                      :type      "number"
-                      :value     (:length-m data)
-                      :spec      :lipas.swimming-pool.slide/length-m
-                      :on-change #(set-field :length-m %)}]]))
+     [lui/text-field
+      {:label     (tr :dimensions/length-m)
+       :adornment (tr :physical-units/m)
+       :type      "number"
+       :value     (:length-m data)
+       :spec      :lipas.swimming-pool.slide/length-m
+       :on-change #(set-field :length-m %)}]]))
 
 (defn dialog [{:keys [tr lipas-id]}]
   (let [data    (<== [::subs/slide-form])
@@ -46,21 +38,19 @@
      [form {:tr tr :data data}]]))
 
 (defn- make-headers [tr]
-  [[:structure (tr :general/structure)]
-   [:length-m (tr :dimensions/length-m)]])
+  [[:length-m (tr :dimensions/length-m)]])
 
 (defn table [{:keys [tr items lipas-id]}]
-  (let [localize (partial localize-field tr :structure :slide-structures)]
-    [lui/form-table
-     {:headers         (make-headers tr)
-      :items           (map localize (vals items))
-      :add-tooltip     (tr :lipas.swimming-pool.slides/add-slide)
-      :edit-tooltip    (tr :actions/edit)
-      :delete-tooltip  (tr :actions/delete)
-      :confirm-tooltip (tr :confirm/press-again-to-delete)
-      :on-add          #(==> [::events/toggle-dialog :slide {}])
-      :on-edit         #(==> [::events/toggle-dialog :slide (get items (:id %))])
-      :on-delete       #(==> [::events/remove-slide lipas-id %])}]))
+  [lui/form-table
+   {:headers         (make-headers tr)
+    :items           (vals items)
+    :add-tooltip     (tr :lipas.swimming-pool.slides/add-slide)
+    :edit-tooltip    (tr :actions/edit)
+    :delete-tooltip  (tr :actions/delete)
+    :confirm-tooltip (tr :confirm/press-again-to-delete)
+    :on-add          #(==> [::events/toggle-dialog :slide {}])
+    :on-edit         #(==> [::events/toggle-dialog :slide (get items (:id %))])
+    :on-delete       #(==> [::events/remove-slide lipas-id %])}])
 
 (defn read-only-table [{:keys [tr items]}]
   [lui/table {:headers (make-headers tr)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -107,7 +107,7 @@
    (-> db
        :swimming-pools
        :pool-types
-       (:dissoc "outdoor-pool")))) ; now we have checbox instead of own type
+       (dissoc "outdoor-pool")))) ; now we have checbox instead of own type
 
 (re-frame/reg-sub
  ::pool-structures

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -104,10 +104,7 @@
 (re-frame/reg-sub
  ::pool-types
  (fn [db _]
-   (-> db
-       :swimming-pools
-       :pool-types
-       (dissoc "outdoor-pool")))) ; now we have checbox instead of own type
+   (-> db :swimming-pools :pool-types)))
 
 (re-frame/reg-sub
  ::pool-structures

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -126,11 +126,6 @@
  (fn [db _]
    (-> db :swimming-pools :sauna-types)))
 
-(re-frame/reg-sub
- ::slide-structures
- (fn [db _]
-   (-> db :swimming-pools :slide-structures)))
-
 (defn ->list-entry [{:keys [cities admins owners types locale]} pool]
   (let [type  (types (-> pool :type :type-code))
         admin (admins (-> pool :admin))
@@ -239,9 +234,7 @@
              (map #(update % :type get-pool-type))
              (map #(update % :structure get-material)))
 
-        :slides
-        (->> (:slides latest)
-             (map #(update % :structure get-material)))
+        :slides (:slides latest)
 
         :saunas
         (->> (:saunas latest)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -104,7 +104,10 @@
 (re-frame/reg-sub
  ::pool-types
  (fn [db _]
-   (-> db :swimming-pools :pool-types)))
+   (-> db
+       :swimming-pools
+       :pool-types
+       (:dissoc "outdoor-pool")))) ; now we have checbox instead of own type
 
 (re-frame/reg-sub
  ::pool-structures

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -21,6 +21,7 @@
     (energy/energy-stats
      {:tr    tr
       :year  year
+      :link  "/#/uimahalliportaali/ilmoita-tiedot"
       :stats stats})))
 
 (defn toggle-dialog

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -75,14 +75,14 @@
 
       :bottom-actions
       (lui/edit-actions-list
-       {:editing?          editing?
-        :valid?            edits-valid?
-        :logged-in?        logged-in?
-        :user-can-publish? user-can-publish?
-        :on-discard        #(==> [:lipas.ui.events/confirm
-                                  (tr :confirm/discard-changes?)
-                                  (fn []
-                                    (==> [::site-events/discard-edits lipas-id]))])
+       {:editing?           editing?
+        :valid?             edits-valid?
+        :logged-in?         logged-in?
+        :user-can-publish?  user-can-publish?
+        :on-discard         #(==> [:lipas.ui.events/confirm
+                                   (tr :confirm/discard-changes?)
+                                   (fn []
+                                     (==> [::site-events/discard-edits lipas-id]))])
         :discard-tooltip    (tr :actions/discard)
         :on-edit-start      #(==> [::site-events/edit-site lipas-id])
         :edit-tooltip       (tr :actions/edit)
@@ -484,32 +484,74 @@
       ;;; Conditions
       (let [display-data (-> display-data :conditions)
             edit-data    (-> edit-data :conditions)
-            on-change    (partial set-field :visitors)]
+            on-change    (partial set-field :conditions)]
 
         [lui/form-card {:title (tr :lipas.swimming-pool.conditions/headline)}
+
+         (into
+          [lui/form {:read-only? (not editing?)}
+
+           ;; Open days in year
+           {:label (tr :lipas.swimming-pool.conditions/open-days-in-year)
+            :value (-> display-data :open-days-in-year)
+            :form-field
+            [lui/text-field
+             {:type      "number"
+              :value     (-> edit-data :open-days-in-year)
+              :spec      :lipas.swimming-pool.conditions/open-days-in-year
+              :adornment (tr :units/days-in-year)
+              :on-change #(on-change :open-days-in-year %)}]}
+
+           ;; Daily open hours total
+           {:label (tr :lipas.swimming-pool.conditions/daily-open-hours)
+            :value (-> display-data :daily-open-hours)
+            :form-field
+            [lui/text-field
+             {:type      "number"
+              :spec      :lipas.swimming-pool.conditions/daily-open-hours
+              :adornment (tr :units/hours-per-day)
+              :value     (-> edit-data :daily-open-hours)
+              :on-change #(on-change :daily-open-hours %)}]}]
+
+          ;; Daily open hours for each day
+          (for [day  ["mon" "tue" "wed" "thu" "fri" "sat" "sun"]
+                :let [kw (keyword (str "open-hours-" day))]]
+
+            {:label (tr (keyword :lipas.swimming-pool.conditions kw))
+             :value (-> display-data kw)
+             :form-field
+             [lui/text-field
+              {:type      "number"
+               :spec      (keyword :lipas.swimming-pool.conditions kw)
+               :adornment (tr :duration/hour)
+               :value     (-> edit-data kw)
+               :on-change #(on-change kw %)}]}))])
+
+      ;;; Energy saving
+      (let [display-data (-> display-data :energy-saving)
+            edit-data    (-> edit-data :energy-saving)
+            on-change    (partial set-field :energy-saving)]
+
+        [lui/form-card {:title (tr :lipas.swimming-pool.energy-saving/headline)}
          [lui/form {:read-only? (not editing?)}
 
-          ;; Daily open hours
-          {:label (tr :lipas.swimming-pool.conditions/daily-open-hours)
-           :value (-> display-data :daily-open-hours)
+          ;; Shower water recycling?
+          {:label (tr (keyword :lipas.swimming-pool.energy-saving
+                               :shower-water-heat-recovery?))
+           :value (-> display-data :shower-water-recovery)
            :form-field
-           [lui/text-field
-            {:type      "number"
-             :spec      :lipas.ice-stadium.conditions/daily-open-hours
-             :adornment (tr :units/hours-per-day)
-             :value     (-> edit-data :daily-open-hours)
-             :on-change #(on-change :daily-open-hours %)}]}
+           [lui/checkbox
+            {:value     (-> edit-data :shower-water-recovery)
+             :on-change #(on-change :shower-water-recovery %)}]}
 
-          ;; Open days in year
-          {:label (tr :lipas.swimming-pool.conditions/open-days-in-year)
-           :value (-> display-data :open-days-in-year)
+          ;; Filter rinse water heat recovery?
+          {:label (tr (keyword :lipas.swimming-pool.energy-saving
+                               :filter-rinse-water-heat-recovery?))
+           :value (-> display-data :filter-rinse-water-heat-recovery?)
            :form-field
-           [lui/text-field
-            {:type      "number"
-             :value     (-> edit-data :open-days-in-year)
-             :spec      :lipas.swimming-pool.conditions/open-days-in-year
-             :adornment (tr :units/days-in-year)
-             :on-change #(on-change :open-days-in-year %)}]}]])
+           [lui/checkbox
+            {:value     (-> edit-data :filter-rinse-water-heat-recovery?)
+             :on-change #(on-change :filter-rinse-water-heat-recovery? %)}]}]])
 
       ;;; Visitors
       [lui/form-card {:title (tr :lipas.swimming-pool.visitors/headline)

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -132,14 +132,13 @@
 (defn make-energy-consumption-year-list
   "Highlights years where there exists any energy consumption data."
   [history]
-  (let [history (index-by :year history)
-        data (for [y    (range 2000 this-year)
-                   :let [data-exists? (data-exists? y history)]]
-               {:label (if data-exists?
-                         (str y " " "✓")
-                         (str y))
-                :value y})]
-    (sort-by :label reverse-cmp data)))
+  (let [history (index-by :year history)]
+    (for [y    (range 2000 this-year)
+          :let [data-exists? (data-exists? y history)]]
+      {:label (if data-exists?
+                (str y " " "✓")
+                (str y))
+       :value y})))
 
 (defn energy-consumption-history [{:keys [history]}]
   (let [by-year (latest-by-year history)


### PR DESCRIPTION
## Live
https://lipas-dev.cc.jyu.fi/
## Functionality for running data maintenance tasks
Sometimes we need to manipulate batches of data stored in the db. Since we're storing documents in JSONB blobs, our options are:
* use SQL with obscurish Postgres JSONB manipulation syntax
* write data manipulation code in Clojure

This does the latter. Tasks are defined in `lipas.maintenance` namespace and running happens by simply executing:

```docker-compose run backend-maintenance :my-maintenance-task```

Let's see how this works for us in the long run.
## Several small changes to swimming pool form content
* Removed unnecessary filtering methods and added one new
* Removed tautological and obscure main construction materials
* Changed 'outdoor pool' from pool type to a boolean property for all pool types
## Added "readings contain other buildings" checkbox to energy consumption form
Sometimes energy consumption readings contain also other buildings or spaces, such as "gym" or "sports hall". These falsify real readings and makes comparing similar swimming pools / ice stadiums less accurate. Therefore we added a checkbox so we can filter these entries. 
## Updated MUI 1.2.1 -> 1.4.0
* Bundle size is now smaller

See commit messages for further details.