### PR TITLE
Admin tools and some localizations to api

### DIFF
--- a/webapp/project.clj
+++ b/webapp/project.clj
@@ -27,6 +27,7 @@
                  [cljsjs/babel-polyfill "6.20.0-2"]
                  [cljsjs/date-fns "1.29.0-0"]
                  [cljsjs/recharts "1.1.0-3"]
+                 [cljsjs/react-autosuggest "9.3.4-0"]
 
                  ;;; Backend ;;;
                  [metosin/reitit "0.2.0-SNAPSHOT"]

--- a/webapp/resources/sql/user.sql
+++ b/webapp/resources/sql/user.sql
@@ -2,74 +2,94 @@
 -- :command :query
 -- :result :many
 -- :doc Selects all users
-SELECT id
-       , email
-       , username
-       , password
-       , user_data
-       , permissions
-FROM   account;
+SELECT
+  id,
+  email,
+  username,
+  password,
+  user_data,
+  permissions
+FROM
+  account;
 
 -- :name get-user-by-id
 -- :command :query
 -- :result :one
 -- :doc Selects the user matching the id
-SELECT id
-       , email
-       , username
-       , password
-       , user_data
-       , permissions
-FROM   account
-WHERE  id = :id
+SELECT
+  id,
+  email,
+  username,
+  password,
+  user_data,
+  permissions
+FROM
+  account
+WHERE
+  id = :id ::uuid;
 
 -- :name get-user-by-username
 -- :command :query
 -- :result :one
 -- :doc Selects the user matching the username
-SELECT id
-       , email
-       , username
-       , password
-       , user_data
-       , permissions
-FROM   account
-WHERE  username = :username
+SELECT
+  id,
+  email,
+  username,
+  password,
+  user_data,
+  permissions
+FROM
+  account
+WHERE  username = :username;
 
 -- :name get-user-by-email
 -- :command :query
 -- :result :one
 -- :doc Selects the user matching the email
-SELECT id
-       , email
-       , username
-       , password
-       , user_data
-       , permissions
-FROM   account
-WHERE  email = :email
+SELECT
+  id,
+  email,
+  username,
+  password,
+  user_data,
+  permissions
+FROM
+  account
+WHERE
+  email = :email;
 
 -- :name insert-user!
 -- :command :insert
 -- :result :raw
 -- :doc Inserts a single user into account table
 INSERT INTO account (
-       email
-        , username
-        , password
-        , user_data
-        , permissions)
+  email,
+  username,
+  password,
+  user_data,
+  permissions
+)
 VALUES (
-       :email
-       , :username
-       , :password
-       , :user_data
-       , :permissions);
+  :email,
+  :username,
+  :password,
+  :user_data,
+  :permissions
+);
+
+-- :name update-user-permissions!
+-- :command :execute
+-- :result :affected
+-- :doc Update user permissions and user-data with given id
+UPDATE account
+SET    permissions = :permissions
+WHERE  id = :id ::uuid;
 
 -- :name update-user-password!
 -- :command :execute
 -- :result :affected
--- :doc Update the password for the user matching the given userid
+-- :doc Update the password for the user with given id
 UPDATE account
 SET    password = :password
 WHERE  id = :id ::uuid;

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -38,7 +38,6 @@
     {:status "OK"}))
 
 (defn update-user-permissions! [db emailer user]
-  (prn user)
   (db/update-user-permissions! db user)) ;; TODO send email
 
 (defn get-user [db identifier]

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -3,6 +3,7 @@
             [lipas.backend.db.db :as db]
             [lipas.backend.email :as email]
             [lipas.backend.jwt :as jwt]
+            [lipas.i18n.core :as i18n]
             [lipas.reports :as reports]))
 
 ;;; User ;;;
@@ -72,8 +73,11 @@
     (throw (ex-info "User doesn't have enough permissions!"
                     {:type :no-permission}))))
 
-(defn get-sports-sites-by-type-code [db type-code opts]
-  (db/get-sports-sites-by-type-code db type-code opts))
+(defn get-sports-sites-by-type-code [db type-code {:keys [locale] :as opts}]
+  (let [data (db/get-sports-sites-by-type-code db type-code opts)]
+    (if (#{:fi :en :se} locale)
+      (map (partial i18n/localize locale) data)
+      data)))
 
 (defn get-sports-site-history [db lipas-id]
   (db/get-sports-site-history db lipas-id))

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -30,7 +30,7 @@
   (let [defaults {:permissions default-permissions
                   :username    (:email user)
                   :user-data   {}
-                  :password    (str (utils/uuid))}
+                  :password    (str (utils/gen-uuid))}
         user     (-> (merge defaults user)
                      (update :password hashers/encrypt))]
 
@@ -44,6 +44,12 @@
   (or (db/get-user-by-email db {:email identifier})
       (db/get-user-by-username db {:username identifier})
       (db/get-user-by-id db {:id identifier})))
+
+(defn get-user! [db identifier]
+  (if-let [user (get-user db identifier)]
+    user
+    (throw (ex-info "User not found."
+                    {:type :user-not-found}))))
 
 (defn get-users [db]
   (db/get-users db))

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -12,17 +12,17 @@
        (map user/unmarshall)
        (map #(dissoc % :password))))
 
-(defn get-user-by-id [db-spec user-id]
-  (when (uuid? (utils/->uuid-safe user-id))
-    (-> (user/get-user-by-id db-spec user-id)
+(defn get-user-by-id [db-spec params]
+  (when (uuid? (utils/->uuid-safe (:id params)))
+    (-> (user/get-user-by-id db-spec params)
         (user/unmarshall))))
 
-(defn get-user-by-email [db-spec email]
-  (-> (user/get-user-by-email db-spec email)
+(defn get-user-by-email [db-spec params]
+  (-> (user/get-user-by-email db-spec params)
       (user/unmarshall)))
 
-(defn get-user-by-username [db-spec username]
-  (-> (user/get-user-by-username db-spec username)
+(defn get-user-by-username [db-spec params]
+  (-> (user/get-user-by-username db-spec params)
       (user/unmarshall)))
 
 (defn add-user! [db-spec user]

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.jdbc :as jdbc]
             [lipas.backend.db.sports-site :as sports-site]
             [lipas.backend.db.user :as user]
-            [lipas.backend.db.utils :as utils]))
+            [lipas.utils :as utils]
+            [lipas.backend.db.utils :as db-utils]))
 
 ;; User ;;
 
@@ -12,8 +13,9 @@
        (map #(dissoc % :password))))
 
 (defn get-user-by-id [db-spec user-id]
-  (-> (user/get-user-by-id db-spec user-id)
-      (user/unmarshall)))
+  (when (uuid? (utils/->uuid-safe user-id))
+    (-> (user/get-user-by-id db-spec user-id)
+        (user/unmarshall))))
 
 (defn get-user-by-email [db-spec email]
   (-> (user/get-user-by-email db-spec email)
@@ -60,7 +62,7 @@
 
 (defn get-sports-site-history [db-spec lipas-id]
   (let [params (-> {:lipas-id lipas-id}
-                   utils/->snake-case-keywords)]
+                   db-utils/->snake-case-keywords)]
     (->> (sports-site/get-history db-spec params)
          (map sports-site/unmarshall))))
 
@@ -73,6 +75,6 @@
         params (-> (merge {:type-code type-code}
                           (when (number? revs)
                             {:year revs}))
-                   utils/->snake-case-keywords)]
+                   db-utils/->snake-case-keywords)]
     (->> (db-fn db-spec params)
          (map sports-site/unmarshall))))

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -7,8 +7,9 @@
 ;; User ;;
 
 (defn get-users [db-spec]
-  (-> (user/all-users db-spec)
-      (user/unmarshall)))
+  (->> (user/all-users db-spec)
+       (map user/unmarshall)
+       (map #(dissoc % :password))))
 
 (defn get-user-by-id [db-spec user-id]
   (-> (user/get-user-by-id db-spec user-id)
@@ -26,6 +27,11 @@
   (->> user
        (user/marshall)
        (user/insert-user! db-spec)))
+
+(defn update-user-permissions! [db-spec user]
+  (->> user
+       (user/marshall)
+       (user/update-user-permissions! db-spec)))
 
 (defn reset-user-password! [db-spec user]
   (->> user

--- a/webapp/src/clj/lipas/backend/db/utils.clj
+++ b/webapp/src/clj/lipas/backend/db/utils.clj
@@ -3,8 +3,7 @@
             [camel-snake-kebab.extras :refer [transform-keys]]
             [cheshire.core :as j]
             [clojure.java.jdbc :as jdbc])
-  (:import [org.postgresql.util PGobject]
-           [java.util.UUID]))
+  (:import [org.postgresql.util PGobject]))
 
 (comment (<-json (->json {:kissa "koira"})))
 (def <-json #(j/decode % true))

--- a/webapp/src/clj/lipas/backend/email.clj
+++ b/webapp/src/clj/lipas/backend/email.clj
@@ -27,6 +27,12 @@
                    :plain   (str reset-link)
                    :html    (str "<html><body>" reset-link "</body></html>")}))
 
+(defn send-magic-login-email! [emailer to link]
+  (.send! emailer {:subject "Taikalinkki Lipakseen"
+                   :to      to
+                   :plain   (str link)
+                   :html    (str "<html><body>" link "</body></html>")}))
+
 (defrecord SMTPEmailer [config]
   Emailer
   (send! [_ message] (send*! config message)))

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -98,7 +98,7 @@
            {:status 200
             :body   (core/get-sports-site-history db lipas-id)})}}]
 
-n      ["/sports-sites/type/:type-code"
+      ["/sports-sites/type/:type-code"
        {:get
         {:parameters {:path  {:type-code int?}
                       :query :lipas.api/query-params}

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -146,7 +146,7 @@
         {:middleware [mw/token-auth mw/auth]
          :handler
          (fn [{:keys [identity]}]
-           (let [user (core/get-user db (-> identity :id))]
+           (let [user (core/get-user! db (-> identity :id))]
              {:status 200
               :body   (merge (dissoc user :password)
                              {:token (jwt/create-token identity)})}))}}]

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -106,9 +106,14 @@
          (fn [{:keys [parameters]}]
            (let [type-code (-> parameters :path :type-code)
                  revs      (or (-> parameters :query :revs)
-                               "latest")]
+                               "latest")
+                 locale    (or (-> parameters :query :lang keyword)
+                               :none)]
              {:status 200
-              :body   (core/get-sports-sites-by-type-code db type-code {:revs revs})}))}}]
+              :body   (core/get-sports-sites-by-type-code db
+                                                          type-code
+                                                          {:revs   revs
+                                                           :locale locale})}))}}]
 
       ["/actions/register"
        {:post

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -149,7 +149,7 @@
            (let [user (core/get-user! db (-> identity :id))]
              {:status 200
               :body   (merge (dissoc user :password)
-                             {:token (jwt/create-token identity)})}))}}]
+                             {:token (jwt/create-token user)})}))}}]
 
       ["/actions/request-password-reset"
        {:post

--- a/webapp/src/clj/lipas/backend/middleware.clj
+++ b/webapp/src/clj/lipas/backend/middleware.clj
@@ -2,7 +2,7 @@
   (:require [buddy.auth :refer [authenticated?]]
             [buddy.auth.middleware :refer [wrap-authentication]]
             [lipas.backend.auth :as auth]
-            [ring.util.http-response :refer [unauthorized]]))
+            [ring.util.http-response :as resp]))
 
 (defn auth
   "Middleware used in routes that require authentication. If request is not
@@ -11,7 +11,7 @@
   (fn [request]
     (if (authenticated? request)
       (handler request)
-      (unauthorized {:error "Not authorized"}))))
+      (resp/unauthorized {:error "Not authorized"}))))
 
 (defn basic-auth [db]
   (fn [handler]
@@ -38,3 +38,9 @@
   "Middleware used on routes requiring token authentication"
   [handler]
   (wrap-authentication handler auth/token-backend))
+
+(defn admin [handler]
+  (fn [request]
+    (if (-> request :identity :permissions :admin?)
+      (handler request)
+      (resp/forbidden {:error "Admin access required"}))))

--- a/webapp/src/clj/lipas/migrate_data.clj
+++ b/webapp/src/clj/lipas/migrate_data.clj
@@ -287,15 +287,15 @@
   {"Avo-/Painehiekka"     ["open-sand" "pressure-sand"]
    "Avohiekka"            ["open-sand"]
    "Avohiekka/monikerros" ["open-sand" "multi-layer-filtering"]
-   "Hiekka/aktiivihiili"  ["sand" "activated-carbon"]
-   "Hiekka/saostus"       ["sand" "precipitation"]
-   "Hiili/hiekka"         ["coal" "sand"]
-   "Imuhiekka"            ["suction-sand"]
+   "Hiekka/aktiivihiili"  ["activated-carbon"]
+   "Hiekka/saostus"       ["precipitation"]
+   "Hiili/hiekka"         ["coal"]
+   "Imuhiekka"            ["other"]
    "Moniker./painehiekka" ["multi-layer-filtering" "pressure-sand"]
    "Monikerrossuodatus"   ["multi-layer-filtering"]
    "Muu"                  ["other"]
    "Painehiekka"          ["pressure-sand"]
-   "Paineimu"             ["pressure-suction"]})
+   "Paineimu"             ["other"]})
 
 (defn ->swimming-pool [portal-entry lipas-entry]
   (merge
@@ -319,7 +319,7 @@
      :staff-count             (when-gt0 (get portal-entry "Henkilö-,kuntaa"))
      :seating-capacity        (-> lipas-entry :properties :standCapacityPerson
                                   utils/->int)
-     :heat-source             nil ; Not present in data dump
+     :heat-sources            nil ; Not present in data dump
      :ventilation-units-count (when-gt0 (get portal-entry "IV-,koneita"))}
 
     :water-treatment

--- a/webapp/src/cljc/lipas/data/ice_stadiums.cljc
+++ b/webapp/src/cljc/lipas/data/ice_stadiums.cljc
@@ -58,24 +58,27 @@
 
 ;; Kylmäliuos
 (def refrigerant-solutions
-  {"cacl"          {:fi "CaCl"
-                    :en "CaCl"
-                    :se "CaCl"}
-   "freezium"      {:fi "Freezium"
-                    :en "Freezium"
-                    :se "Freezium"}
-   "water-glycol"  {:fi "Vesi-glykoli"
-                    :en "Water-glycol"
-                    :se nil}
-   "ethanol-water" {:fi "Etanoli-vesi"
-                    :en "Ethanol-water"
-                    :se nil}
-   "CO2"           {:fi "CO2"
-                    :en "CO2"
-                    :se "CO2"}
-   "H2ONH3"        {:fi "H2O/NH3"
-                    :en "H2O/NH3"
-                    :se "H2O/NH3"}})
+  {"cacl"            {:fi "CaCl"
+                      :en "CaCl"
+                      :se "CaCl"}
+   "freezium"        {:fi "Freezium"
+                      :en "Freezium"
+                      :se "Freezium"}
+   "water-glycol"    {:fi "Vesi-glykoli"
+                      :en "Water-glycol"
+                      :se nil}
+   "ethanol-water"   {:fi "Etanoli-vesi"
+                      :en "Ethanol-water"
+                      :se nil}
+   "CO2"             {:fi "CO2"
+                      :en "CO2"
+                      :se "CO2"}
+   "H2ONH3"          {:fi "H2O/NH3"
+                      :en "H2O/NH3"
+                      :se "H2O/NH3"}
+   "ethylene-glycol" {:fi "Etyleeniglykoli"
+                      :en "Ethylene glycol"
+                      :se nil}})
 
 ;; LTO_tyyppi
 (def heat-recovery-types

--- a/webapp/src/cljc/lipas/i18n/core.cljc
+++ b/webapp/src/cljc/lipas/i18n/core.cljc
@@ -5,6 +5,7 @@
             [lipas.data.materials :as materials]
             [lipas.data.owners :as owners]
             [lipas.data.swimming-pools :as pools]
+            [lipas.data.cities :as cities]
             [lipas.i18n.en :as en]
             [lipas.i18n.fi :as fi]
             [lipas.i18n.se :as se]
@@ -14,6 +15,8 @@
 (defn- ->translations [locale m]
   (reduce-kv (fn [res k v]
                (assoc res k (-> v locale))) {} m))
+
+(def cities (utils/index-by :city-code cities/all))
 
 (defn- append-data! [locale m]
   (->>
@@ -105,6 +108,14 @@
     :translations admins/all}
    {:path         [:owner]
     :translations owners/all}
+
+   ;; Location
+
+   {:path [:location :city]
+    :translate-fn (fn [locale {:keys [city-code] :as city}]
+                    (assoc city :city-name (-> (get cities city-code)
+                                               :name
+                                               locale)))}
 
    ;; Ice stadiums
    {:path         [:type :size-category]

--- a/webapp/src/cljc/lipas/i18n/core.cljc
+++ b/webapp/src/cljc/lipas/i18n/core.cljc
@@ -1,13 +1,15 @@
 (ns lipas.i18n.core
-  (:require [tongue.core :as tongue]
-            [clojure.string :as s]
-            [lipas.data.swimming-pools :as pools]
-            [lipas.data.materials :as materials]
+  (:require [clojure.string :as s]
             [lipas.data.admins :as admins]
+            [lipas.data.ice-stadiums :as ice]
+            [lipas.data.materials :as materials]
             [lipas.data.owners :as owners]
-            [lipas.i18n.fi :as fi]
+            [lipas.data.swimming-pools :as pools]
             [lipas.i18n.en :as en]
-            [lipas.i18n.se :as se]))
+            [lipas.i18n.fi :as fi]
+            [lipas.i18n.se :as se]
+            [lipas.utils :as utils]
+            [tongue.core :as tongue]))
 
 (defn- ->translations [locale m]
   (reduce-kv (fn [res k v]
@@ -15,17 +17,26 @@
 
 (defn- append-data! [locale m]
   (->>
-   {:admin                 (->translations locale admins/all)
-    :owner                 (->translations locale owners/all)
-    :pool-types            (->translations locale pools/pool-types)
-    :sauna-types           (->translations locale pools/sauna-types)
-    :heat-sources          (->translations locale pools/heat-sources)
-    :filtering-methods     (->translations locale pools/filtering-methods)
-    :pool-structures       (->translations locale materials/pool-structures)
-    :slide-structures      (->translations locale materials/slide-structures)
-    :building-materials    (->translations locale materials/building-materials)
-    :supporting-structures (->translations locale materials/supporting-structures)
-    :ceiling-structures    (->translations locale materials/ceiling-structures)}
+   {:admin                     (->translations locale admins/all)
+    :owner                     (->translations locale owners/all)
+    :pool-types                (->translations locale pools/pool-types)
+    :sauna-types               (->translations locale pools/sauna-types)
+    :heat-sources              (->translations locale pools/heat-sources)
+    :filtering-methods         (->translations locale pools/filtering-methods)
+    :pool-structures           (->translations locale materials/pool-structures)
+    :slide-structures          (->translations locale materials/slide-structures)
+    :building-materials        (->translations locale materials/building-materials)
+    :supporting-structures     (->translations locale materials/supporting-structures)
+    :ceiling-structures        (->translations locale materials/ceiling-structures)
+    :heat-recovery-types       (->translations locale ice/heat-recovery-types)
+    :dryer-duty-types          (->translations locale ice/dryer-duty-types)
+    :dryer-types               (->translations locale ice/dryer-types)
+    :heat-pump-types           (->translations locale ice/heat-pump-types)
+    :condensate-energy-targets (->translations locale ice/condensate-energy-targets)
+    :ice-resurfacer-fuels      (->translations locale ice/ice-resurfacer-fuels)
+    :refrigerant-solutions     (->translations locale ice/refrigerant-solutions)
+    :refrigerants              (->translations locale ice/refrigerants)
+    :size-categories           (->translations locale ice/size-categories)}
    (merge m)))
 
 (def dicts
@@ -75,3 +86,88 @@
     ([kw & args]
      (-> (apply translate (into [locale kw] (filter (complement keyword?) args)))
          (fmt args)))))
+
+(defn localize-pool [locale pool]
+  (-> pool
+      (update-in [:type] #(locale (get-in pools/pool-types %)))
+      (update-in [:structure] #(locale (get-in materials/all %)))
+      utils/clean))
+
+(defn localize-sauna [locale sauna]
+  (-> sauna
+      (update-in [:type] #(locale (get-in pools/sauna-types %)))
+      utils/clean))
+
+(def localizations
+  [
+   ;; Sports site
+   {:path         [:admin]
+    :translations admins/all}
+   {:path         [:owner]
+    :translations owners/all}
+
+   ;; Ice stadiums
+   {:path         [:type :size-category]
+    :translations ice/size-categories}
+   {:path         [:building :base-floor-structure]
+    :translations materials/all}
+   {:path         [:ventilation :dryer-type]
+    :translations ice/dryer-types}
+   {:path         [:ventilation :dryer-duty-type]
+    :translations ice/dryer-duty-types}
+   {:path         [:ventilation :heat-pump-type]
+    :translations ice/heat-pump-types}
+   {:path         [:ventilation :heat-recovery-type]
+    :translations ice/heat-recovery-types}
+   {:path         [:refrigeration :condensate-energy-main-targets]
+    :translations ice/condensate-energy-targets
+    :coll?        true}
+   {:path         [:refrigeration :refrigerant]
+    :translations ice/refrigerants}
+   {:path         [:refrigeration :refrigerant-solution]
+    :translations ice/refrigerant-solutions}
+   {:path         [:envelope :base-floor-structure]
+    :translations materials/all}
+
+   ;; Swimming pools
+   {:path         [:building :supporting-structures]
+    :translations materials/all
+    :many?        true}
+   {:path         [:building :main-construction-materials]
+    :translations materials/all
+    :many?        true}
+   {:path         [:building :ceiling-structures]
+    :translations materials/all
+    :many?        true}
+   {:path         [:water-treatment :filtering-methods]
+    :translations pools/filtering-methods
+    :many?        true}
+   {:path         [:pools]
+    :translate-fn (fn [locale pools] (->> pools
+                                          (map (partial localize-pool locale))
+                                          (remove nil?)))}
+   {:path         [:saunas]
+    :translate-fn (fn [locale saunas] (->> saunas
+                                           (map (partial localize-sauna locale))
+                                           (remove nil?)))}])
+
+(defn localize [locale sports-site]
+  (reduce
+   (fn [sports-site {:keys [path translations many? translate-fn]}]
+     (if-let [value (get-in sports-site path)]
+       (assoc-in sports-site path
+                  (cond
+                    translations (if many?
+                                   (map #(get-in translations [% locale]) value)
+                                   (get-in translations [value locale]))
+                    translate-fn (apply translate-fn [locale value])
+                    :else        (throw
+                                  (ex-info "Invalid localization definition."
+                                           {:missing-either
+                                            [:translations :translate-fn]}))))
+       sports-site))
+   sports-site
+   localizations))
+
+(localize :fi {:admin "state"
+               :building {:supporting-structures ["concrete"]}})

--- a/webapp/src/cljc/lipas/i18n/core.cljc
+++ b/webapp/src/cljc/lipas/i18n/core.cljc
@@ -89,13 +89,13 @@
 
 (defn localize-pool [locale pool]
   (-> pool
-      (update-in [:type] #(locale (get-in pools/pool-types %)))
-      (update-in [:structure] #(locale (get-in materials/all %)))
+      (update-in [:type] #(locale (get pools/pool-types %)))
+      (update-in [:structure] #(locale (get materials/all %)))
       utils/clean))
 
 (defn localize-sauna [locale sauna]
   (-> sauna
-      (update-in [:type] #(locale (get-in pools/sauna-types %)))
+      (update-in [:type] #(locale (get pools/sauna-types %)))
       utils/clean))
 
 (def localizations

--- a/webapp/src/cljc/lipas/i18n/en.cljc
+++ b/webapp/src/cljc/lipas/i18n/en.cljc
@@ -172,10 +172,16 @@
    :user
    {:headline        "Profile"
     :greeting        "Hello {1} {2}!"
-    :front-page-link "front page"}
+    :front-page-link "front page"
+    :admin-page-link "Admin page"}
+
+   :lipas.admin
+   {:headline "Admin"
+    :users    "Users"}
 
    :lipas.user
-   {:email                 "Email"
+   {:contact-info          "Contact info"
+    :email                 "Email"
     :email-example         "email@example.com"
     :username              "Username"
     :username-example      "tane12"

--- a/webapp/src/cljc/lipas/i18n/fi.cljc
+++ b/webapp/src/cljc/lipas/i18n/fi.cljc
@@ -173,10 +173,20 @@
    :user
    {:headline        "Oma sivu"
     :greeting        "Hei {1} {2}!"
-    :front-page-link "Siirry etusivulle"}
+    :front-page-link "Siirry etusivulle"
+    :admin-page-link "Siirry admin-sivulle"}
+
+   :lipas.admin
+   {:headline           "Admin"
+    :users              "Käyttäjät"
+    :magic-link         "Taikalinkki"
+    :confirm-magic-link "Haluatko varmasti lähettää taikalinkin
+    käyttäjälle {1}?"
+    }
 
    :lipas.user
-   {:email                 "Sähköposti"
+   {:contact-info          "Yhteystiedot"
+    :email                 "Sähköposti"
     :email-example         "email@example.com"
     :username              "Käyttäjätunnus"
     :username-example      "tane12"
@@ -189,11 +199,13 @@
     :requested-permissions "Pyydetyt oikeudet"}
 
    :lipas.user.permissions
-   {:admin?       "Pääkäyttäjän oikeudet"
+   {:admin?       "Admin"
     :draft?       "Ehdota muutoksia"
-    :sports-sites "Oikeus liikuntapaikkoihin"
-    :types        "Oikeus liikuntapaikkatyypin liikuntapaikkoihin"
-    :cities       "Oikeus kunnan liikuntapaikkoihin"}
+    :all-cities?  "Oikeus kaikkiin kuntiin"
+    :all-types?   "Oikeus kaikkiin tyyppeihin"
+    :sports-sites "Liikuntapaikat"
+    :types        "Tyypit"
+    :cities       "Kunnat"}
 
    :register
    {:headline "Rekisteröidy"}

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -726,4 +726,7 @@
 ;;; HTTP-API ;;;
 
 (s/def :lipas.api/revs #{"latest" "yearly"})
-(s/def :lipas.api/query-params (s/keys :opt-un [::revs]))
+(s/def :lipas.api/lang #{"fi" "en" "se"})
+(s/def :lipas.api/query-params
+  (s/keys :opt-un [:lipas.api/revs
+                   :lipas.api/lang]))

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -289,6 +289,13 @@
 (s/def :lipas.building/staff-count (s/int-in 0 (inc 1000)))
 (s/def :lipas.building/seating-capacity (s/int-in 0 (inc 50000)))
 (s/def :lipas.building/heat-source (into #{} (keys swimming-pools/heat-sources)))
+(s/def :lipas.building/heat-sources
+  (s/coll-of :lipas.building/heat-source
+             :min-count 0
+             :max-count (count swimming-pools/heat-sources)
+             :distinct true
+             :into []))
+
 (s/def :lipas.building/ventilation-units-count (s/int-in 0 (inc 100)))
 
 (s/def :lipas.building/main-construction-materials
@@ -527,6 +534,7 @@
                    :lipas.building/ceiling-structures
                    :lipas.building/staff-count
                    :lipas.building/heat-source
+                   :lipas.building/heat-sources
                    :lipas.building/ventilation-units-count]))
 
 ;; Water treatment ;;

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -136,21 +136,25 @@
 
 (s/def :lipas.user.permissions/admin? boolean?)
 (s/def :lipas.user.permissions/draft? boolean?)
+(s/def :lipas.user.permissions/all-cities? boolean?)
+(s/def :lipas.user.permissions/all-types? boolean?)
 
 (s/def :lipas.user/permissions
   (s/keys :opt-un [:lipas.user.permissions/admin?
                    :lipas.user.permissions/draft?
                    :lipas.user.permissions/sports-sites
+                   :lipas.user.permissions/all-cities?
+                   :lipas.user.permissions/all-types?
                    :lipas.user.permissions/cities
                    :lipas.user.permissions/types]))
 
 (s/def :lipas.user/permissions-request (str-in 1 200))
 
 (s/def :lipas/new-user (s/keys :req-un [:lipas.user/email
-                                        :lipas.user/username
-                                        :lipas.user/password
-                                        :lipas.user/user-data]
-                               :opt-un [:lipas.user/permissions]))
+                                        :lipas.user/username]
+                               :opt-un [:lipas.user/password
+                                        :lipas.user/permissions
+                                        :lipas.user/user-data]))
 
 (s/def :lipas/user (s/merge :lipas/new-user
                             (s/keys :req-un [:lipas.user/id])))

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -413,7 +413,7 @@
 (s/def :lipas.ice-stadium.conditions/open-months (s/int-in 0 (inc 12)))
 
 (s/def :lipas.ice-stadium.conditions/ice-surface-temperature-c
-  (s/int-in -10 (inc -1)))
+  (s/int-in -10 (inc 0)))
 
 (s/def :lipas.ice-stadium.conditions/skating-area-temperature-c
   (s/int-in -15 (inc 20)))

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -56,6 +56,13 @@
   #?(:clj (java.util.UUID/fromString s)
      :cljs (uuid s)))
 
+(defn ->uuid-safe [x]
+  (cond
+    (uuid? x)   x
+    (string? x) (try (->uuid x) #?(:cljs (catch :default ex)
+                                   :clj  (catch Exception e)))
+    :else nil))
+
 (defn uuid []
   #?(:clj (java.util.UUID/randomUUID)
      :cljs (random-uuid)))

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -63,7 +63,7 @@
                                    :clj  (catch Exception e)))
     :else nil))
 
-(defn uuid []
+(defn gen-uuid []
   #?(:clj (java.util.UUID/randomUUID)
      :cljs (random-uuid)))
 

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -3,7 +3,8 @@
             [clojure.spec.alpha :as s]
             #?(:cljs [cljs.reader :refer [read-string]])
             #?(:cljs [goog.string :as gstring])
-            #?(:cljs [goog.string.format])))
+            #?(:cljs [goog.string.format]))
+  (:import [java.util.UUID]))
 
 (defn index-by
   ([idx-fn coll]
@@ -50,6 +51,14 @@
 (defn ->int [s]
   (when-let [num (->number s)]
     (int num)))
+
+(defn ->uuid [s]
+  #?(:clj (java.util.UUID/fromString s)
+     :cljs (uuid s)))
+
+(defn uuid []
+  #?(:clj (java.util.UUID/randomUUID)
+     :cljs (random-uuid)))
 
 ;;; Simple statistics ;;;
 

--- a/webapp/src/cljs/lipas/ui/admin/events.cljs
+++ b/webapp/src/cljs/lipas/ui/admin/events.cljs
@@ -1,0 +1,84 @@
+(ns lipas.ui.admin.events
+  (:require [ajax.core :as ajax]
+            [lipas.ui.utils :as utils]
+            [re-frame.core :as re-frame]))
+
+(re-frame/reg-event-db
+ ::get-users-success
+ (fn [db [_ users]]
+   (assoc-in db [:admin :users] (utils/index-by :id users))))
+
+(re-frame/reg-event-fx
+ ::failure
+ (fn [{:keys [db]} [_ resp]]
+   (let [tr (:translator db)]
+     {:dispatch [:lipas.ui.events/set-active-notification
+                 {:message  (or (-> resp :response :message)
+                                (-> resp :response :error)
+                                (tr :error/unknown))
+                  :success? false}]})))
+
+(re-frame/reg-event-fx
+ ::get-users
+ (fn [{:keys [db]} [_ _]]
+   (let [token (-> db :user :login :token)]
+     {:http-xhrio
+      {:method          :get
+       :headers         {:Authorization (str "Token " token)}
+       :uri             (str (:backend-url db) "/users")
+       :response-format (ajax/json-response-format {:keywords? true})
+       :on-success      [::get-users-success]
+       :on-failure      [::failure]}})))
+
+(re-frame/reg-event-db
+ ::display-user
+ (fn [db [_ {:keys [id]}]]
+   (assoc-in db [:admin :selected-user] id)))
+
+(re-frame/reg-event-db
+ ::set-user-to-edit
+ (fn [db [_ {:keys [id]}]]
+   (assoc-in db [:admin :editing-user] (get-in db [:admin :users id]))))
+
+(re-frame/reg-event-db
+ ::edit-user
+ (fn [db [_ path value]]
+   (assoc-in db (into [:admin :editing-user] path) value)))
+
+(re-frame/reg-event-fx
+ ::save-user-success
+ (fn [{:keys [db]} [_ user _]]
+   (let [tr (:translator db)]
+     {:db       (assoc-in db [:admin :users (:id user)] user)
+      :dispatch [:lipas.ui.events/set-active-notification
+                 {:message  (tr :notifications/save-success)
+                  :success? true}]})))
+
+(re-frame/reg-event-fx
+ ::save-user
+ (fn [{:keys [db]} [_ user]]
+   (let [token (-> db :user :login :token)]
+     {:http-xhrio
+      {:method          :post
+       :uri             (str (:backend-url db) "/actions/update-user-permissions")
+       :headers         {:Authorization (str "Token " token)}
+       :params          (select-keys user [:id :permissions])
+       :format          (ajax/json-request-format)
+       :response-format (ajax/json-response-format {:keywords? true})
+       :on-success      [::save-user-success user]
+       :on-failure      [::failure]}})))
+
+(re-frame/reg-event-fx
+ ::send-magic-link
+ (fn [{:keys [db]} [_ user]]
+   (let [token (-> db :user :login :token)]
+     {:http-xhrio
+      {:method          :post
+       :uri             (str (:backend-url db) "/actions/send-magic-link")
+       :headers         {:Authorization (str "Token " token)}
+       :params          {:user      user
+                         :login-url (str (utils/base-url) "/#/kirjaudu")}
+       :format          (ajax/json-request-format)
+       :response-format (ajax/json-response-format {:keywords? true})
+       :on-success      [::save-user-success user]
+       :on-failure      [::failure]}})))

--- a/webapp/src/cljs/lipas/ui/admin/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/admin/subs.cljs
@@ -1,0 +1,62 @@
+(ns lipas.ui.admin.subs
+  (:require [lipas.ui.utils :as utils]
+            [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ ::users
+ (fn [db _]
+   (-> db :admin :users)))
+
+(defn ->users-list-entry [user]
+  {:id           (-> user :id)
+   :email        (-> user :email)
+   :firstname    (-> user :user-data :firstname)
+   :lastname     (-> user :user-data :lastname)
+   :admin?       (-> user :permissions :admin?)
+   :sports-sites (-> user :permissions :sports-sites)
+   :cities       (-> user :permissions :cities)
+   :types        (-> user :permissions :types)})
+
+(re-frame/reg-sub
+ ::users-list
+ :<- [::users]
+ (fn [users _]
+   (map ->users-list-entry (vals users))))
+
+(re-frame/reg-sub
+ ::selected-user
+ (fn [db _]
+   (get-in db [:admin :users (-> db :admin :selected-user)])))
+
+(re-frame/reg-sub
+ ::editing-user
+ (fn [db _]
+   (get-in db [:admin :editing-user])))
+
+(defn ->list-entry [locale [k v]]
+  {:value k
+   :label (str (get-in v [:name locale]) " " k)})
+
+(re-frame/reg-sub
+ ::types-list
+ :<- [:lipas.ui.sports-sites.subs/all-types]
+ (fn [types [_ locale]]
+   (->> types
+        (map (partial ->list-entry locale))
+        (sort-by :label))))
+
+(re-frame/reg-sub
+ ::cities-list
+ :<- [:lipas.ui.sports-sites.subs/cities-by-city-code]
+ (fn [cities [_ locale]]
+   (->> cities
+        (map (partial ->list-entry locale))
+        (sort-by :label))))
+
+(re-frame/reg-sub
+ ::sites-list
+ :<- [:lipas.ui.sports-sites.subs/latest-sports-site-revs]
+ (fn [sites _]
+   (->> sites
+        (map (fn [[lipas-id s]] {:value lipas-id :label (:name s)}))
+        (sort-by :label))))

--- a/webapp/src/cljs/lipas/ui/admin/views.cljs
+++ b/webapp/src/cljs/lipas/ui/admin/views.cljs
@@ -1,0 +1,164 @@
+(ns lipas.ui.admin.views
+  (:require [lipas.ui.admin.events :as events]
+            [lipas.ui.admin.subs :as subs]
+            [lipas.ui.components :as lui]
+            [lipas.ui.mui :as mui]
+            [lipas.ui.utils :refer [<== ==>] :as utils]))
+
+(defn user-dialog [tr]
+  (let [locale    (tr)
+        cities    (<== [::subs/cities-list locale])
+        types     (<== [::subs/types-list locale])
+        sites     (<== [::subs/sites-list])
+        user      (<== [::subs/editing-user])
+        existing? (some? (:id user))]
+
+    [lui/full-screen-dialog
+     {:open?          (boolean (seq user))
+      :title          (or (:username user)
+                          (:email user))
+      :close-label    (tr :actions/close)
+      :on-close       #(==> [::events/set-user-to-edit nil])
+      :bottom-actions
+      [[lui/email-button
+        {:label    (tr :lipas.admin/magic-link)
+         :on-click #(==> [:lipas.ui.events/confirm
+                          (tr :lipas.admin/confirm-magic-link (:email user))
+                          (fn [] (==> [::events/send-magic-link user]))])}]
+       (when existing?
+         [lui/save-button
+          {:tooltip  (tr :actions/save)
+           :on-click #(==> [::events/save-user user])}])]}
+
+     [mui/grid {:container true :spacing 8}
+
+      ;;; Contact info
+      [lui/form-card {:title (tr :lipas.user/contact-info)}
+       [mui/form-group
+
+        ;; Email
+        [lui/text-field
+         {:label     (tr :lipas.user/email)
+          :value     (:email user)
+          :on-change #(==> [::events/edit-user [:email] %])
+          :disabled  existing?}]
+
+        ;; Username
+        [lui/text-field
+         {:label     (tr :lipas.user/username)
+          :value     (:username user)
+          :on-change #(==> [::events/edit-user [:username] %])
+          :disabled  existing?}]
+
+        ;; Firstname
+        [lui/text-field
+         {:label     (tr :lipas.user/firstname)
+          :value     (-> user :user-data :firstname)
+          :on-change #(==> [::events/edit-user [:user-data :firstname] %])
+          :disabled  existing?}]
+
+        ;; Lastname
+        [lui/text-field
+         {:label     (tr :lipas.user/lastname)
+          :value     (-> user :user-data :lastname)
+          :on-change #(==> [::events/edit-user [:user-data :lastname] %])
+          :disabled  existing?}]]]
+
+      ;;; Permissions
+      [lui/form-card {:title (tr :lipas.user/permissions)}
+       [mui/form-group
+
+        [mui/card {:style {:background-color mui/gray3
+                           :margin-bottom    "1em"}}
+         [mui/card-header {:subheader (tr :lipas.user/requested-permissions)}]
+         [mui/card-content
+          [mui/typography
+           [:i (or (-> user :user-data :permissions-request)
+                   "-")]]]]
+
+        ;; Admin?
+        [lui/checkbox
+         {:label     (tr :lipas.user.permissions/admin?)
+          :value     (-> user :permissions :admin?)
+          :on-change #(==> [::events/edit-user [:permissions :admin?] %])}]
+
+        ;; Permission to all types?
+        [lui/checkbox
+         {:label     (tr :lipas.user.permissions/all-types?)
+          :value     (-> user :permissions :all-types?)
+          :on-change #(==> [::events/edit-user [:permissions :all-types?] %])}]
+
+        ;; Permission to all cities?
+        [lui/checkbox
+         {:label     (tr :lipas.user.permissions/all-cities?)
+          :value     (-> user :permissions :all-cities?)
+          :on-change #(==> [::events/edit-user [:permissions :all-cities?] %])}]
+
+        ;; Permission to individual spoorts-sites
+        [lui/autocomplete
+         {:items     sites
+          :label     (tr :lipas.user.permissions/sports-sites)
+          :value     (-> user :permissions :sports-sites)
+          :on-change #(==> [::events/edit-user [:permissions :sports-sites] %])}]
+
+        ;; Permission to individual types
+        [lui/autocomplete
+         {:items     types
+          :label     (tr :lipas.user.permissions/types)
+          :value     (-> user :permissions :types)
+          :on-change #(==> [::events/edit-user [:permissions :types] %])}]
+
+        ;; Permission to individual cities
+        [lui/autocomplete
+         {:items     cities
+          :label     (tr :lipas.user.permissions/cities)
+          :value     (-> user :permissions :cities)
+          :on-change #(==> [::events/edit-user [:permissions :cities] %])}]]
+       ]]]))
+
+
+(defn admin-panel []
+  (let [tr    (<== [:lipas.ui.subs/translator])
+        users (<== [::subs/users-list])]
+    [mui/grid {:container true}
+     [mui/grid {:item true :xs 12}
+      [mui/card {:square true}
+       [mui/card-content
+        [mui/typography {:variant :headline}
+         (tr :lipas.admin/users)]
+
+        ;; Full-screen user dialog
+        [user-dialog tr]
+
+        ;; Magic link button
+        [mui/button {:variant  :fab
+                     :color    :secondary
+                     :mini     true
+                     :style {:margin-top "1em"}
+                     :on-click #(==> [::events/edit-user [:email] "fix@me.com"])}
+         [mui/icon "add"]]
+
+        ;; Users table
+        [lui/table
+         {:headers
+          [[:email (tr :lipas.user/email)]
+           [:firstname (tr :lipas.user/firstname)]
+           [:lastname (tr :lipas.user/lastname)]
+           [:sports-sites (tr :lipas.user.permissions/sports-sites)]
+           [:cities (tr :lipas.user.permissions/cities)]
+           [:types (tr :lipas.user.permissions/types)]]
+          :sort-fn   :email
+          :items     users
+          :on-select #(==> [::events/set-user-to-edit %])}]]]]]))
+
+(defn main []
+  (let [admin? (<== [:lipas.ui.user.subs/admin?])]
+    (if admin?
+      (do
+        (==> [::events/get-users])
+        (==> [:lipas.ui.sports-sites.events/get-by-type-code 3110])
+        (==> [:lipas.ui.sports-sites.events/get-by-type-code 3130])
+        (==> [:lipas.ui.sports-sites.events/get-by-type-code 2510])
+        (==> [:lipas.ui.sports-sites.events/get-by-type-code 2520])
+        [admin-panel])
+      (==> [:lipas.ui.events/navigate "/#/"]))))

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -413,6 +413,12 @@
                :as   props}]
   (let [props   (-> props
                     (dissoc :value-fn :label-fn :label :sort-fn :sort-cmp)
+                    ;; Following fixes Chrome scroll issue
+                    ;; https://github.com/mui-org/material-ui/pull/12003
+                    (assoc :MenuProps
+                           {:PaperProps
+                            {:style
+                             {:transform "translate2(0)"}}})
                     (assoc :value (if value (pr-str value) ""))
                     (assoc :on-change #(on-change (-> %
                                                       .-target

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -566,7 +566,9 @@
                     :on-change #(on-change :type :type-code %)}]}
 
      ;; Ice-stadiums get special treatment
-     (when (= 2520 (-> edit-data :type :type-code))
+     (when (or (= 2520 (-> edit-data :type :type-code))
+               (and read-only?
+                    (= 2520 (-> display-data :type :type-code))))
        {:label      (tr :ice/size-category)
         :value      (-> display-data :type :size-category)
         :form-field [select

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -150,13 +150,14 @@
                     (on-edit-start %))
        :tooltip  edit-tooltip}])])
 
-(defn checkbox [{:keys [label value on-change disabled]}]
+(defn checkbox [{:keys [label value on-change disabled style]}]
   [mui/form-control-label
    {:label   label
+    :style   style
     :control (r/as-element
               [mui/checkbox
-               {:value     (or (str value) "")
-                :checked   value
+               {:value     (str (boolean value))
+                :checked   (boolean value)
                 :disabled  disabled
                 :on-change #(on-change %2)}])}]) ; %2 = checked?
 

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -27,6 +27,15 @@
 
 ;;; Components ;;;
 
+(defn email-button [{:keys [on-click label] :as props}]
+  [mui/button (merge {:color    "secondary"
+                      :variant  "contained"
+                      :on-click on-click}
+                     props)
+   [mui/icon {:style {:margin-right "0.25em"}}
+    "email"]
+   label])
+
 (defn download-button [{:keys [on-click label] :as props}]
   [mui/button (merge {:color    "secondary"
                       :variant  "outlined"

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -406,13 +406,21 @@
 (def text-field text-field-controlled)
 
 (defn select [{:keys [label value items on-change value-fn label-fn
-                      sort-fn sort-cmp]
+                      sort-fn sort-cmp deselect?]
                :or   {value-fn :value
                       label-fn :label
                       sort-cmp compare}
                :as   props}]
-  (let [props   (-> props
-                    (dissoc :value-fn :label-fn :label :sort-fn :sort-cmp)
+  (let [on-change #(on-change (-> %
+                                  .-target
+                                  .-value
+                                  read-string
+                                  (as-> $ (if (and deselect? (= $ value))
+                                            nil ; toggle
+                                            $))))
+        props   (-> props
+                    (dissoc :value-fn :label-fn :label :sort-fn :sort-cmp
+                            :deselect?)
                     ;; Following fixes Chrome scroll issue
                     ;; https://github.com/mui-org/material-ui/pull/12003
                     (assoc :MenuProps
@@ -420,10 +428,7 @@
                             {:style
                              {:transform "translate2(0)"}}})
                     (assoc :value (if value (pr-str value) ""))
-                    (assoc :on-change #(on-change (-> %
-                                                      .-target
-                                                      .-value
-                                                      read-string))))
+                    (assoc :on-change on-change))
         sort-fn (or sort-fn label-fn)]
     [mui/form-control
      (when label [mui/input-label label])

--- a/webapp/src/cljs/lipas/ui/energy/views.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/views.cljs
@@ -52,11 +52,11 @@
      :on-change #(on-change :water-m3 %)}]
 
    ;; Contains other buildings?
-   [:span {:style {:margin-top "1em"}}
-    [lui/checkbox
-     {:label     (tr :lipas.energy-consumption/contains-other-buildings?)
-      :value     (:contains-other-buildings? data)
-      :on-change #(on-change :contains-other-buildings? %)}]]])
+   [lui/checkbox
+    {:style     {:margin-top "1em"}
+     :label     (tr :lipas.energy-consumption/contains-other-buildings?)
+     :value     (:contains-other-buildings? data)
+     :on-change #(on-change :contains-other-buildings? %)}]])
 
 (comment ;; Example data grid
   {:jan {:electricity-mwh 1233 :heat-mwh 2323 :cold-mwh 2323 :water-m3 5533}

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/subs.cljs
@@ -152,7 +152,9 @@
 (defn ->list-entry [{:keys [cities admins owners types locale size-categories]}
                     ice-stadium]
   (let [type          (types (-> ice-stadium :type :type-code))
-        size-category (-> ice-stadium :type :size-category size-categories locale)
+        size-category (and
+                       (= 2520 (-> ice-stadium :type :type-code))
+                       (-> ice-stadium :type :size-category size-categories locale))
         admin         (admins (-> ice-stadium :admin))
         owner         (owners (-> ice-stadium :owner))
         city          (get cities (-> ice-stadium :location :city :city-code))]
@@ -187,7 +189,7 @@
                :owners          owners
                :types           types
                :size-categories size-categories}]
-     (sort-by :city (map (partial ->list-entry data) (vals sites))))))
+     (map (partial ->list-entry data) (vals sites)))))
 
 (re-frame/reg-sub
  ::display-site-raw

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
@@ -237,6 +237,7 @@
            [lui/select
             {:value     (-> edit-data :ice-resurfacer-fuel)
              :on-change #(on-change :ice-resurfacer-fuel %)
+             :deselect? true
              :items     ice-resurfacer-fuels
              :value-fn  first
              :label-fn  (comp locale second)}]}
@@ -335,6 +336,7 @@
            [lui/select
             {:value     (-> edit-data :base-floor-structure)
              :on-change #(on-change :base-floor-structure %)
+             :deselect? true
              :items     base-floor-structures
              :value-fn  first
              :label-fn  (comp locale second)}]}

--- a/webapp/src/cljs/lipas/ui/login/events.cljs
+++ b/webapp/src/cljs/lipas/ui/login/events.cljs
@@ -74,6 +74,18 @@
          :on-failure      [::logout]}}))))
 
 (re-frame/reg-event-fx
+ ::login-with-magic-link
+ (fn [{db :db} [_ token]]
+   {:http-xhrio
+    {:method          :get
+     :uri             (str (:backend-url db) "/actions/refresh-login")
+     :headers         {:Authorization (str "Token " token)}
+     :format          (ajax/json-request-format)
+     :response-format (ajax/json-response-format {:keywords? true})
+     :on-success      [::login-success]
+     :on-failure      [::logout]}}))
+
+(re-frame/reg-event-fx
  ::logout
  [(re-frame/inject-cofx :remove-local-storage-value :login-data)]
  (fn [{:keys [db]}  _]

--- a/webapp/src/cljs/lipas/ui/login/views.cljs
+++ b/webapp/src/cljs/lipas/ui/login/views.cljs
@@ -5,7 +5,7 @@
             [lipas.ui.mui :as mui]
             [reagent.core :as r]
             [lipas.ui.routes :refer [navigate!]]
-            [lipas.ui.utils :refer [<== ==>]]))
+            [lipas.ui.utils :refer [<== ==>] :as utils]))
 
 (defn set-field [& args]
   (==> [::events/set-field (butlast args) (last args)]))
@@ -86,7 +86,9 @@
 
 (defn main [tr]
   (let [logged-in?    (<== [::subs/logged-in?])
-        comeback-path (<== [::subs/comeback-path])]
-    (if logged-in?
-      (navigate! (or comeback-path "/#/profiili"))
-      [login-panel {:tr tr}])))
+        comeback-path (<== [::subs/comeback-path])
+        token         (utils/parse-token (-> js/window .-location .-href))]
+    (cond
+      token      (==> [:lipas.ui.login.events/login-with-magic-link token])
+      logged-in? (navigate! (or comeback-path "/#/profiili"))
+      :else      [login-panel {:tr tr}])))

--- a/webapp/src/cljs/lipas/ui/mui.cljs
+++ b/webapp/src/cljs/lipas/ui/mui.cljs
@@ -118,6 +118,7 @@
 (def card-header (mui->reagent "CardHeader"))
 (def card-actions (mui->reagent "CardActions"))
 (def card-media (mui->reagent "CardMedia"))
+(def chip (mui->reagent "Chip"))
 (def menu (mui->reagent "Menu"))
 (def menu-item (mui->reagent "MenuItem"))
 (def menu-list (mui->reagent "MenuList"))

--- a/webapp/src/cljs/lipas/ui/navbar.cljs
+++ b/webapp/src/cljs/lipas/ui/navbar.cljs
@@ -255,6 +255,7 @@
       ;; Sub page header
       (case active-panel
         :home-panel           (tr :home-page/headline)
+        :admin-panel          (tr :lipas.admin/headline)
         :sports-panel         (tr :sport/headline)
         :ice-panel            (tr :ice/headline)
         :swim-panel           (tr :swim/headline)

--- a/webapp/src/cljs/lipas/ui/navbar.cljs
+++ b/webapp/src/cljs/lipas/ui/navbar.cljs
@@ -27,8 +27,8 @@
      [avatar]
      [mui/icon "account_circle"])])
 
-(defn create-menu [tr anchor logged-in?]
-  (let [close #(==> [::events/show-account-menu nil])]
+(defn menu [tr anchor logged-in?]
+  (let [close  #(==> [::events/show-account-menu nil])]
     [mui/menu {:anchor-el anchor
                :open      true
                :on-close  close}
@@ -103,9 +103,11 @@
 (defn toggle-drawer [_]
   (==> [::events/toggle-drawer]))
 
-(defn create-drawer [tr logged-in?]
-  (let [hide-and-navigate! (comp toggle-drawer navigate!)]
-    [mui/swipeable-drawer {:open     true
+(defn drawer [tr logged-in?]
+  (let [open?              (<== [::subs/drawer-open?])
+        admin?             (<== [:lipas.ui.user.subs/admin?])
+        hide-and-navigate! (comp toggle-drawer navigate!)]
+    [mui/swipeable-drawer {:open     open?
                            :anchor   :top
                            :on-open  #()
                            :on-close toggle-drawer}
@@ -156,12 +158,21 @@
        [mui/list-item-text {:primary (tr :swim/headline)}]]
       [mui/divider]
 
+      ;; Admin
+      (when admin?
+        [mui/list-item {:button   true
+                        :on-click #(hide-and-navigate! "/#/admin")}
+         [mui/list-item-icon
+          [mui/icon "settings"]]
+         [mui/list-item-text {:primary (tr :lipas.admin/headline)}]])
+
       ;; Help
       [mui/list-item {:button   true
                       :on-click #(hide-and-navigate! (:help links))}
        [mui/list-item-icon
         [mui/icon "help"]]
        [mui/list-item-text {:primary (tr :help/headline)}]]
+
       [mui/divider]
 
       ;; Profile
@@ -196,88 +207,88 @@
           [mui/icon "group_add"]]
          [mui/list-item-text {:primary (tr :register/headline)}]])]]))
 
-(defn nav [tr menu-anchor drawer-open? active-panel logged-in?]
-  [mui/app-bar {:position "static"
-                :color    "primary"
-                :style    {:border-box "1px solid black"}}
+(defn nav [tr active-panel logged-in?]
+  (let [menu-anchor (<== [::subs/account-menu-anchor])]
+    [mui/app-bar {:position "static"
+                  :color    "primary"
+                  :style    {:border-box "1px solid black"}}
 
-   [mui/tool-bar {:disable-gutters true}
+     [mui/tool-bar {:disable-gutters true}
 
-    (when menu-anchor
-      (create-menu tr menu-anchor logged-in?))
+      (when menu-anchor
+        [menu tr menu-anchor logged-in?])
 
-    (when drawer-open?
-      (create-drawer tr logged-in?))
+      [drawer tr logged-in?]
 
-    ;;; JYU logo
-    [:a {:href "/#/"}
-     [mui/svg-icon {:view-box "0 0 132.54 301.95"
-                    :style    {:height "2em"
-                               :margin "0.45em"}}
-      [svg/jyu-logo]]]
+      ;;; JYU logo
+      [:a {:href "/#/"}
+       [mui/svg-icon {:view-box "0 0 132.54 301.95"
+                      :style    {:height "2em"
+                                 :margin "0.45em"}}
+        [svg/jyu-logo]]]
 
-    ;;; Header text
-    [mui/typography {:variant "title"
-                     :style   {:flex        1
-                               :font-size   "1em"
-                               :font-weight "bold"}}
+      ;;; Header text
+      [mui/typography {:variant "title"
+                       :style   {:flex        1
+                                 :font-size   "1em"
+                                 :font-weight "bold"}}
 
-     ;; University of Jyväskylä
-     [mui/hidden {:sm-down true}
-      [mui/typography {:component "a"
-                       :variant   "title"
-                       :href      "/#/"
-                       :style
-                       (merge mui/headline-aleo
-                              {:display         :inline
-                               :font-size       "1em"
-                               :text-transform  :none
-                               :text-decoration :none})}
-       (tr :menu/jyu)]
+       ;; University of Jyväskylä
+       [mui/hidden {:sm-down true}
+        [mui/typography {:component "a"
+                         :variant   "title"
+                         :href      "/#/"
+                         :style
+                         (merge mui/headline-aleo
+                                {:display         :inline
+                                 :font-size       "1em"
+                                 :text-transform  :none
+                                 :text-decoration :none})}
+         (tr :menu/jyu)]
 
-      [separator]]
+        [separator]]
 
-     ;; LIPAS
-     [mui/typography {:component "a"
-                      :variant   "title"
-                      :href      "/#/"
-                      :style
-                      (merge mui/headline-aleo
-                             {:display         :inline
-                              :font-size       "1em"
-                              :text-transform  :none
-                              :text-decoration :none})}
+       ;; LIPAS
+       [mui/typography {:component "a"
+                        :variant   "title"
+                        :href      "/#/"
+                        :style
+                        (merge mui/headline-aleo
+                               {:display         :inline
+                                :font-size       "1em"
+                                :text-transform  :none
+                                :text-decoration :none})}
 
-      (tr :menu/headline)
+        (tr :menu/headline)
 
-      [separator]
+        [separator]
 
-      ;; Sub page header
-      (case active-panel
-        :home-panel           (tr :home-page/headline)
-        :admin-panel          (tr :lipas.admin/headline)
-        :sports-panel         (tr :sport/headline)
-        :ice-panel            (tr :ice/headline)
-        :swim-panel           (tr :swim/headline)
-        :login-panel          (tr :login/headline)
-        :register-panel       (tr :register/headline)
-        :user-panel           (tr :user/headline)
-        :reset-password-panel (tr :reset-password/headline)
-        "")]]
+        ;; Sub page header
+        (case active-panel
+          :home-panel           (tr :home-page/headline)
+          :admin-panel          (tr :lipas.admin/headline)
+          :sports-panel         (tr :sport/headline)
+          :ice-panel            (tr :ice/headline)
+          :swim-panel           (tr :swim/headline)
+          :login-panel          (tr :login/headline)
+          :register-panel       (tr :register/headline)
+          :user-panel           (tr :user/headline)
+          :reset-password-panel (tr :reset-password/headline)
+          "")]]
 
-    [mui/hidden {:sm-down true}
-      [lang-selector]]
+      [mui/hidden {:sm-down true}
+       [lang-selector]]
 
     ;;; Search button
-    ;; [mui/icon-button {:id         "search-btn"
-    ;;                   :aria-label (tr :actions/open-search)}
-    ;;  [mui/icon "search"]]
+      ;; [mui/icon-button {:id         "search-btn"
+      ;;                   :aria-label (tr :actions/open-search)}
+      ;;  [mui/icon "search"]]
 
-    ;;; Account menu button
-    [account-menu-button {:tr tr :logged-in? logged-in?}]
+      ;;; Account menu button
+      [account-menu-button {:tr tr :logged-in? logged-in?}]
 
-    ;;; Main menu (drawer) button
-    [mui/icon-button {:id         "main-menu-btn"
-                      :aria-label (tr :actions/open-main-menu)
-                      :on-click   toggle-drawer}
-     [mui/icon {:color "secondary"} "menu"]]]])
+      ;;; Main menu (drawer) button
+      [mui/icon-button {:id         "main-menu-btn"
+                        :aria-label (tr :actions/open-main-menu)
+                        :on-click   toggle-drawer}
+       [mui/icon {:color "secondary"} "menu"]]]]))

--- a/webapp/src/cljs/lipas/ui/routes.cljs
+++ b/webapp/src/cljs/lipas/ui/routes.cljs
@@ -32,6 +32,11 @@
   (defroute "/" []
     (==> [:lipas.ui.events/set-active-panel :home-panel]))
 
+  ;;; Admin ;;;
+
+  (defroute "/admin" []
+    (==> [:lipas.ui.events/set-active-panel :admin-panel]))
+
   ;;; Sports sites ;;;
 
   (defroute "/liikuntapaikat" []

--- a/webapp/src/cljs/lipas/ui/swimming_pools/pools.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/pools.cljs
@@ -24,7 +24,7 @@
 
      ;; Pool type
      [lui/select
-      {:required  true
+      {:deselect? true
        :label     (tr :general/type)
        :value     (:type data)
        :items     pool-types
@@ -35,6 +35,7 @@
      ;; Structure
      [lui/select
       {:label     (tr :general/structure)
+       :deselect? true
        :value     (:structure data)
        :items     pool-structures
        :label-fn  (comp locale second)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -155,7 +155,7 @@
                :admins admins
                :owners owners
                :types  types}]
-     (sort-by :city (map (partial ->list-entry data) (vals pools))))))
+     (map (partial ->list-entry data) (vals pools)))))
 
 (re-frame/reg-sub
  ::display-site-raw

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -220,7 +220,7 @@
             (update :main-construction-materials #(map get-material %))
             (update :ceiling-structures #(map get-material %))
             (update :supporting-structures #(map get-material %))
-            (update :heat-source get-heat-source))
+            (update :heat-sources #(map get-heat-source %)))
 
         :renovations (:renovations latest)
         :conditions  (:conditions latest)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -201,17 +201,16 @@
             {:value     (-> edit-data :piled?)
              :on-change #(on-change :piled? %)}]}
 
-          ;; Heat source
+          ;; Heat sources
           {:label (tr :lipas.building/heat-source)
-           :value (-> display-data :heat-source)
+           :value (-> display-data :heat-sources)
            :form-field
-           [lui/select
-            {:value     (-> edit-data :heat-source)
-             :deselect? true
+           [lui/multi-select
+            {:value     (-> edit-data :heat-sources)
              :items     heat-sources
              :label-fn  (comp locale second)
              :value-fn  first
-             :on-change #(on-change :heat-source %)}]}
+             :on-change #(on-change :heat-sources %)}]}
 
           ;; Main construction materials
           {:label (tr :lipas.building/main-construction-materials)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -207,6 +207,7 @@
            :form-field
            [lui/select
             {:value     (-> edit-data :heat-source)
+             :deselect? true
              :items     heat-sources
              :label-fn  (comp locale second)
              :value-fn  first

--- a/webapp/src/cljs/lipas/ui/user/reset_password.cljs
+++ b/webapp/src/cljs/lipas/ui/user/reset_password.cljs
@@ -87,17 +87,10 @@
        :disabled (not (s/valid? :lipas.user/password @password))}
       (tr :actions/submit)]]))
 
-(defn parse-token [s]
-  (-> s
-      url/url
-      :anchor
-      (string/split "?token=")
-      second))
-
 (defn main []
   (==> [::events/clear-feedback])
   (let [tr    (<== [:lipas.ui.subs/translator])
-        token (parse-token (-> js/window .-location .-href))]
+        token (utils/parse-token (-> js/window .-location .-href))]
     (if token
       ;; Reset password
       [panel {:tr          tr

--- a/webapp/src/cljs/lipas/ui/user/views.cljs
+++ b/webapp/src/cljs/lipas/ui/user/views.cljs
@@ -3,9 +3,9 @@
             [lipas.ui.components :as lui]
             [lipas.ui.user.subs :as subs]
             [lipas.ui.routes :refer [navigate!]]
-            [re-frame.core :as re-frame]))
+            [lipas.ui.utils :refer [<== ==>]]))
 
-(defn user-panel [tr data]
+(defn user-panel [tr data admin?]
   (let [card-props {:square true
                     :style  {:height "100%"}}
         firstname  (-> data :user-data :firstname)
@@ -91,11 +91,16 @@
        [mui/card-actions
         [mui/button {:href  "/#/"
                      :color :secondary}
-         (str "> " (tr :user/front-page-link))]]]]]))
+         (str "> " (tr :user/front-page-link))]
+        (when admin?
+          [mui/button {:href  "/#/admin"
+                       :color :primary}
+           (str "> " (tr :user/admin-page-link))])]]]]))
 
 (defn main [tr]
-  (let [logged-in? (re-frame/subscribe [::subs/logged-in?])
-        user-data  (re-frame/subscribe [::subs/user-data])]
-    (if @logged-in?
-      [user-panel tr @user-data]
+  (let [logged-in? (<== [::subs/logged-in?])
+        user-data  (<== [::subs/user-data])
+        admin?     (<== [::subs/admin?])]
+    (if logged-in?
+      [user-panel tr user-data admin?]
       (navigate! "/#/kirjaudu"))))

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -298,7 +298,7 @@
         {:keys [protocol host port]} m]
     (str protocol "://"
          host
-         (when-not (#{80 443} port) (str ":" port)))))
+         (when-not (#{80 443 -1 nil ""} port) (str ":" port)))))
 
 (defn current-path []
   (let [path (-> js/window .-location .-href url/url :anchor)]

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -140,11 +140,20 @@
                 (str y))
        :value y})))
 
+(defn some-energy-data-exists? [{:keys [energy-consumption]}]
+  (or (:electricity-mwh energy-consumption)
+      (:heat-mwh energy-consumption)
+      (:water-m3 energy-consumption)
+      (:cold-mwh energy-consumption)))
+
 (defn energy-consumption-history [{:keys [history]}]
   (let [by-year (latest-by-year history)
         entries (select-keys history (vals by-year))]
-    (map #(assoc (:energy-consumption %)
-                 :year (resolve-year (:event-date %))) (vals entries))))
+    (->> entries
+         vals
+         (filter some-energy-data-exists?)
+         (map #(assoc (:energy-consumption %)
+                      :year (resolve-year (:event-date %)))))))
 
 (defn visitors-history [{:keys [history]}]
   (let [by-year (latest-by-year history)

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -304,6 +304,13 @@
   (let [path (-> js/window .-location .-href url/url :anchor)]
     (str "/#" path)))
 
+(defn parse-token [s]
+  (-> s
+      url/url
+      :anchor
+      (string/split "?token=")
+      second))
+
 (defn ->row [d headers]
   (let [header-keys (map first headers)]
     (mapv (fn [k] (get d k)) header-keys)))

--- a/webapp/src/cljs/lipas/ui/views.cljs
+++ b/webapp/src/cljs/lipas/ui/views.cljs
@@ -34,8 +34,6 @@
 
 (defn main-panel []
   (let [active-panel (<== [::subs/active-panel])
-        menu-anchor  (<== [::subs/account-menu-anchor])
-        drawer-open? (<== [::subs/drawer-open?])
         logged-in?   (<== [::subs/logged-in?])
         notification (<== [::subs/active-notification])
         confirmation (<== [::subs/active-confirmation])
@@ -47,7 +45,7 @@
      [mui/mui-theme-provider {:theme mui/jyu-theme-dark}
 
       ;; Navbar and drawer
-      [nav/nav tr menu-anchor drawer-open? active-panel logged-in?]
+      [nav/nav tr active-panel logged-in?]
 
       ;; Dev-env disclaimer
       (when disclaimer

--- a/webapp/src/cljs/lipas/ui/views.cljs
+++ b/webapp/src/cljs/lipas/ui/views.cljs
@@ -1,5 +1,6 @@
 (ns lipas.ui.views
-  (:require [lipas.ui.components :as lui]
+  (:require [lipas.ui.admin.views :as admin]
+            [lipas.ui.components :as lui]
             [lipas.ui.events :as events]
             [lipas.ui.front-page.views :as front-page]
             [lipas.ui.ice-stadiums.views :as ice-stadiums]
@@ -18,6 +19,7 @@
 (defn- panels [panel-name tr logged-in?]
   (case panel-name
     :home-panel           [front-page/main tr]
+    :admin-panel          [admin/main]
     :sports-panel         [sports-sites/main tr]
     :ice-panel            [ice-stadiums/main]
     :swim-panel           [swimming-pools/main]

--- a/webapp/test/clj/lipas/backend/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/handler_test.clj
@@ -82,7 +82,7 @@
     (is (= (:email user) (:email body)))))
 
 (deftest refresh-login-test
-  (let [user   (gen-user)
+  (let [user   (gen-user {:db? true})
         token1 (jwt/create-token user :terse? true)
         _      (Thread/sleep 1000) ; to see effect between timestamps
         resp   (app (-> (mock/request :get "/api/actions/refresh-login")


### PR DESCRIPTION
Live https://lipas-dev.cc.jyu.fi/

## Admin tools

* Admin panel in UI
* Assigning permissions to users
* Sending magic links for passwordless login (and creating new users as side-effect) 

## Localized interface for SportVenue

Added optional `lang` query parameter to queries that fetch lists of sports-sites. Supported languages are `fi` `en` and `se`, however Swedish translations aren't done yet. Without lang parameters interface returns raw 'data values' without any localizations.

Localized fields are:

owner
admin
type -> size-category
envelope -> base-floor-structure
ventilation -> dryer-type
ventilation -> dryer-duty-type
ventilation -> heat-pump-type
ventilation -> heat-recovery-type
refrigeration -> condensate-energy-main-target 
refrigeration -> refrigerant
refrigeration -> refrigerant-solution
building -> supporting-structures 
building -> main-construction-materials
building -> ceiling-structures 
water-treatment -> filtering-methods
pools -> [altaita on lista] -> structure
pools -> [altaita on lista] -> type
saunas -> [saunoja on lista] -> type

Examples:
- https://lipas-dev.cc.jyu.fi/api/sports-sites/type/3110?lang=fi
- https://lipas-dev.cc.jyu.fi/api/sports-sites/type/3110?lang=se
 
## Small fixes

- Scrolling bug with Chrome + selects
- Possibility to deselect values in select 