### PR TITLE
Small fixes to magic links + subdomain related redirects

### DIFF
--- a/webapp/resources/email_templates/magic_link_fi.html
+++ b/webapp/resources/email_templates/magic_link_fi.html
@@ -225,8 +225,7 @@ versiot. </p>
 
 <p class=MsoNormal><a href="{{link}}">{{link}}</a></p>
 
-<p class=MsoNormal>Linkki on voimassa seuraavat X
-päivää/viikkoa/kuukautta/vuotta. Voit käyttää linkkiä tänä aikana niin monta
+<p class=MsoNormal>Linkki on voimassa 7 päivää. Voit käyttää linkkiä tänä aikana niin monta
 kertaa kuin haluat.</p>
 
 <h2>Mitä tapahtuu, kun klikkaan linkkiä?</h2>

--- a/webapp/resources/email_templates/magic_link_fi.html
+++ b/webapp/resources/email_templates/magic_link_fi.html
@@ -288,7 +288,7 @@ href="mailto:lipas@jyu.fi"><span lang=EN-US>lipasinfo@jyu.fi</span></a><span
 lang=EN-US><a class=msocomanchor id="_anchor_1"
 onmouseover="msoCommentShow('_anchor_1','_com_1')"
 onmouseout="msoCommentHide('_com_1')" href="#_msocom_1" language=JavaScript
-name="_msoanchor_1">[HV1]</a>&nbsp;</span></p>
+name="_msoanchor_1"></a>&nbsp;</span></p>
 
 <p class=MsoNormal><span class=Heading2Char><span lang=EN-US style='font-size:
 13.0pt;line-height:107%'>Osoitteet</span></span></p>

--- a/webapp/resources/email_templates/magic_link_fi.txt
+++ b/webapp/resources/email_templates/magic_link_fi.txt
@@ -8,7 +8,7 @@ Alla henkilökohtainen sisäänkirjautumislinkkisi:
 
 {{link}}
 
-Linkki on voimassa seuraavat X päivää/viikkoa/kuukautta/vuotta. Voit käyttää linkkiä tänä aikana niin monta kertaa kuin haluat.
+Linkki on voimassa 7 päivää. Voit käyttää linkkiä tänä aikana niin monta kertaa kuin haluat.
 
 Mitä tapahtuu, kun klikkaan linkkiä?
 

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -54,8 +54,8 @@
   (db/get-users db))
 
 (defn create-magic-link [url user]
-  (let [token (jwt/create-token user :terse? true)]
-    (str url "?token=" token) ))
+  (let [token (jwt/create-token user :terse? true :valid-seconds (* 7 24 60 60))]
+    (str url "?token=" token)))
 
 (defn send-password-reset-link! [db emailer {:keys [email reset-url]}]
   (if-let [user (db/get-user-by-email db {:email email})]

--- a/webapp/src/cljs/lipas/ui/routes.cljs
+++ b/webapp/src/cljs/lipas/ui/routes.cljs
@@ -30,6 +30,12 @@
   ;;; Front page ;;;
 
   (defroute "/" []
+    (case (utils/domain)
+      "uimahallit.lipas.fi" (navigate! "/#/uimahalliportaali")
+      "jaahallit.lipas.fi"  (navigate! "/#/jaahalliportaali")
+      (navigate! "/#/etusivu")))
+
+  (defroute "/etusivu" []
     (==> [:lipas.ui.events/set-active-panel :home-panel]))
 
   ;;; Admin ;;;

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -309,6 +309,9 @@
          host
          (when-not (#{80 443 -1 nil ""} port) (str ":" port)))))
 
+(defn domain []
+  (-> js/window .-location .-href url/url :host))
+
 (defn current-path []
   (let [path (-> js/window .-location .-href url/url :anchor)]
     (str "/#" path)))


### PR DESCRIPTION
## Magic link fixes
* Increased validity to 7 days
* Cleaned up crap from email templates

## Subdomain related redirects
jaahallit.lipas.fi 👉 "/#/jaahalliportaali"
uimahallit.lipas.fi 👉 "/#/uimahalliportaali"