### PR TITLE
Enable inserting monthly energy and visitor data

### DIFF
--- a/webapp/resources/sql/sports_site.sql
+++ b/webapp/resources/sql/sports_site.sql
@@ -40,7 +40,7 @@ WHERE type_code = :type_code
 -- :result :many
 -- :doc Returns history for a single sports-site (lipas_id)
 SELECT *
-FROM sports_site
+FROM sports_site_by_year
 WHERE lipas_id = :lipas_id
 
 -- :name get-yearly-by-type-code

--- a/webapp/src/clj/lipas/maintenance.clj
+++ b/webapp/src/clj/lipas/maintenance.clj
@@ -1,15 +1,17 @@
 (ns lipas.maintenance
-  (:require [lipas.backend.system :as backend]
+  (:require [clojure.data.csv :as csv]
+            [clojure.edn :as edn]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as string]
             [lipas.backend.core :as core]
+            [lipas.backend.db.db :as db]
+            [lipas.backend.system :as backend]
+            [lipas.data.materials :as materials]
+            [lipas.data.swimming-pools :as swimming-pools]
             [lipas.schema.core]
             [lipas.utils :as utils]
-            [lipas.backend.db.db :as db]
-            [clojure.string :as string]
-            [clojure.edn :as edn]
-            [lipas.data.swimming-pools :as swimming-pools]
-            [lipas.data.materials :as materials]
-            [clojure.spec.alpha :as s]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log])
+  (:import java.lang.Math))
 
 (defn upsert-all!
   ([db user sports-sites]
@@ -31,7 +33,7 @@
 
 (defn fix-filtering-methods!
   "Updates [:water-treatment :filtering-method] to match spec."
-  [db user]
+  [db user & args]
   (log/info "Starting to fix swimming pool (3110 3130) filtering methods..")
   (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
         data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
@@ -47,7 +49,7 @@
 (defn fix-building-materials!
   "Updates [:building :main-construction-materials] to contain only
   allowed values."
-  [db user]
+  [db user & args]
   (log/info "Starting to fix swimming pool (3110 3130) building materials..")
   (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
         data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
@@ -63,7 +65,7 @@
 (defn fix-ceiling-structures!
   "Updates [:building :ceiling-structures] to contain only
   allowed values."
-  [db user]
+  [db user & args]
   (log/info "Starting to fix swimming pool (3110 3130) ceiling structures..")
   (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
         data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
@@ -88,7 +90,7 @@
 (defn fix-pool-types!
   "Updates {:pools [{:pool-type \"some-type\"} {...}]} entries to
   contain only allowed values."
-  [db user]
+  [db user & args]
   (log/info "Starting to fix swimming pool (3110 3130) pool types..")
   (let [data-3110  (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
         data-3130  (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})
@@ -105,7 +107,7 @@
 (defn heat-source->heat-sources!
   "Creates new field [:building :heat-sources [...]] and migrates values
   from old field [:building :heat-source]. Old field is removed."
-  [db user]
+  [db user & args]
   (log/info "Starting to fix swimming pool (3110 3130) heat sources..")
   (let [data-3110 (core/get-sports-sites-by-type-code db 3110 {:revs "latest"})
         data-3130 (core/get-sports-sites-by-type-code db 3130 {:revs "latest"})]
@@ -115,12 +117,129 @@
          (map #(update-in % [:building] dissoc :heat-source))
          (upsert-all! db user :lipas.sports-site/swimming-pool))))
 
+(def months
+  {"01" :jan
+   "02" :feb
+   "03" :mar
+   "04" :apr
+   "05" :may
+   "06" :jun
+   "07" :jul
+   "08" :aug
+   "09" :sep
+   "10" :oct
+   "11" :nov
+   "12" :dec})
+
+(def path-parts
+  {"LÄMPÖ"        {:root :energy-consumption-monthly :leaf :heat-mwh}
+   "SÄHKÖ"        {:root :energy-consumption-monthly :leaf :electricity-mwh}
+   "VESI"         {:root :energy-consumption-monthly :leaf :water-m3}
+   "KÄYTTÖTUNNIT" {:root :energy-consumption-monthly :leaf :operating-hours}
+   "KATSOJAT"     {:root :visitors-monthly :leaf :spectators-count}
+   "KÄYTTÄJÄT"    {:root :visitors-monthly :leaf :total-count}})
+
+(defn- append-monthly-entries [year new-rev entries]
+  (reduce (fn [rev entry]
+            (let [type  (get entry "Laji")
+                  v     (-> entry
+                            (get "Kulutus")
+                            utils/->int
+                            (as-> $ (case type ; KWh->MWh
+                                      ("LÄMPÖ" "SÄHKÖ") (double (/ $ 1000))
+                                      $)))
+                  month (get months (-> entry
+                                        (get "Kuukausi")
+                                        (string/split #"/")
+                                        second))
+                  parts (get path-parts type)
+                  path  [(:root parts) month (:leaf parts)]]
+              (assoc-in rev path v)))
+          new-rev
+          entries))
+
+(defn- yearly-sum [k m]
+  (let [entries (map k m)]
+    ;; Sum only if there's data for all months
+    (when (= 12 (count (filter some? entries)))
+      (/ (reduce utils/+safe (map #(* 1000 %) entries))
+         1000))))
+
+(defn- calculate-totals [rev]
+  (let [monthly-vals (-> rev :energy-consumption-monthly vals)
+
+        electricity-mwh  (yearly-sum :electricity-mwh monthly-vals)
+        heat-mwh         (yearly-sum :heat-mwh monthly-vals)
+        water-m3         (yearly-sum :water-m3 monthly-vals)
+        operating-hours  (yearly-sum :operating-hours monthly-vals)
+        spectators-count (yearly-sum :spectators-count monthly-vals)
+        total-count      (yearly-sum :total-count monthly-vals)]
+
+    (cond-> rev
+      (some? electricity-mwh)  (assoc-in [:energy-consumption :electricity-mwh] electricity-mwh)
+      (some? heat-mwh)         (assoc-in [:energy-consumption :heat-mwh] heat-mwh)
+      (some? water-m3)         (assoc-in [:energy-consumption :water-m3] water-m3)
+      (some? operating-hours)  (assoc-in [:energy-consumption :operating-hours] operating-hours)
+      (some? spectators-count) (assoc-in [:visitors :spectators-count] spectators-count)
+      (some? total-count)      (assoc-in [:visitors :total-count] total-count))))
+
+(defn- make-revs [lipas-revs monthly-entries]
+  (let [revs-by-year    (utils/index-by (comp #(subs % 0 4) :event-date) lipas-revs)
+        entries-by-year (group-by (comp
+                                   first ;; yyyy/MM/dd
+                                   #(string/split % #"/")
+                                   #(get % "Kuukausi"))
+                                  monthly-entries)]
+    (for [[year entries] entries-by-year
+          :let           [rev (or (get revs-by-year year)
+                                  (first lipas-revs))
+                          event-date (str year "-12-31T23:59:59.999Z")
+                          new-rev (assoc rev :event-date event-date)]]
+      (->> entries
+           (append-monthly-entries year new-rev)
+           calculate-totals))))
+
+(defn append-monthly-readings!
+  "Appends monthly readings from csv to corresponding ice stadiums (2510
+  2520) revisions under fields :energy-consumption-monthly
+  and :visitors-monthly and calculates corresponding yearly
+  consumptions under :energy-consumption and :visitors."
+  [db user & args]
+  (when-not (first args)
+    (throw (ex-info "Please provide csv-url as argument!" {})))
+  (let [csv-url  (first args)
+        csv-data (-> csv-url
+                     slurp
+                     csv/read-csv
+                     utils/csv-data->maps)
+
+        monthly-data (group-by (comp utils/->int #(get % "Lipas-ID")) csv-data)
+
+        lipas-ids (into #{}
+                        (map (comp utils/->int #(get % "Lipas-ID")) csv-data))
+
+        data-2510 (core/get-sports-sites-by-type-code db 2510 {:revs "yearly"})
+        data-2520 (core/get-sports-sites-by-type-code db 2520 {:revs "yearly"})
+
+        lipas-data (->> (concat data-2510 data-2520)
+                        (filter (comp lipas-ids :lipas-id))
+                        (group-by :lipas-id))
+
+        revs (for [lipas-id lipas-ids
+                   :let     [lipas-revs (get lipas-data lipas-id)
+                             monthly-entries (get monthly-data lipas-id)]]
+               (make-revs lipas-revs monthly-entries))]
+    (->> revs
+         flatten
+         (upsert-all! db user :lipas.sports-site/ice-stadium))))
+
 (def tasks
   {:fix-filtering-methods     fix-filtering-methods!
    :fix-building-materials    fix-building-materials!
    :fix-ceiling-structures    fix-ceiling-structures!
    :fix-pool-types            fix-pool-types!
-   :heat-source->heat-sources heat-source->heat-sources!})
+   :heat-source->heat-sources heat-source->heat-sources!
+   :append-monthly-readings   append-monthly-readings!})
 
 (defn print-usage! []
   (println "\nUsage: lein run -m lipas.maintenance :task-name\n")
@@ -128,23 +247,26 @@
   (doseq [task (keys tasks)]
     (println task)))
 
-(defn run-task! [task-fn]
+(defn run-task! [task-fn args]
   (let [config   (select-keys backend/default-config [:db])
         system   (backend/start-system! config)
         db       (:db system)
         user     (core/get-user db "import@lipas.fi")]
     (try
-      (apply task-fn [db user]) ; TODO maybe pass a map instead?
+      (apply task-fn (into [db user] args))
       (finally (backend/stop-system! system)))))
 
 (defn -main [& args]
-  (let [task-key (-> args first edn/read-string)]
+  (let [task-key (-> args first edn/read-string)
+        args     (rest args)]
     (if-let [task (get tasks task-key)]
-      (run-task! task)
+      (run-task! task args)
       (print-usage!))))
 
 (comment
   (-main ":fix-kissa")
   (-main ":fix-pool-types")
   (-main ":fix-ceiling-structures")
-  (-main ":heat-source->heat-sources"))
+  (-main ":heat-source->heat-sources")
+  (-main ":append-monthly-readings" (str "/Users/vaotjuha/Dropbox/Public/"
+                                         "2018-10-04-jaahallien-kk-kulutukset.csv")))

--- a/webapp/src/clj/lipas/migrate_data.clj
+++ b/webapp/src/clj/lipas/migrate_data.clj
@@ -106,17 +106,11 @@
      (get-lipas-data* (str url "&page=3"))
      (get-lipas-data* (str url "&page=4")))))
 
-(defn csv-data->maps [csv-data]
-  (map zipmap
-       (->> (first csv-data) ;; First row is the header
-            repeat)
-       (rest csv-data)))
-
 (defn get-portal-data [path]
   (as-> path $
     (slurp $)
     (csv/read-csv $)
-    (csv-data->maps $)
+    (utils/csv-data->maps $)
     (group-by #(get % "Halli_ID") $)))
 
 (def admins (utils/index-by (comp :fi second) first admins/all))

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -122,3 +122,13 @@
            (vector? y) (concat x y)
            :else       y))
    a b))
+
+(defn csv-data->maps [csv-data]
+  (map zipmap
+       (->> (first csv-data) ;; First row is the header
+            repeat)
+       (rest csv-data)))
+
+(defn +safe [& args]
+  (if-let [valid-args (not-empty (filter number? args))]
+    (apply + valid-args)))

--- a/webapp/test/clj/lipas/backend/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/handler_test.clj
@@ -258,9 +258,9 @@
                          :admin)))))
 
 (deftest get-sports-site-history-test
-  (let [user     (gen-user {:db? true})
+  (let [user     (gen-user {:db? true :admin? true})
         rev1     (-> (gen/generate (s/gen :lipas/sports-site))
-                     (assoc :status "draft"))
+                     (assoc :status "active"))
         rev2     (-> rev1
                      (assoc :event-date (gen/generate (s/gen :lipas/timestamp)))
                      (assoc :name "Kissalan kuulahalli"))


### PR DESCRIPTION
This PR adds a maintenance script for inserting monthly visitor and energy data posthumously from csv-file.