### PR TITLE
Double bundle and excel exports

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -724,6 +724,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "core-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -943,6 +948,11 @@
         "prr": "~1.0.1"
       }
     },
+    "es6-promise": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1119,6 +1129,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "file-saver": {
+      "version": "1.3.8",
+      "resolved": "http://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1806,6 +1821,11 @@
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -2064,6 +2084,43 @@
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
+    "jszip": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+      "requires": {
+        "core-js": "~2.3.0",
+        "es6-promise": "~3.0.2",
+        "lie": "~3.1.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.0.6"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2076,6 +2133,14 @@
       "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "loader-runner": {
@@ -2106,6 +2171,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -3677,6 +3747,16 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "zipcelx": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/zipcelx/-/zipcelx-1.5.0.tgz",
+      "integrity": "sha512-ejHa2g7bqN+v1uKhtyvfL3HZsYLQRjKsS85BKHJWG1e+bILDsOGx9AjtvWvWn3QTh9NYJBK2w5BLJyEsjTtlSg==",
+      "requires": {
+        "file-saver": "^1.3.3",
+        "jszip": "^3.1.3",
+        "lodash.escape": "^4.0.1"
       }
     }
   }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "ol": "^5.2.0",
-    "webpack": "^4.20.2"
+    "webpack": "^4.20.2",
+    "zipcelx": "^1.5.0"
   },
   "devDependencies": {
     "webpack-cli": "^3.1.2"

--- a/webapp/project.clj
+++ b/webapp/project.clj
@@ -20,8 +20,6 @@
                  [cljsjs/material-ui "3.1.1-0"]
                  [tongue "0.2.4"]
                  [day8.re-frame/http-fx "0.1.6"]
-                 [cljsjs/filesaverjs "1.3.3-0"]
-                 [testdouble/clojurescript.csv "0.3.0"]
                  [cljsjs/google-analytics "2015.04.13-0"]
                  [district0x.re-frame/google-analytics-fx "1.0.0"]
                  [cljsjs/babel-polyfill "6.20.0-2"]
@@ -115,8 +113,10 @@
                     :npm-deps             false
                     :infer-externs        true
                     :foreign-libs         [{:file           "dist/index.bundle.js"
-                                            :provides       ["ol"]
-                                            :global-exports {ol ol}}]
+                                            :provides       ["ol"
+                                                             "zipcelx"]
+                                            :global-exports {ol ol
+                                                             zipcelx zipcelx}}]
                     :output-to            "resources/public/js/compiled/app.js"
                     :output-dir           "resources/public/js/compiled/out"
                     :asset-path           "js/compiled/out"
@@ -133,8 +133,8 @@
                     :npm-deps        false
                     :infer-externs   true
                     :foreign-libs    [{:file           "dist/index.bundle.js"
-                                       :provides       ["ol"]
-                                       :global-exports {ol ol}}]
+                                       :provides       ["ol" "zipcelx"]
+                                       :global-exports {ol ol zipcelx zipcelx}}]
                     :output-to       "resources/public/js/compiled/app.js"
                     :optimizations   :advanced
                     :closure-defines {goog.DEBUG false}

--- a/webapp/src/cljs/lipas/ui/core.cljs
+++ b/webapp/src/cljs/lipas/ui/core.cljs
@@ -4,7 +4,7 @@
             [day8.re-frame.http-fx]
             [district0x.re-frame.google-analytics-fx]
             [lipas.ui.local-storage]
-            [lipas.ui.scroll]
+            [lipas.ui.effects]
             [lipas.ui.config :as config]
             [lipas.ui.events :as events]
             [lipas.ui.routes :as routes]

--- a/webapp/src/cljs/lipas/ui/effects.cljs
+++ b/webapp/src/cljs/lipas/ui/effects.cljs
@@ -1,0 +1,8 @@
+(ns lipas.ui.effects
+  (:require [re-frame.core :as re-frame]
+            ["zipcelx"]))
+
+(re-frame/reg-fx
+ ::download-excel!
+ (fn  [config]
+   (zipcelx (clj->js config))))

--- a/webapp/src/cljs/lipas/ui/effects.cljs
+++ b/webapp/src/cljs/lipas/ui/effects.cljs
@@ -3,6 +3,11 @@
             ["zipcelx"]))
 
 (re-frame/reg-fx
+ ::reset-scroll!
+ (fn  [_]
+   (js/window.scrollTo 0 0)))
+
+(re-frame/reg-fx
  ::download-excel!
  (fn  [config]
    (zipcelx (clj->js config))))

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/events.cljs
@@ -48,4 +48,4 @@
        [:lipas.ui.events/navigate (str "/#/jaahalliportaali/hallit/" lipas-id)])
      (when-not lipas-id
        [:lipas.ui.events/navigate "/#/jaahalliportaali/hallit"])]
-    :lipas.ui.scroll/reset! nil}))
+    :lipas.ui.effects/reset-scroll! nil}))

--- a/webapp/src/cljs/lipas/ui/scroll.cljs
+++ b/webapp/src/cljs/lipas/ui/scroll.cljs
@@ -1,7 +1,0 @@
-(ns lipas.ui.scroll
-  (:require [re-frame.core :as re-frame]))
-
-(re-frame/reg-fx
- ::reset!
- (fn  [_]
-   (js/window.scrollTo 0 0)))

--- a/webapp/src/cljs/lipas/ui/sports_sites/events.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/events.cljs
@@ -1,6 +1,5 @@
 (ns lipas.ui.sports-sites.events
-  (:require cljsjs.filesaverjs
-            [ajax.core :as ajax]
+  (:require [ajax.core :as ajax]
             [lipas.ui.utils :as utils]
             [re-frame.core :as re-frame]))
 
@@ -130,11 +129,8 @@
 (re-frame/reg-event-fx
  ::download-contacts-report
  (fn [{:keys [db]} [_ data headers]]
-   (let [tr       (:translator db)
-         filename (str (tr :reports/contacts) ".csv")
-         mime     (str "text/plain;charset=" (.-characterSet js/document))
-         blob     (new js/Blob
-                       [(utils/->csv data headers)]
-                       (clj->js {:type mime}))
-         _        (js/saveAs blob filename)]
-     {})))
+   (let [tr     (:translator db)
+         config {:filename (tr :reports/contacts)
+                 :sheet
+                 {:data (utils/->excel-data headers data)}}]
+     {:lipas.ui.effects/download-excel! config})))

--- a/webapp/src/cljs/lipas/ui/swimming_pools/events.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/events.cljs
@@ -70,4 +70,4 @@
        [:lipas.ui.events/navigate (str "/#/uimahalliportaali/hallit/" lipas-id)])
      (when-not lipas-id
        [:lipas.ui.events/navigate "/#/uimahalliportaali/hallit"])]
-    :lipas.ui.scroll/reset! nil}))
+    :lipas.ui.effects/reset-scroll! nil}))

--- a/webapp/src/js/index.js
+++ b/webapp/src/js/index.js
@@ -1,2 +1,3 @@
-//import * as ol from "ol";
-//window.ol = ol;
+import zipcelx from 'zipcelx';
+
+window.zipcelx = zipcelx;


### PR DESCRIPTION
# Introducing Double Bundle (Webpack + cljsbuild)

- bundle npm dependencies with webpack. More info: https://github.com/pesterhazy/double-bundle and https://clojurescript.org/guides/webpack

Two additional steps to build process:
- `docker-compose run frontend-npm-deps`
- `docker-compose run frontend-npm-bundle`

After these `docker-compose run frontend-build` can be run normally. 

See example in [ci.sh](ci.sh)

First example is using https://github.com/egeriis/zipcelx to export reports as `xlsx` instead of `csv`