### PR TITLE
Auto-publish drafts and refactoring

### DIFF
--- a/webapp/project.clj
+++ b/webapp/project.clj
@@ -23,7 +23,6 @@
                  [cljsjs/google-analytics "2015.04.13-0"]
                  [district0x.re-frame/google-analytics-fx "1.0.0"]
                  [cljsjs/babel-polyfill "6.20.0-2"]
-                 [cljsjs/date-fns "1.29.0-0"]
                  [cljsjs/recharts "1.1.0-3"]
                  [cljsjs/react-autosuggest "9.3.4-0"]
 

--- a/webapp/resources/migrations/20181022051044-document-status.down.sql
+++ b/webapp/resources/migrations/20181022051044-document-status.down.sql
@@ -1,0 +1,2 @@
+-- No reasonable way to rollback data changes for now.
+-- Restore 'old' data from backup if necessary.

--- a/webapp/resources/migrations/20181022051044-document-status.up.sql
+++ b/webapp/resources/migrations/20181022051044-document-status.up.sql
@@ -1,0 +1,19 @@
+-- Separate 'document status' from 'sports-site status'
+
+-- Document status describes status of the document
+-- Sports-site status describes status of the actual sports-site
+
+-- Document status is not stored within the "document" JSON. It exists
+-- only as field in 'sports_site' table.
+
+-- Sports-site status is not *currently* included in 'sports_site' table
+-- but it can be added there later if needed for indexing etc.
+
+-- NOTE: JSON field document.status is the actual 'sports-site status'.
+
+-- Document statuses are now 'draft' and 'published'
+update sports_site set status = 'published' where status = 'active';
+
+-- Change existing 'draft' sports-site statuses to 'active'
+update sports_site set "document" = jsonb_set("document", '{status}', '"active"')
+where "document"::json->>'status' = 'draft';

--- a/webapp/resources/sql/sports_site.sql
+++ b/webapp/resources/sql/sports_site.sql
@@ -58,3 +58,11 @@ WHERE type_code = :type_code
 SELECT *
 FROM sports_site_by_year
 WHERE type_code = :type_code AND date_part('year', event_date) = :year
+
+-- :name get-by-author-and-status
+-- :command :query
+-- :result :many
+-- :doc Lists sports-sites by given author_id (user) and status
+SELECT *
+FROM sports_site
+WHERE status = :status AND author_id = :author_id ::uuid

--- a/webapp/src/clj/lipas/backend/config.clj
+++ b/webapp/src/clj/lipas/backend/config.clj
@@ -1,0 +1,19 @@
+(ns lipas.backend.config
+  (:require [environ.core :refer [env]]
+            [integrant.core :as ig]))
+
+(def default-config
+  {:db      {:dbtype   "postgresql"
+             :dbname   (:db-name env)
+             :host     (:db-host env)
+             :user     (:db-user env)
+             :port     (:db-port env)
+             :password (:db-password env)}
+   :emailer {:host (:smtp-host env)
+             :user (:smtp-user env)
+             :pass (:smtp-pass env)
+             :from (:smtp-from env)}
+   :app     {:db      (ig/ref :db)
+             :emailer (ig/ref :emailer)}
+   :server  {:app  (ig/ref :app)
+             :port 8091}})

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -94,12 +94,15 @@
 
 ;;; Sports-sites ;;;
 
-(defn upsert-sports-site! [db user sports-site draft?]
-  (if (or draft?
-          (permissions/publish? (:permissions user) sports-site))
-    (db/upsert-sports-site! db user sports-site draft?)
-    (throw (ex-info "User doesn't have enough permissions!"
-                    {:type :no-permission}))))
+(defn upsert-sports-site!
+  ([db user sports-site]
+   (upsert-sports-site! db user sports-site false))
+  ([db user sports-site draft?]
+   (if (or draft?
+           (permissions/publish? (:permissions user) sports-site))
+     (db/upsert-sports-site! db user sports-site draft?)
+     (throw (ex-info "User doesn't have enough permissions!"
+                     {:type :no-permission})))))
 
 (defn get-sports-sites-by-type-code [db type-code {:keys [locale] :as opts}]
   (let [data (db/get-sports-sites-by-type-code db type-code opts)]

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -94,13 +94,10 @@
 
 ;;; Sports-sites ;;;
 
-(defn draft? [sports-site]
-  (= (-> sports-site :status) "draft"))
-
-(defn upsert-sports-site! [db user sports-site]
-  (if (or (draft? sports-site)
+(defn upsert-sports-site! [db user sports-site draft?]
+  (if (or draft?
           (permissions/publish? (:permissions user) sports-site))
-    (db/upsert-sports-site! db user sports-site)
+    (db/upsert-sports-site! db user sports-site draft?)
     (throw (ex-info "User doesn't have enough permissions!"
                     {:type :no-permission}))))
 

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -78,3 +78,14 @@
                    db-utils/->snake-case-keywords)]
     (->> (db-fn db-spec params)
          (map sports-site/unmarshall))))
+
+(defn get-users-drafts [db user]
+  (let [params {:author_id (:id user)
+                :status    "draft"}]
+    (->> (sports-site/get-by-author-and-status db params)
+         (map sports-site/unmarshall))))
+
+(comment
+  (require '[lipas.backend.config :as config])
+  (def db-spec (:db config/default-config))
+  (get-users-drafts db-spec {:id "a112fd21-9470-480a-8961-6ddd308f58d9"}))

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -42,14 +42,18 @@
 
 ;; Sports Site ;;
 
-(defn upsert-sports-site! [db-spec user sports-site]
-  (jdbc/with-db-transaction [tx db-spec]
-    (let [lipas-id    (or (:lipas-id sports-site)
-                          (:nextval (sports-site/next-lipas-id tx)))
-          sports-site (assoc sports-site :lipas-id lipas-id)]
-      (->> (sports-site/marshall sports-site user)
-           (sports-site/insert-sports-site-rev! tx)
-           (sports-site/unmarshall)))))
+(defn upsert-sports-site!
+  ([db-spec user sports-site]
+   (upsert-sports-site! db-spec user sports-site false))
+  ([db-spec user sports-site draft?]
+   (jdbc/with-db-transaction [tx db-spec]
+     (let [status      (if draft? "draft" "published")
+           lipas-id    (or (:lipas-id sports-site)
+                           (:nextval (sports-site/next-lipas-id tx)))
+           sports-site (assoc sports-site :lipas-id lipas-id)]
+       (->> (sports-site/marshall sports-site user status)
+            (sports-site/insert-sports-site-rev! tx)
+            (sports-site/unmarshall))))))
 
 (defn upsert-sports-sites! [db-spec user sports-sites]
   (jdbc/with-db-transaction [tx db-spec]

--- a/webapp/src/clj/lipas/backend/db/sports_site.clj
+++ b/webapp/src/clj/lipas/backend/db/sports_site.clj
@@ -7,7 +7,6 @@
    {:event-date  (-> sports-site :event-date)
     :lipas-id    (-> sports-site :lipas-id)
     :status      status
-    :site-status (-> sports-site :status)
     :type-code   (-> sports-site :type :type-code)
     :city-code   (-> sports-site :location :city :city-code)
     :author-id   (-> user :id)}

--- a/webapp/src/clj/lipas/backend/db/sports_site.clj
+++ b/webapp/src/clj/lipas/backend/db/sports_site.clj
@@ -2,14 +2,15 @@
   (:require [hugsql.core :as hugsql]
             [lipas.backend.db.utils :as utils]))
 
-(defn marshall [sports-site user]
+(defn marshall [sports-site user status]
   (->
-   {:event-date (-> sports-site :event-date)
-    :lipas-id   (-> sports-site :lipas-id)
-    :status     (-> sports-site :status)
-    :type-code  (-> sports-site :type :type-code)
-    :city-code  (-> sports-site :location :city :city-code)
-    :author-id  (-> user :id)}
+   {:event-date  (-> sports-site :event-date)
+    :lipas-id    (-> sports-site :lipas-id)
+    :status      status
+    :site-status (-> sports-site :status)
+    :type-code   (-> sports-site :type :type-code)
+    :city-code   (-> sports-site :location :city :city-code)
+    :author-id   (-> user :id)}
    utils/->snake-case-keywords
    (assoc :document sports-site)))
 

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -1,5 +1,6 @@
 (ns lipas.backend.handler
   (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [lipas.backend.core :as core]
             [lipas.backend.jwt :as jwt]
             [lipas.backend.middleware :as mw]
@@ -86,10 +87,12 @@
       ["/sports-sites"
        {:post
         {:middleware [mw/token-auth mw/auth]
-         :parameters {:query :lipas.api/query-params}
+         :parameters {:query :lipas.api/query-params
+                      :body  (s/or :new :lipas/new-sports-site
+                                   :existing :lipas/sports-site)}
          :handler
          (fn [{:keys [body-params identity] :as req}]
-           (let [draft? (-> req :parameters :query :draft utils/->bool)]
+           (let [draft?      (-> req :parameters :query :draft utils/->bool)]
              {:status 201
               :body   (core/upsert-sports-site! db identity body-params draft?)}))}}]
 

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -4,6 +4,7 @@
             [lipas.backend.jwt :as jwt]
             [lipas.backend.middleware :as mw]
             [lipas.schema.core]
+            [lipas.utils :as utils]
             [muuntaja.core :as m]
             [reitit.coercion.spec]
             [reitit.ring :as ring]
@@ -85,10 +86,12 @@
       ["/sports-sites"
        {:post
         {:middleware [mw/token-auth mw/auth]
+         :parameters {:query :lipas.api/query-params}
          :handler
-         (fn [{:keys [body-params identity]}]
-           {:status 201
-            :body   (core/upsert-sports-site! db identity body-params)})}}]
+         (fn [{:keys [body-params identity] :as req}]
+           (let [draft? (-> req :parameters :query :draft utils/->bool)]
+             {:status 201
+              :body   (core/upsert-sports-site! db identity body-params draft?)}))}}]
 
       ["/sports-sites/history/:lipas-id"
        {:get

--- a/webapp/src/clj/lipas/backend/system.clj
+++ b/webapp/src/clj/lipas/backend/system.clj
@@ -1,26 +1,10 @@
 (ns lipas.backend.system
-  (:require [environ.core :refer [env]]
-            [clojure.pprint :refer [pprint]]
-            [ring.adapter.jetty :as jetty]
+  (:require [clojure.pprint :refer [pprint]]
             [integrant.core :as ig]
+            [lipas.backend.config :as config]
             [lipas.backend.email :as email]
-            [lipas.backend.handler :as handler]))
-
-(def default-config
-  {:db      {:dbtype   "postgresql"
-             :dbname   (:db-name env)
-             :host     (:db-host env)
-             :user     (:db-user env)
-             :port     (:db-port env)
-             :password (:db-password env)}
-   :emailer {:host (:smtp-host env)
-             :user (:smtp-user env)
-             :pass (:smtp-pass env)
-             :from (:smtp-from env)}
-   :app     {:db      (ig/ref :db)
-             :emailer (ig/ref :emailer)}
-   :server  {:app  (ig/ref :app)
-             :port 8091}})
+            [lipas.backend.handler :as handler]
+            [ring.adapter.jetty :as jetty]))
 
 (defmethod ig/init-key :db [_ db-spec]
   ;; TODO setup connection pooling
@@ -43,7 +27,7 @@
 
 (defn start-system!
   ([]
-   (start-system! default-config))
+   (start-system! config/default-config))
   ([config]
    (let [system (ig/init config)]
      (prn "System started with config:")
@@ -56,4 +40,4 @@
   (ig/halt! system))
 
 (defn -main [& args]
-  (start-system! default-config))
+  (start-system! config/default-config))

--- a/webapp/src/clj/lipas/dev.clj
+++ b/webapp/src/clj/lipas/dev.clj
@@ -1,7 +1,8 @@
 (ns lipas.dev
   (:require [lipas.backend.system :as backend]
+            [lipas.backend.config :as config]
             [ring.middleware.reload :refer [wrap-reload]]))
 
-(def system (backend/start-system! (dissoc backend/default-config :server)))
+(def system (backend/start-system! (dissoc config/default-config :server)))
 (def app (:app system))
 (def dev-handler (-> #'app wrap-reload))

--- a/webapp/src/clj/lipas/maintenance.clj
+++ b/webapp/src/clj/lipas/maintenance.clj
@@ -3,6 +3,7 @@
             [clojure.edn :as edn]
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
+            [lipas.backend.config :as config]
             [lipas.backend.core :as core]
             [lipas.backend.db.db :as db]
             [lipas.backend.system :as backend]
@@ -258,7 +259,7 @@
     (println task)))
 
 (defn run-task! [task-fn args]
-  (let [config   (select-keys backend/default-config [:db])
+  (let [config   (select-keys config/default-config [:db])
         system   (backend/start-system! config)
         db       (:db system)
         user     (core/get-user db "import@lipas.fi")]

--- a/webapp/src/clj/lipas/migrate_data.clj
+++ b/webapp/src/clj/lipas/migrate_data.clj
@@ -4,6 +4,7 @@
             [clojure.spec.alpha :as spec]
             [clojure.string :as string]
             [environ.core :refer [env]]
+            [lipas.backend.config :as config]
             [lipas.backend.core :as core]
             [lipas.backend.db.db :as db]
             [lipas.backend.system :as backend]
@@ -511,7 +512,7 @@
   (let [source                  (first args)
         ice-stadiums-csv-path   (:ice-stadiums-csv-url env)
         swimming-pools-csv-path (:swimming-pools-csv-url env)
-        config                  (select-keys backend/default-config [:db])
+        config                  (select-keys config/default-config [:db])
         {:keys [db]}            (backend/start-system! config)
         user                    (core/get-user db "import@lipas.fi")]
     (case source

--- a/webapp/src/clj/lipas/seed.clj
+++ b/webapp/src/clj/lipas/seed.clj
@@ -1,10 +1,11 @@
 (ns lipas.seed
-  (:require [lipas.backend.system :as backend]
-            [lipas.backend.core :as core]
-            [environ.core :refer [env]]
-            [lipas.schema.core]
-            [clojure.spec.alpha :as s]
+  (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
+            [environ.core :refer [env]]
+            [lipas.backend.config :as config]
+            [lipas.backend.core :as core]
+            [lipas.backend.system :as backend]
+            [lipas.schema.core]
             [taoensso.timbre :as log]))
 
 (def jh-demo
@@ -69,7 +70,7 @@
   (log/info "Seeding done!"))
 
 (defn -main [& args]
-  (let [config (select-keys backend/default-config [:db])
+  (let [config (select-keys config/default-config [:db])
         system (backend/start-system! config)
         db     (:db system)]
     (try

--- a/webapp/src/cljc/lipas/data/sports_sites.cljc
+++ b/webapp/src/cljc/lipas/data/sports_sites.cljc
@@ -1,12 +1,25 @@
 (ns lipas.data.sports-sites)
 
+(def document-statuses
+  {"draft"
+   {:fi "Ehdotus"
+    :se nil
+    :en "Draft"}
+   "published"
+   {:fi "Julkaistu"
+    :se nil
+    :en "Published"}})
+
 (def statuses
-  {"draft"     {:fi "Ehdotus"
-                :se nil
-                :en "Draft"}
-   "active"    {:fi "Toiminnassa"
-                :se nil
-                :en "Active"}
-   "abolished" {:fi "Poistettu käytöstä"
-                :se nil
-                :en "Abolished"}})
+  {"active"
+   {:fi "Toiminnassa"
+    :se nil
+    :en "Active"}
+   "out-of-service-temporarily"
+   {:fi "Pois käytöstä väliaikaisesti"
+    :se nil
+    :en "Temporarily out of service"}
+   "out-of-service-permanently"
+   {:fi "Poistettu käytöstä"
+    :se nil
+    :en "Out of service"}})

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -755,6 +755,8 @@
 
 (s/def :lipas.api/revs #{"latest" "yearly"})
 (s/def :lipas.api/lang #{"fi" "en" "se"})
+(s/def :lipas.api/draft #{"true" "false"})
 (s/def :lipas.api/query-params
   (s/keys :opt-un [:lipas.api/revs
-                   :lipas.api/lang]))
+                   :lipas.api/lang
+                   :lipas.api/draft]))

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -287,9 +287,8 @@
 (s/def :lipas/visitors-monthly
   (s/map-of months :lipas/visitors))
 
-(s/def :lipas/sports-site
+(s/def :lipas/new-sports-site
   (s/keys :req-un [:lipas.sports-site/event-date
-                   :lipas.sports-site/lipas-id
                    :lipas.sports-site/status
                    :lipas.sports-site/type
                    :lipas.sports-site/name
@@ -311,6 +310,11 @@
                    :lipas/visitors-monthly
                    ;; :lipas.sports-site/properties
                    ]))
+
+(s/def :lipas/sports-site
+  (s/merge
+   :lipas/new-sports-site
+   (s/keys :req-un [:lipas.sports-site/lipas-id])))
 
 (s/def :lipas/sports-sites (s/coll-of :lipas/sports-site :distinct true :into []))
 

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -1,5 +1,6 @@
 (ns lipas.utils
   (:require [clojure.walk :as walk]
+            [clojure.string :as string]
             [clojure.spec.alpha :as s]
             #?(:cljs [cljs.reader :refer [read-string]])
             #?(:cljs [goog.string :as gstring])
@@ -65,6 +66,10 @@
     (string? x) (try (->uuid x) #?(:cljs (catch :default ex)
                                    :clj  (catch Exception e)))
     :else nil))
+
+(defn ->bool [x]
+  #?(:clj (java.lang.Boolean/parseBoolean (str x))
+     :cljs (= "true" (-> x str string/lower-case))))
 
 (defn gen-uuid []
   #?(:clj (java.util.UUID/randomUUID)

--- a/webapp/src/cljs/lipas/ui/charts.cljs
+++ b/webapp/src/cljs/lipas/ui/charts.cljs
@@ -1,33 +1,38 @@
 (ns lipas.ui.charts
   (:require ["recharts" :as rc]
-            [lipas.ui.mui :as mui]
             [clojure.set :refer [rename-keys map-invert]]))
 
 (def colors
   {:energy-mwh       "orange"
-   :electricity-mwh  "#ffd400"
+   ;; :electricity-mwh  "#ffd400"
+   :electricity-mwh  "#efc700"
    :heat-mwh         "#ff503c"
    :water-m3         "#0a9bff"
-   ;;:total-count      "#8ce614"
+   ;; :total-count      "#8ce614"
    :total-count      "#3367d6"
    ;; :spectators-count "#05cdaa"
    :spectators-count "#72a4f7"
    })
 
+(def font-styles
+  {:font-family "lato"})
+
+(def font-styles-bold
+  (merge font-styles
+         {:font-weight "bold"}))
+
 (def tooltip-styles
-  {:itemStyle  {:font-family "lato"
-                :font-weight "bold"}
-   :labelStyle {:font-weight "bold"
-                :font-family "lato"}})
+  {:itemStyle  font-styles-bold
+   :labelStyle font-styles-bold})
 
 (defn energy-chart [{:keys [data energy energy-label]}]
   (let [data (map #(rename-keys % {energy energy-label}) data)]
    [:> rc/ResponsiveContainer {:width "100%" :height 300}
     [:> rc/BarChart {:data data}
      [:> rc/CartesianGrid]
-     [:> rc/Legend]
+     [:> rc/Legend {:wrapperStyle font-styles}]
      [:> rc/Tooltip tooltip-styles]
-     [:> rc/YAxis]
+     [:> rc/YAxis {:tick font-styles}]
      [:> rc/XAxis {:dataKey :name :label false :tick false}]
      [:> rc/Bar {:dataKey energy-label :label false :fill (get colors energy)}]]]))
 
@@ -45,10 +50,10 @@
     [:> rc/ResponsiveContainer {:width "100%" :height 300}
      (into
       [:> rc/BarChart {:data data}
-       [:> rc/Legend]
+       [:> rc/Legend {:wrapperStyle font-styles}]
        [:> rc/Tooltip tooltip-styles]
-       [:> rc/YAxis]
-       [:> rc/XAxis {:dataKey :month :tick true}]]
+       [:> rc/YAxis {:tick font-styles}]
+       [:> rc/XAxis {:dataKey :month :tick font-styles}]]
       (for [k data-keys]
         (when (some #(get % k) data)
           [:> rc/Bar {:dataKey k :label false :fill (get colors (get lookup k))}])))]))
@@ -67,10 +72,10 @@
      (into
       [:> rc/BarChart {:data     data
                        :on-click on-click}
-       [:> rc/Legend]
+       [:> rc/Legend {:wrapperStyle font-styles}]
        [:> rc/Tooltip tooltip-styles]
-       [:> rc/YAxis]
-       [:> rc/XAxis {:dataKey :year :tick true}]]
+       [:> rc/YAxis {:tick font-styles}]
+       [:> rc/XAxis {:dataKey :year :tick font-styles}]]
       (for [k data-keys]
         (when (some #(get % k) data)
           [:> rc/Bar {:dataKey k :label false :fill (get colors (get lookup k))}])))]))

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -377,8 +377,9 @@
                  (assoc :ref (:inputRef props))
                  (dissoc :inputRef))])
 
-(defn text-field-controlled [{:keys [value type on-change spec required
+(defn text-field-controlled [{:keys [value type on-change spec required defer-ms
                                      Input-props adornment multiline read-only?]
+                              :or   {defer-ms 200}
                               :as   props} & children]
   (r/with-let [read-only*?   (r/atom read-only?)
                state (r/atom value)]
@@ -386,7 +387,7 @@
                        (do ; fix stale state between read-only? switches
                          (reset! read-only*? read-only?)
                          (reset! state value)))
-          on-change  (gfun/debounce on-change 200)
+          on-change  (gfun/debounce on-change defer-ms)
           on-change* (fn [e]
                        (let [new-val (->> e .-target .-value (coerce type))]
                          (reset! state new-val)
@@ -394,7 +395,7 @@
           input      (if multiline
                        patched-text-area
                        patched-input)
-          props      (-> (dissoc props :read-only?)
+          props      (-> (dissoc props :read-only? :defer-ms)
                          (as-> $ (if (= "number" type) (dissoc $ :type) $))
                          (assoc :error (error? spec @state required))
                          (assoc :Input-props

--- a/webapp/src/cljs/lipas/ui/components.cljs
+++ b/webapp/src/cljs/lipas/ui/components.cljs
@@ -673,7 +673,7 @@
 
    ;; Floating actions
    (into
-    [floating-container {:right 16 :bottom 16 :background-color "transparent"}]
+    [floating-container {:right 24 :bottom 16 :background-color "transparent"}]
     (interpose [:span {:style {:margin-left  "0.25em"
                                :margin-right "0.25em"}}]
                bottom-actions))

--- a/webapp/src/cljs/lipas/ui/energy/events.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/events.cljs
@@ -6,10 +6,12 @@
 (re-frame/reg-event-fx
  ::select-energy-consumption-site
  (fn [{:keys [db]} [_ lipas-id]]
-   {:db       (-> db
-                  (assoc-in [:energy-consumption :lipas-id] lipas-id)
-                  (assoc-in [:energy-consumption :year] nil))
-    :dispatch [:lipas.ui.sports-sites.events/get-history lipas-id]}))
+   (merge
+    {:db (-> db
+             (assoc-in [:energy-consumption :lipas-id] lipas-id)
+             (assoc-in [:energy-consumption :year] nil))}
+    (when lipas-id
+      {:dispatch [:lipas.ui.sports-sites.events/get-history lipas-id]}))))
 
 (re-frame/reg-event-db
  ::select-energy-consumption-year
@@ -79,10 +81,8 @@
 (re-frame/reg-event-fx
  ::commit-energy-consumption
  (fn [_ [_ rev draft?]]
-   (let [status (if draft? "draft" (:status rev))
-         rev    (-> (utils/make-saveable rev)
-                    (assoc :status status))]
-     {:dispatch [:lipas.ui.sports-sites.events/commit-rev rev]})))
+   (let [rev (utils/make-saveable rev)]
+     {:dispatch [:lipas.ui.sports-sites.events/commit-rev rev draft?]})))
 
 (re-frame/reg-event-db
  ::fetch-energy-report-success

--- a/webapp/src/cljs/lipas/ui/energy/views.cljs
+++ b/webapp/src/cljs/lipas/ui/energy/views.cljs
@@ -282,7 +282,15 @@
         years      (<== [::subs/energy-consumption-years-list])
         year       (<== [::subs/energy-consumption-year])
 
-        sites  (or editable-sites draftable-sites)
+        sites (or editable-sites draftable-sites)
+
+        lipas-id (get-in site [:history (:latest site) :lipas-id])
+
+        ;; Fix stale data when jumping between swimming-pool and
+        ;; ice-stadium portals
+        _ (when-not (some #{lipas-id} (map :lipas-id sites))
+            (==> [::events/select-energy-consumption-site nil]))
+
         draft? (empty? editable-sites)]
 
     (if-not logged-in?
@@ -314,7 +322,7 @@
           [mui/form-group
            [lui/select
             {:label     (tr :actions/select-hall)
-             :value     (get-in site [:history (:latest site) :lipas-id])
+             :value     lipas-id
              :items     sites
              :label-fn  :name
              :value-fn  :lipas-id

--- a/webapp/src/cljs/lipas/ui/front_page/views.cljs
+++ b/webapp/src/cljs/lipas/ui/front_page/views.cljs
@@ -57,13 +57,21 @@
                 :font-size        "1.25em"
                 :opacity          0.95}
                style)}
-    [mui/card-header {:title  title
-                      :action (when link
-                                (r/as-element
-                                 [mui/icon-button
-                                  {:href  link
-                                   :color :secondary}
-                                  [mui/icon "arrow_forward_ios"]]))}]
+    [mui/card-header
+     (merge
+      {:title  title
+       :action (when link
+                 (r/as-element
+                  [mui/icon-button
+                   {:href  link
+                    :color :secondary}
+                   [mui/icon "arrow_forward_ios"]]))}
+      (when link
+        {:titleTypographyProps
+         {:component "a"
+          :href      link
+          :style     {:font-weight     600
+                      :text-decoration "none"}}}))]
     (into [mui/card-content] children)
     [mui/card-actions
      (when link-text

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/subs.cljs
@@ -63,7 +63,9 @@
  (fn [[_ locale] _]
    (re-frame/subscribe [:lipas.ui.user.subs/sports-sites locale]))
  (fn [sites-list _]
-   (filter (comp #{2510 2520} :type-code) sites-list)))
+   (->> sites-list
+        (filter (comp #{2510 2520} :type-code))
+        not-empty)))
 
 (re-frame/reg-sub
  ::sites-to-draft-list

--- a/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ice_stadiums/views.cljs
@@ -546,23 +546,25 @@
       [lui/form-card {:title (tr :lipas.visitors/headline)
                       :md    12 :lg 12}
        [sports-site/visitors-view
-        {:tr           tr
-         :lipas-id     lipas-id
-         :spectators?  true
-         :editing?     editing?
-         :close        close
-         :display-data display-data}]]
+        {:tr                tr
+         :lipas-id          lipas-id
+         :spectators?       true
+         :editing?          editing?
+         :user-can-publish? user-can-publish?
+         :close             close
+         :display-data      display-data}]]
 
       ;;; Energy consumption
       [lui/form-card {:title (tr :lipas.energy-consumption/headline)
                       :md    12 :lg 12}
        [sports-site/energy-consumption-view
-        {:tr           tr
-         :cold?        true
-         :lipas-id     lipas-id
-         :editing?     editing?
-         :close        close
-         :display-data display-data}]]]]))
+        {:tr                tr
+         :cold?             true
+         :lipas-id          lipas-id
+         :editing?          editing?
+         :user-can-publish? user-can-publish?
+         :close             close
+         :display-data      display-data}]]]]))
 
 (defn ice-stadiums-tab [tr logged-in?]
   (let [locale       (tr)

--- a/webapp/src/cljs/lipas/ui/login/views.cljs
+++ b/webapp/src/cljs/lipas/ui/login/views.cljs
@@ -35,6 +35,10 @@
        :label        (tr :login/password)
        :type         "password"
        :value        (:password form-data)
+       ;; Enter press might occur 'immediately' so we can't afford
+       ;; waiting default 200ms for text-field to update
+       ;; asynchronously.
+       :defer-ms     0
        :on-change    (comp clear-errors #(set-field :password %))
        :on-key-press (fn [e]
                        (when (= 13 (.-charCode e)) ; Enter

--- a/webapp/src/cljs/lipas/ui/mui.cljs
+++ b/webapp/src/cljs/lipas/ui/mui.cljs
@@ -82,7 +82,10 @@
     :text      {:disabled "rgba(0, 0, 0, 0.68)"}}
    :overrides
    {:Mui-card-header
-    {:title {:font-size      "2rem"}}}})
+    {:title
+     {:font-size "2rem"}
+     :action
+     {:margin-top 0}}}})
 
 (def jyu-styles-light
   (utils/deep-merge

--- a/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
@@ -12,10 +12,11 @@
  ::latest-sports-site-revs
  :<- [::sports-sites]
  (fn [sites _]
-   (reduce-kv (fn [m k v]
-                (assoc m k (get-in v [:history (:latest v)])))
-              {}
-              sites)))
+   (not-empty
+    (reduce-kv (fn [m k v]
+                 (assoc m k (get-in v [:history (:latest v)])))
+               {}
+               sites))))
 
 (re-frame/reg-sub
  ::latest-rev

--- a/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
@@ -187,14 +187,14 @@
                        (close)
                        (==> [:lipas.ui.events/report-energy-consumption lipas-id]))
                      (fn []
-                       (==> [::events/discard-edits])
+                       (==> [::events/discard-edits lipas-id])
                        (close)
                        (==> [:lipas.ui.events/report-energy-consumption lipas-id]))])}
    [mui/icon "add"]
    (tr :lipas.user/report-energy-and-visitors)])
 
 (defn energy-consumption-view [{:keys [tr display-data lipas-id
-                                       editing? close cold?]
+                                       editing? close cold? user-can-publish?]
                                 :or   {cold? false}}]
   (r/with-let [selected-year (r/atom {})
                selected-tab  (r/atom 0)]
@@ -240,7 +240,7 @@
            :tr       tr}])
 
        ;; Report readings button
-       (when editing?
+       (when (and editing? user-can-publish?)
          [report-readings-button
           {:tr       tr
            :lipas-id lipas-id
@@ -253,8 +253,8 @@
            (when spectators?
              [:spectators-count (tr :lipas.visitors/spectators-count)])]))
 
-(defn visitors-view [{:keys [tr display-data lipas-id
-                             editing? close spectators?]
+(defn visitors-view [{:keys [tr display-data lipas-id editing? close
+                             spectators? user-can-publish?]
                       :or   [spectators? false]}]
   (r/with-let [selected-year (r/atom {})
                selected-tab  (r/atom 0)]
@@ -302,7 +302,7 @@
            :tr       tr}])
 
        ;; Report readings button
-       (when editing?
+       (when (and editing? user-can-publish?)
          [report-readings-button
           {:tr       tr
            :lipas-id lipas-id

--- a/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
@@ -199,6 +199,7 @@
   (r/with-let [selected-year (r/atom {})
                selected-tab  (r/atom 0)]
 
+    ;; Chart/Table tabs
     (if (empty? (:energy-consumption display-data))
       [mui/typography (tr :lipas.energy-consumption/not-reported)]
       [:div
@@ -209,6 +210,7 @@
 
        (case @selected-tab
 
+         ;; Chart tab
          0 [:div {:style {:margin-top "2em"}}
             [charts/yearly-chart
              {:data     (-> display-data :energy-consumption)
@@ -222,6 +224,7 @@
                           (let [year (gobj/get e "activeLabel")]
                             (reset! selected-year {lipas-id year})))}]]
 
+         ;; Table tab
          1 [energy/table
             {:read-only? true
              :cold?      cold?
@@ -229,12 +232,14 @@
              :on-select  #(reset! selected-year {lipas-id (:year %)})
              :items      (-> display-data :energy-consumption)}])
 
+       ;; Monthly chart
        (when-let [year (get @selected-year lipas-id)]
          [energy/monthly-chart
           {:lipas-id lipas-id
            :year     year
            :tr       tr}])
 
+       ;; Report readings button
        (when editing?
          [report-readings-button
           {:tr       tr
@@ -254,6 +259,7 @@
   (r/with-let [selected-year (r/atom {})
                selected-tab  (r/atom 0)]
 
+    ;; Chart/Table tabs
     (if (empty? (:visitors-history display-data))
       [mui/typography (tr :lipas.visitors/not-reported)]
 
@@ -265,6 +271,7 @@
 
        (case @selected-tab
 
+         ;; Chart tab
          0 [:div {:style {:margin-top "2em"}}
             [charts/yearly-chart
              {:data     (-> display-data :visitors-history)
@@ -276,6 +283,7 @@
                           (let [year (gobj/get e "activeLabel")]
                             (reset! selected-year {lipas-id year})))}]]
 
+         ;; Table tab
          1 [lui/table
             {:headers          (make-headers tr spectators?)
              :items            (-> display-data :visitors-history)
@@ -293,6 +301,7 @@
            :year     year
            :tr       tr}])
 
+       ;; Report readings button
        (when editing?
          [report-readings-button
           {:tr       tr

--- a/webapp/src/cljs/lipas/ui/swimming_pools/saunas.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/saunas.cljs
@@ -4,7 +4,7 @@
             [lipas.ui.mui :as mui]
             [lipas.ui.swimming-pools.events :as events]
             [lipas.ui.swimming-pools.subs :as subs]
-            [lipas.ui.utils :refer [<== ==> localize-field ->setter-fn]]))
+            [lipas.ui.utils :refer [<== ==> localize-field]]))
 
 (defn set-field [dialog field value]
   (#(==> [::events/set-dialog-field dialog field value])))

--- a/webapp/src/cljs/lipas/ui/swimming_pools/slides.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/slides.cljs
@@ -4,7 +4,7 @@
             [lipas.ui.mui :as mui]
             [lipas.ui.swimming-pools.events :as events]
             [lipas.ui.swimming-pools.subs :as subs]
-            [lipas.ui.utils :refer [<== ==> localize-field ->setter-fn]]))
+            [lipas.ui.utils :refer [<== ==> localize-field]]))
 
 (defn set-field [dialog field value]
   (#(==> [::events/set-dialog-field dialog field value])))

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -62,7 +62,9 @@
  (fn [[_ locale] _]
    (re-frame/subscribe [:lipas.ui.user.subs/sports-sites locale]))
  (fn [sites-list _]
-   (filter (comp #{3110 3130} :type-code) sites-list)))
+   (->> sites-list
+        (filter (comp #{3110 3130} :type-code))
+        not-empty)))
 
 (re-frame/reg-sub
  ::sites-to-draft-list

--- a/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/subs.cljs
@@ -246,5 +246,5 @@
 
         :facilities         (:facilities latest)
         :visitors           (:visitors latest)
-        :visitors-history   (sort-by :year visitors-history)
-        :energy-consumption (sort-by :year energy-history)}))))
+        :visitors-history   (sort-by :year utils/reverse-cmp visitors-history)
+        :energy-consumption (sort-by :year utils/reverse-cmp energy-history)}))))

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -586,11 +586,12 @@
       [lui/form-card {:title (tr :lipas.visitors/headline)
                       :md    12 :lg 12}
        [sports-site/visitors-view
-        {:tr           tr
-         :lipas-id     lipas-id
-         :editing?     editing?
-         :close        close
-         :display-data display-data}]]
+        {:tr                tr
+         :lipas-id          lipas-id
+         :editing?          editing?
+         :user-can-publish? user-can-publish?
+         :close             close
+         :display-data      display-data}]]
 
       ;;; Energy consumption
       [lui/form-card {:title (tr :lipas.energy-consumption/headline)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -596,11 +596,12 @@
       [lui/form-card {:title (tr :lipas.energy-consumption/headline)
                       :md    12 :lg 12}
        [sports-site/energy-consumption-view
-        {:tr           tr
-         :lipas-id     lipas-id
-         :editing?     editing?
-         :close        close
-         :display-data display-data}]]]]))
+        {:tr                tr
+         :lipas-id          lipas-id
+         :editing?          editing?
+         :user-can-publish? user-can-publish?
+         :close             close
+         :display-data      display-data}]]]]))
 
 (defn swimming-pools-tab [tr logged-in?]
   (let [locale       (tr)

--- a/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
+++ b/webapp/src/cljs/lipas/ui/swimming_pools/views.cljs
@@ -651,40 +651,6 @@
                    :href  "http://www.suh.fi/toiminta/tekninen_neuvonta"}
        (str "> " (tr :swim-energy/suh-link))]]]]])
 
-(defn energy-form [{:keys [tr year]}]
-  (let [data           (<== [::subs/editing-rev])
-        energy-history (<== [::subs/energy-consumption-history])
-        edits-valid?   (<== [::subs/edits-valid?])
-        lipas-id       (:lipas-id data)
-        set-field      (partial set-field lipas-id)]
-
-    [mui/grid {:container true}
-
-     ;; Energy consumption
-     [lui/form-card {:title (tr :lipas.energy-consumption/headline-year year)}
-
-      [mui/typography {:variant "subheading"
-                       :style   {:margin-bottom "1em"}}
-       (tr :lipas.energy-consumption/yearly)]
-      [energy/form
-       {:tr        tr
-        :data      (:energy-consumption data)
-        :on-change (partial set-field :energy-consumption)}]
-
-      [lui/expansion-panel {:label (tr :actions/show-all-years)}
-       [energy/table {:tr         tr
-                      :read-only? true
-                      :items      energy-history}]]]
-
-     ;; Actions
-     [lui/form-card {}
-      [mui/button {:full-width true
-                   :disabled   (not edits-valid?)
-                   :color      "secondary"
-                   :variant    "raised"
-                   :on-click   #(==> [::events/commit-energy-consumption data])}
-       (tr :actions/save)]]]))
-
 (defn energy-form-tab [tr]
   (let [locale          (tr)
         editable-sites  (<== [::subs/sites-to-edit-list locale])

--- a/webapp/src/cljs/lipas/ui/user/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/user/subs.cljs
@@ -53,7 +53,7 @@
  :<- [:lipas.ui.sports-sites.subs/cities-by-city-code]
  :<- [:lipas.ui.sports-sites.subs/all-types]
  (fn [[sites permissions cities types] [_ locale]]
-   (when permissions
+   (when (and permissions sites)
      (->> sites
           vals
           (filter (partial permissions/publish? permissions))

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -1,6 +1,5 @@
 (ns lipas.ui.utils
   (:require [cemerick.url :as url]
-            [cljsjs.date-fns]
             [clojure.data :as data]
             [clojure.reader :refer [read-string]]
             [clojure.spec.alpha :as s]
@@ -47,12 +46,9 @@
     (update m k #(tr (keyword prefix %)))
     m))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; TODO refactor to use js/dateFns where appropriate ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(comment (resolve-year "2014-12-02"))
-(comment (resolve-year 2014))
+(comment
+  (resolve-year 2014)
+  (resolve-year "2014-12-02"))
 (defn resolve-year [timestamp]
   (read-string (reduce str (take 4 (str timestamp)))))
 
@@ -146,14 +142,9 @@
         timestamp      (get latest-by-year year)]
     (get history timestamp)))
 
-(comment
-  (.getFullYear (.parse js/dateFns "2014-01-01T00:00:00.000Z")) ; This works
-  (.getFullYear (.parse js/dateFns "2013-12-31T23:59:59.999Z")) ; Interesting...
-  (.getFullYear (.parse js/dateFns "2013-12-31T23:59:59.999"))) ; This works
 (defn same-year? [ts1 ts2]
-  (.isSameYear js/dateFns
-               (string/replace ts1 "Z" "")
-               (string/replace ts2 "Z" "")))
+  (= (subs (str ts1) 0 4)
+     (subs (str ts2) 0 4)))
 
 (defn make-revision
   ([site]

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -148,16 +148,14 @@
   ([site event-date]
    (let [history-with-edits (merge (:history site) (:edits site))
          prev-rev           (resolve-prev-rev history-with-edits event-date)
-         same-year?         (same-year? (:event-date prev-rev) event-date)]
-     (-> prev-rev
-         (assoc :event-date event-date)
-         (as-> $ (if same-year?
-                   $
-                   (-> $
-                       (dissoc :energy-consumption)
-                       (dissoc :energy-consumption-monthly)
-                       (dissoc :visitors)
-                       (dissoc :visitors-monthly))))))))
+         new-rev            (assoc prev-rev :event-date event-date)]
+     (if (same-year? (:event-date prev-rev) event-date)
+       new-rev
+       (-> new-rev
+           (dissoc :energy-consumption
+                   :energy-consumption-monthly
+                   :visitors
+                   :visitors-monthly))))))
 
 (defn latest-edit [edits]
   (let [latest (first (sort reverse-cmp (keys edits)))]

--- a/webapp/src/cljs/lipas/ui/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/utils.cljs
@@ -12,10 +12,6 @@
 (def <== (comp deref re-frame/subscribe))
 (def ==> re-frame/dispatch)
 
-(defn ->setter-fn [event]
-  (fn [& args]
-    (==> [event (butlast args) (last args)])))
-
 (defn set-field [db path value]
   (if value
     (assoc-in db path value)

--- a/webapp/test/clj/lipas/backend/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/handler_test.clj
@@ -155,11 +155,12 @@
 
         ;; Add 'draft' which is expected to get publshed as side-effect
         event-date (utils/timestamp)
+        draft?     true
         site       (-> (gen/generate (s/gen :lipas/sports-site))
                        (assoc :event-date event-date)
-                       (assoc :status "draft")
+                       (assoc :status "active")
                        (assoc :lipas-id 123))
-        _          (core/upsert-sports-site! db user site)
+        _          (core/upsert-sports-site! db user site draft?)
 
         perms {:admin? true}
         token (jwt/create-token admin)
@@ -201,9 +202,9 @@
   (let [user  (gen-user {:db? true})
         token (jwt/create-token user)
         site  (-> (gen/generate (s/gen :lipas/sports-site))
-                  (assoc :status "draft")
+                  (assoc :status "active")
                   (dissoc :lipas-id))
-        resp  (app (-> (mock/request :post "/api/sports-sites")
+        resp  (app (-> (mock/request :post "/api/sports-sites?draft=true")
                        (mock/content-type "application/json")
                        (mock/body (->json site))
                        (token-header token)))]


### PR DESCRIPTION
## Features

- Auto-publish drafts by author (user) when user receives permissions to the sites
- Front page headers work now as links

## Refactoring

- Separated "document status" from "Sports-site status"
- Simplified UI-side saving/revisioning logic
- Changed text-field implementation to more efficient one (feels more responsive)
- Use JYU-font in charts and changed yellow core to more visible tone
- Separate lipas.config namespace for backend for more flexible REPL experience