### PR TITLE
Fix sorting by name

### DIFF
--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -5,6 +5,7 @@
    [clojure.core.async :as async]
    [clojure.data.csv :as csv]
    [clojure.java.jdbc :as jdbc]
+   [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as excel]
    [lipas.backend.accessibility :as accessibility]
    [lipas.backend.analysis.diversity :as diversity]
@@ -302,7 +303,8 @@
         main-category (-> type-code types :main-category types/main-categories)
         sub-category  (-> type-code types :sub-category types/sub-categories)
         field-types   (->> sports-site :fields (map :type) distinct)
-        search-meta   {:admin {:name (-> sports-site :admin admins)}
+        search-meta   {:name (utils/->sortable-name (:name sports-site))
+                       :admin {:name (-> sports-site :admin admins)}
                        :owner {:name (-> sports-site :owner owners)}
                        :location
                        {:wgs84-point  start-coords

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -11,9 +11,11 @@
 
 
 (defn ->sortable-name [s]
-  (-> s
-      (string/lower-case)
-      (string/replace #"(\"|\(|\))" "")))
+  (if (nil? s)  
+    ""
+    (-> s
+        (string/lower-case)
+        (string/replace #"(\"|\(|\))" ""))))
 
 (defn index-by
   ([idx-fn coll]

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -9,6 +9,12 @@
    #?(:cljs [goog.string :as gstring])
    #?(:cljs [goog.string.format])))
 
+
+(defn ->sortable-name [s]
+  (-> s
+      (string/lower-case)
+      (string/replace #"(\"|\(|\))" "")))
+
 (defn index-by
   ([idx-fn coll]
    (index-by idx-fn identity coll))

--- a/webapp/src/cljs/lipas/ui/search/events.cljs
+++ b/webapp/src/cljs/lipas/ui/search/events.cljs
@@ -16,6 +16,7 @@
 (defn ->sort-key [k locale]
   (case k
     (:lipas-id)         :lipas-id
+    (:name)             :search-meta.name.keyword
     (:location.city.name
      :type.name
      :admin.name

--- a/webapp/src/cljs/lipas/ui/search/views.cljs
+++ b/webapp/src/cljs/lipas/ui/search/views.cljs
@@ -261,7 +261,6 @@
         :save-label     (tr :actions/save)
         :discard-label  (tr :actions/discard)
         :on-select      #(on-result-click %)
-        :sort-fn        (or (:sort-fn sort-opts) :score)
         :sort-asc?      (:asc? sort-opts)
         :allow-editing? :permission?
         :allow-saving?  (fn [item]

--- a/webapp/test/clj/lipas/backend/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/handler_test.clj
@@ -573,14 +573,12 @@
     (is (= 200 (:status resp2)))))
 
 (deftest search-order-test
-  (let [sites    (for [site-name ["\"Bantis\" beachvolleykenttä 2"
-                                  "Antis"
-                                  "bantis beachvolleykenttä (1)"
-                                  "!antis"]]
-                   (-> (tu/gen-sports-site)
-                       (assoc :name site-name)))
-        _        (doseq [site sites] (core/index! search site true))
-        resp     (app (-> (mock/request :post "/api/actions/search")
+  (doseq [site-name ["\"Bantis\" beachvolleykenttä 2"
+                     "Antis"
+                     "bantis beachvolleykenttä (1)"
+                     "!antis"]]
+    (core/index! search (-> (tu/gen-sports-site) (assoc :name site-name)) :sync))
+  (let [resp     (app (-> (mock/request :post "/api/actions/search")
                           (mock/content-type "application/json")
                           (mock/body (->json {:query
                                               {:bool

--- a/webapp/test/clj/lipas/utils_test.cljc
+++ b/webapp/test/clj/lipas/utils_test.cljc
@@ -1,0 +1,9 @@
+(ns lipas.utils-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [lipas.utils :as utils]))
+
+(deftest sortable-name-test
+  (testing "sortable name"
+    (is (= (utils/->sortable-name "\"Bantis\" beachvolleykenttä (2)") "bantis beachvolleykenttä 2"))))
+  
+  

--- a/webapp/test/clj/lipas/utils_test.cljc
+++ b/webapp/test/clj/lipas/utils_test.cljc
@@ -4,6 +4,11 @@
 
 (deftest sortable-name-test
   (testing "sortable name"
-    (is (= (utils/->sortable-name "\"Bantis\" beachvolleykenttä (2)") "bantis beachvolleykenttä 2"))))
+    (is (= (utils/->sortable-name "\"Bantis\" beachvolleykenttä (2)") "bantis beachvolleykenttä 2")))
+  (testing "sortable name with nil"
+    (is (= (utils/->sortable-name nil) ""))))
   
   
+(comment
+  (t/run-tests *ns*)
+  )


### PR DESCRIPTION
 * Add name to search-meta: remove double quotes, parenthesis and lowercase requires re-indexing
 * Remove client side sorting, allways decide sorting in ES query