### PR TITLE
Fix re-frame-10x panel

### DIFF
--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -321,7 +321,8 @@
 
 (re-frame/reg-event-fx
  ::map-clicked
- (fn [_]
+ (fn [event]
+   (-> event .-target .getTargetElement .focus)
    {:dispatch [::hide-address]}))
 
 (re-frame/reg-event-fx

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -322,7 +322,8 @@
 (re-frame/reg-event-fx
  ::map-clicked
  (fn [event]
-   (-> event .-target .getTargetElement .focus)
+   ;; Set browser focus to Map element to enable keyboard pan/zoom
+   (-> event .-target .getTargetElement .focus) 
    {:dispatch [::hide-address]}))
 
 (re-frame/reg-event-fx

--- a/webapp/src/cljs/lipas/ui/map/map.cljs
+++ b/webapp/src/cljs/lipas/ui/map/map.cljs
@@ -617,8 +617,9 @@
     (r/create-class
 
      {:reagent-render
-      (fn [] [mui/grid {:id    "map"
-                        :tabIndex -1
+      (fn [] [mui/grid {:id    "map" 
+                        ;; Make Map a focus target for the browser (relates to keyboard pan/zoom) 
+                        :tabIndex -1 
                         :item  true
                         :style {:height "100%" :width "100%"}
                         :xs    12}])

--- a/webapp/src/cljs/lipas/ui/map/map.cljs
+++ b/webapp/src/cljs/lipas/ui/map/map.cljs
@@ -195,7 +195,6 @@
         popup-overlay (init-overlay)
 
         opts #js {:target   "map"
-                  :keyboardEventTarget js/document
                   :layers   #js[(-> layers :basemaps :taustakartta)
                                 (-> layers :basemaps :maastokartta)
                                 (-> layers :basemaps :ortokuva)
@@ -619,6 +618,7 @@
 
      {:reagent-render
       (fn [] [mui/grid {:id    "map"
+                        :tabIndex -1
                         :item  true
                         :style {:height "100%" :width "100%"}
                         :xs    12}])


### PR DESCRIPTION
  * Previous keyboard navigation feature broke re-frame-10x panel
  * Remove document level keyboard events, use focus on map instead

How to test:

1. re-frame-10x (ctrl+h) should work
2. map navigation with arrows should work