### PR TITLE
Remove manually setting the focus in map-clicked

### DIFF
--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -322,8 +322,6 @@
 (re-frame/reg-event-fx
  ::map-clicked
  (fn [event]
-   ;; Set browser focus to Map element to enable keyboard pan/zoom
-   (-> event .-target .getTargetElement .focus) 
    {:dispatch [::hide-address]}))
 
 (re-frame/reg-event-fx

--- a/webapp/src/cljs/lipas/ui/map/map.cljs
+++ b/webapp/src/cljs/lipas/ui/map/map.cljs
@@ -618,7 +618,8 @@
 
      {:reagent-render
       (fn [] [mui/grid {:id    "map" 
-                        ;; Make Map a focus target for the browser (relates to keyboard pan/zoom) 
+                        ;; Keyboard navigation requires that this element has a tabIndex
+                        ;; see https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html  
                         :tabIndex -1 
                         :item  true
                         :style {:height "100%" :width "100%"}


### PR DESCRIPTION
The function caused some undefined errors in js console and setting the focus manually was not needed. Just the tabIndex on map element was enough to unleash the keyboard wizards.