### PR TITLE
Helper dialog for new site

### DIFF
--- a/webapp/.clj-kondo/config.edn
+++ b/webapp/.clj-kondo/config.edn
@@ -1,1 +1,2 @@
-{:lint-as {reagent.core/with-let clojure.core/let}}
+{:lint-as
+ {reagent.core/with-let clojure.core/let}}

--- a/webapp/.clj-kondo/config.edn
+++ b/webapp/.clj-kondo/config.edn
@@ -1,2 +1,1 @@
-{:lint-as
- {reagent.core/with-let clojure.core/let}}
+{:lint-as {reagent.core/with-let clojure.core/let}}

--- a/webapp/src/cljc/lipas/i18n/generated.cljc
+++ b/webapp/src/cljc/lipas/i18n/generated.cljc
@@ -241,7 +241,8 @@
     {:name          "Liikuntapaikkatyyppi",
      :main-category "Pääryhmä",
      :sub-category  "Alaryhmä",
-     :type-code     "Tyyppikoodi"},
+     :type-code     "Tyyppikoodi"
+     :geometry      "Geometria"},
     :duration
     {:hour        "tuntia",
      :month       "kuukautta",

--- a/webapp/src/cljc/lipas/i18n/generated.cljc
+++ b/webapp/src/cljc/lipas/i18n/generated.cljc
@@ -242,7 +242,10 @@
      :main-category "Pääryhmä",
      :sub-category  "Alaryhmä",
      :type-code     "Tyyppikoodi"
-     :geometry      "Geometria"},
+     :geometry      "Geometria",
+     :Point         "Piste",
+     :LineString    "Reitti",
+     :Polygon       "Alue"},
     :duration
     {:hour        "tuntia",
      :month       "kuukautta",

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -470,7 +470,7 @@
           {:keys [types cities admins owners editing? edits-valid?
                   problems?  editing-allowed? delete-dialog-open?
                   can-publish? logged-in?  size-categories sub-mode
-                  geom-type portal save-in-progress? undo redo
+                  geom-type save-in-progress? undo redo
                   more-tools-menu-anchor dead?]}
           (<== [::subs/sports-site-view lipas-id type-code])
 
@@ -1358,8 +1358,7 @@
 
 (defn default-tools [{:keys [tr logged-in?]}]
   (let [result-view (<== [:lipas.ui.search.subs/search-results-view])
-        mode-name   (<== [::subs/mode-name])
-        admin?      (<== [:lipas.ui.user.subs/admin?])]
+        mode-name   (<== [::subs/mode-name])]
     [:<>
      [address-search-dialog]
      [lui/floating-container {:bottom 0 :background-color "transparent"}

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -528,9 +528,9 @@
              :value 2
              :label "Esteettömyys"}])
 
-         (when (or (and (floorball-types type-code)
-                        (= :floorball floorball-visibility))
-                   #_(football-types type-code))
+         (when 
+          (and (floorball-types type-code)
+               (= :floorball floorball-visibility))
            [mui/tab
             {:style {:min-width 0}
              :value 3

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -283,11 +283,11 @@
           [mui/table-body {:component "th" :scope "row"}]
           (for [row sorted-and-filtered-table-data]
             [helper-row
-             [row :type-code]
-             [row :name]
-             [row :geometry-type]
-             [row :description]
-             geom-help-open?]))]]])))
+             (row :type-code)
+             (row :name)
+             (->>  row :geometry-type (keyword :type) tr) 
+             (row :description)
+             geom-help-open?]))]]]])))
 
 (defn type-selector-single [{:keys [tr on-change types]}] 
     (let [locale        (tr)

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -1058,7 +1058,7 @@
 
             [lui/dialog {:open? @geom-help-open?
                          :cancel-label (tr :actions/close)
-                         :title "kekkonen666"
+                         ;; :title (tr :type/name)
                          :max-width "xl"
                          :on-close #(swap! geom-help-open? not)}
              [mui/grid {:container true

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -423,9 +423,7 @@
              [mui/typography (tr :analysis/mode)]]
             [mui/table-cell
              (when (seq (:diversity-idx-mode data))
-               (string/join "," (:diversity-idx-mode data)))]]
-
-         ]]
+               (string/join "," (:diversity-idx-mode data)))]]]]
 
        ;; No data available
        [:div {:style {:width "200px" :padding "0.5em 0.5em 0em 0.5em"}}
@@ -834,7 +832,7 @@
               [mui/fab
                {:size     "small"
                 :on-click #(==> [::events/show-analysis lipas-id])}
-               [mui/icon "insights"]]])
+               [mui/icon "insights"]]])]
 
            ;; ;; Import geom
            ;; (when (and editing? (#{"LineString"} geom-type))
@@ -910,7 +908,7 @@
            ;;     {:style
            ;;      {:font-size 24 :margin-left "4px" :margin-right "16px"}}
            ;;     "?"]])
-           ]
+           
 
           (concat
            (lui/edit-actions-list

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -992,7 +992,7 @@
   [{:keys [tr width]}]
   (r/with-let [selected-tab (r/atom 0)
                geom-tab     (r/atom "draw")
-               geom-help-open? (r/atom true)]
+               geom-help-open? (r/atom false)]
     (let [locale               (tr)
           {:keys [type data save-enabled? admins owners
                   cities problems? types size-categories zoomed? geom

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -1203,26 +1203,26 @@
                  [mui/grid {:item true}
                   [mui/grid {:item true}
 
-                ;; Undo & Redo
+                   ;; Undo & Redo
                    [mui/grid {:container true}
 
-                 ;; Undo
+                    ;; Undo
                     [mui/grid {:item true}
                      [mui/tooltip {:title "Undo"}
-                   [:span
-                    [mui/icon-button
-                     {:disabled (not undo)
-                      :on-click #(==> [::events/undo "new"])}
-                     [mui/icon "undo"]]]]]
+                      [:span
+                       [mui/icon-button
+                        {:disabled (not undo)
+                         :on-click #(==> [::events/undo "new"])}
+                        [mui/icon "undo"]]]]]
 
-                 ;; Redo
+                    ;; Redo
                     [mui/grid {:item true}
                      [mui/tooltip {:title "Redo"}
-                   [:span
-                    [mui/icon-button
-                     {:disabled (not redo)
-                      :on-click #(==> [::events/redo "new"])}
-                     [mui/icon "redo"]]]]]]]]]]
+                      [:span
+                       [mui/icon-button
+                        {:disabled (not redo)
+                         :on-click #(==> [::events/redo "new"])}
+                        [mui/icon "redo"]]]]]]]]]]
 
                ;; Retkikartta Problems
                (when (and (#{"LineString"} geom-type) problems?)
@@ -1481,8 +1481,8 @@
 
        ;; Feedback btn
        #_[mui/grid {:item true}
-        [mui/paper {:style {:background-color "rgba(255,255,255,0.9)"}}
-         [feedback/feedback-btn]]]
+          [mui/paper {:style {:background-color "rgba(255,255,255,0.9)"}}
+           [feedback/feedback-btn]]]
 
        ;; Zoom to users location btn
        [mui/grid {:item true}

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -266,11 +266,13 @@
     (let [filtered-table-data (filter-by-term @search-term table-data)
           sorted-and-filtered-table-data (sort-by :name filtered-table-data)]
       [mui/grid {:container true}
-       [mui/text-field {:label (tr :search/search)
+       [mui/grid {:item true :xs 12}
+        [mui/text-field {:label (tr :search/search)
                         :xs 3
                         :on-change #(reset! search-term (-> % .-target .-value))
-                        :placeholder nil}]
-       [mui/table-container
+                        :placeholder nil}]]
+       [mui/grid {:item true :xs 12}
+        [mui/table-container
         [mui/table
          [mui/table-head
           [mui/table-row
@@ -1058,7 +1060,7 @@
 
             [lui/dialog {:open? @geom-help-open?
                          :cancel-label (tr :actions/close)
-                         ;; :title (tr :type/name)
+                         :title (tr :type/name)
                          :max-width "xl"
                          :on-close #(swap! geom-help-open? not)}
              [mui/grid {:container true

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -437,8 +437,7 @@
          "Klikkaa aluetta hiirellä tai valitse alue taulukosta."]])]))
 
 (defn popup []
-  (let [{:keys [data anchor-el]
-         :or   {type :default}
+  (let [{:keys [data anchor-el] 
          :as   popup'} (<== [::subs/popup])
         tr             (<== [:lipas.ui.subs/translator])]
     (when anchor-el

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -6,7 +6,7 @@
    ["mdi-material-ui/FileUpload$default" :as FileUpload]
    ["mdi-material-ui/MapSearchOutline$default" :as MapSearchOutline]
    [clojure.spec.alpha :as s]
-   [clojure.string :as string :refer [includes? lower-case join]]
+   [clojure.string :as string]
    [lipas.data.sports-sites :as ss]
    [lipas.ui.accessibility.views :as accessibility]
    [lipas.ui.analysis.views :as analysis]
@@ -253,11 +253,11 @@
    [mui/table-cell description]])
 
 (defn filter-by-term [term table-data]
-  (let [lower-case-term (lower-case term)]
-    (filter #(or (includes? (lower-case (% :name)) lower-case-term)
-                 (includes? (lower-case (% :geometry-type)) lower-case-term)
-                 (includes? (lower-case (% :description)) lower-case-term)
-                 (includes? (lower-case (join (% :tags))) lower-case-term))
+  (let [lower-case-term (string/lower-case term)]
+    (filter #(or (string/includes? (string/lower-case (% :name)) lower-case-term)
+                 (string/includes? (string/lower-case (% :geometry-type)) lower-case-term)
+                 (string/includes? (string/lower-case (% :description)) lower-case-term)
+                 (string/includes? (string/lower-case (string/join (% :tags))) lower-case-term))
             table-data)))
 
 (defn type-helper-table [tr geom-help-open?]

--- a/webapp/src/cljs/lipas/ui/mui.cljs
+++ b/webapp/src/cljs/lipas/ui/mui.cljs
@@ -56,6 +56,7 @@
    ["@material-ui/core/Tab$default" :as Tab]
    ["@material-ui/core/Table$default" :as Table]
    ["@material-ui/core/TableBody$default" :as TableBody]
+   ["@material-ui/core/TableContainer$default" :as TableContainer]
    ["@material-ui/core/TableCell$default" :as TableCell]
    ["@material-ui/core/TableHead$default" :as TableHead]
    ["@material-ui/core/TablePagination$default" :as TablePagination]
@@ -254,6 +255,7 @@
 (def table (r/adapt-react-class Table))
 (def table-body (r/adapt-react-class TableBody))
 (def table-cell (r/adapt-react-class TableCell))
+(def table-container (r/adapt-react-class TableContainer))
 (def table-head (r/adapt-react-class TableHead))
 (def table-pagination (r/adapt-react-class TablePagination))
 (def table-row (r/adapt-react-class TableRow))

--- a/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
@@ -159,7 +159,8 @@
       :geometry-type (:geometry-type m)
       :main-category (get-in types/main-categories [(:main-category m) :name locale])
       :sub-category  (get-in types/sub-categories [(:sub-category m) :name locale])
-      :description   (get-in m [:description locale])})))
+      :description   (get-in m [:description locale])
+      :tags          (get-in m [:tags locale])})))
 
 (re-frame/reg-sub
  ::admins


### PR DESCRIPTION
Add new helper view to describe different sports site.

- Clicking a sports site will select it.
- Searching uses tags which can be used to add keywords for a sports site. 

![image](https://github.com/lipas-liikuntapaikat/lipas/assets/10090580/94f600bb-0a15-4934-a45b-441cdb5a553a)
 