### PR TITLE
Add geom simplification tool

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -24,6 +24,7 @@
         "@turf/line-intersect": "^6.0.2",
         "@turf/line-split": "^6.5.0",
         "@turf/nearest-point-on-line": "^6.5.0",
+        "@turf/simplify": "^6.5.0",
         "@turf/truncate": "^6.5.0",
         "file-saver": "^2.0.2",
         "highlight.js": "^11.7.0",
@@ -550,6 +551,20 @@
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
       "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
       "dependencies": {
+        "@turf/clone": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-6.5.0.tgz",
+      "integrity": "sha512-USas3QqffPHUY184dwQdP8qsvcVH/PWBYdXY5am7YTBACaQOMAlf6AKJs9FT8jiO6fQpxfgxuEtwmox+pBtlOg==",
+      "dependencies": {
+        "@turf/clean-coords": "^6.5.0",
         "@turf/clone": "^6.5.0",
         "@turf/helpers": "^6.5.0",
         "@turf/meta": "^6.5.0"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,6 +28,7 @@
     "@turf/line-intersect": "^6.0.2",
     "@turf/line-split": "^6.5.0",
     "@turf/nearest-point-on-line": "^6.5.0",
+    "@turf/simplify": "^6.5.0",
     "@turf/truncate": "^6.5.0",
     "file-saver": "^2.0.2",
     "highlight.js": "^11.7.0",

--- a/webapp/src/cljc/lipas/i18n/generated.cljc
+++ b/webapp/src/cljc/lipas/i18n/generated.cljc
@@ -321,7 +321,8 @@
      :edit-tool            "Muokkaustyökalu",
      :importing-tooltip    "Tuontityökalu valittu",
      :deleting-tooltip     "Poistotyökalu valittu",
-     :splitting-tooltip    "Katkaisutyökalu valittu"},
+     :splitting-tooltip    "Katkaisutyökalu valittu"
+     :simplify             "Yksinkertaista"},
     :partners           {:headline "Kehittä​misessä mukana"},
     :actions
     {:duplicate                "Kopioi",
@@ -1978,7 +1979,8 @@ Utflyktsmålets administratör ansvarar för uppgifternas riktighet och utflykts
      :edit-tool            "Edit tool",
      :importing-tooltip    "Import tool selected",
      :deleting-tooltip     "Delete tool selected",
-     :splitting-tooltip    "Split tool selected"},
+     :splitting-tooltip    "Split tool selected"
+     :simplify             "Simplify"},
     :partners         {:headline "In association with"},
     :actions
     {:duplicate                "Duplicate",

--- a/webapp/src/cljc/lipas/i18n/generated.cljc
+++ b/webapp/src/cljc/lipas/i18n/generated.cljc
@@ -189,7 +189,9 @@
      :general-info   "Yleiset tiedot",
      :comment        "Kommentti",
      :measures       "Mitat",
-     :men            "Miehet"},
+     :men            "Miehet"
+     :more           "Enemmän"
+     :less           "Vähemmän"},
     :dryer-duty-types   {:automatic "Automaattinen", :manual "Manuaali"},
     :swim-energy
     {:description
@@ -323,6 +325,8 @@
      :deleting-tooltip     "Poistotyökalu valittu",
      :splitting-tooltip    "Katkaisutyökalu valittu"
      :simplify             "Yksinkertaista"},
+    :map.tools.simplify
+    {:headline "Yksinkertaista geometrioita"}
     :partners           {:headline "Kehittä​misessä mukana"},
     :actions
     {:duplicate                "Kopioi",
@@ -1856,7 +1860,9 @@ Utflyktsmålets administratör ansvarar för uppgifternas riktighet och utflykts
      :general-info   "General information",
      :comment        "Comment",
      :measures       "Measures",
-     :men            "Men"},
+     :men            "Men"
+     :more           "More"
+     :less           "Less"},
     :dryer-duty-types {:automatic "Automatic", :manual "Manual"},
     :swim-energy
     {:description
@@ -1981,6 +1987,8 @@ Utflyktsmålets administratör ansvarar för uppgifternas riktighet och utflykts
      :deleting-tooltip     "Delete tool selected",
      :splitting-tooltip    "Split tool selected"
      :simplify             "Simplify"},
+    :map.tools.simplify
+    {:headline "Simplify geometries"}
     :partners         {:headline "In association with"},
     :actions
     {:duplicate                "Duplicate",

--- a/webapp/src/cljs/lipas/ui/map/db.cljs
+++ b/webapp/src/cljs/lipas/ui/map/db.cljs
@@ -12,6 +12,9 @@
     :selected-encoding "ISO-8859-1"
     :selected-items    #{}
     :replace-existing? true}
+   :simplify
+   {:dialog-open? false
+    :tolerance    0}
    :address-search
    {:base-url     "https://api.digitransit.fi/geocoding/v1"
     :dialog-open? false}})

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -585,6 +585,13 @@
            [:dispatch [::close-simplify-tool]]
            [:dispatch [::continue-editing]]]})))
 
+(re-frame/reg-event-fx
+ ::simplify-new
+ (fn [_ [_ geoms tolerance]]
+   (let [simplified (map-utils/simplify geoms (map-utils/simplify-scale tolerance))]
+     {:fx [[:dispatch [::new-geom-drawn simplified]]
+           [:dispatch [::toggle-simplify-dialog]]]})))
+
 ;; Address search ;;
 
 (re-frame/reg-event-db

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -552,6 +552,39 @@
                      (togpx #js{:creator "LIPAS"}))]
      {:lipas.ui.effects/save-as! {:blob (js/Blob. #js[xml-str]) :filename fname}})))
 
+;; Geom simplification ;;
+
+(re-frame/reg-event-fx
+ ::open-simplify-tool
+ (fn [{:keys [db]} [_ lipas-id geoms tolerance]]
+   (println "open simplify tool")
+   {:db (assoc-in db [:map :mode :sub-mode] :simplifying)
+    :fx [[:dispatch [::toggle-simplify-dialog]]]}))
+
+(re-frame/reg-event-fx
+ ::close-simplify-tool
+ (fn [{:keys [db]} _]
+   {:fx [[:dispatch [::toggle-simplify-dialog]]
+         [:dispatch [::continue-editing]]]}))
+
+(re-frame/reg-event-db
+ ::toggle-simplify-dialog
+ (fn [db _]
+   (update-in db [:map :simplify :dialog-open?] not)))
+
+(re-frame/reg-event-db
+ ::set-simplify-tolerance
+ (fn [db [_ v]]
+   (assoc-in db [:map :simplify :tolerance] v)))
+
+(re-frame/reg-event-fx
+ ::simplify
+ (fn [_ [_ lipas-id geoms tolerance]]
+   (let [simplified (map-utils/simplify geoms (map-utils/simplify-scale tolerance))]
+     {:fx [[:dispatch [::update-geometries lipas-id simplified]]
+           [:dispatch [::close-simplify-tool]]
+           [:dispatch [::continue-editing]]]})))
+
 ;; Address search ;;
 
 (re-frame/reg-event-db

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -556,10 +556,10 @@
 
 (re-frame/reg-event-fx
  ::open-simplify-tool
- (fn [{:keys [db]} [_ lipas-id geoms tolerance]]
-   (println "open simplify tool")
+ (fn [{:keys [db]} _]
    {:db (assoc-in db [:map :mode :sub-mode] :simplifying)
-    :fx [[:dispatch [::toggle-simplify-dialog]]]}))
+    :fx [[:dispatch [::set-simplify-tolerance 0]]
+         [:dispatch [::toggle-simplify-dialog]]]}))
 
 (re-frame/reg-event-fx
  ::close-simplify-tool

--- a/webapp/src/cljs/lipas/ui/map/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/map/subs.cljs
@@ -165,13 +165,13 @@
  :<- [::simplify]
  (fn [[content-padding mode reachability diversity simplify] _]
    (let [analysis?  (= (:name mode) :analysis)
-         simplifty? (and (= (:name mode) :editing)
+         simplify? (and (#{:adding :editing} (:name mode))
                          (= (:sub-mode mode) :simplifying))]
      (cond-> mode
        true       (assoc :content-padding content-padding)
        analysis?  (assoc :analysis {:reachability reachability
                                     :diversity    diversity})
-       simplifty? (assoc :simplify simplify)))))
+       simplify? (assoc :simplify simplify)))))
 
 (re-frame/reg-sub
  ::editing-lipas-id

--- a/webapp/src/cljs/lipas/ui/map/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/map/subs.cljs
@@ -162,12 +162,16 @@
  :<- [::mode*]
  :<- [:lipas.ui.analysis.reachability.subs/reachability]
  :<- [:lipas.ui.analysis.diversity.subs/diversity]
- (fn [[content-padding mode reachability diversity] _]
-   (let [analysis? (= (:name mode) :analysis)]
+ :<- [::simplify]
+ (fn [[content-padding mode reachability diversity simplify] _]
+   (let [analysis?  (= (:name mode) :analysis)
+         simplifty? (and (= (:name mode) :editing)
+                         (= (:sub-mode mode) :simplifying))]
      (cond-> mode
-       true      (assoc :content-padding content-padding)
-       analysis? (assoc :analysis {:reachability reachability
-                                   :diversity    diversity})))))
+       true       (assoc :content-padding content-padding)
+       analysis?  (assoc :analysis {:reachability reachability
+                                    :diversity    diversity})
+       simplifty? (assoc :simplify simplify)))))
 
 (re-frame/reg-sub
  ::editing-lipas-id
@@ -258,6 +262,27 @@
  ::replace-existing-geoms?
  (fn [db _]
    (-> db :map :import :replace-existing?)))
+
+;;; Simplify geoms ;;;
+
+(re-frame/reg-sub
+ ::simplify
+ (fn [db _]
+   (-> db :map :simplify)))
+
+(re-frame/reg-sub
+ ::simplify-dialog-open?
+ :<- [::simplify]
+ (fn [simplify _]
+   (:dialog-open? simplify)))
+
+(re-frame/reg-sub
+ ::simplify-tolerance
+ :<- [::simplify]
+ (fn [simplify _]
+   (:tolerance simplify)))
+
+;;; Address search ;;;
 
 (re-frame/reg-sub
  ::address-search-dialog-open?

--- a/webapp/src/cljs/lipas/ui/map/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/map/utils.cljs
@@ -13,6 +13,7 @@
    ["@turf/line-split$default" :as turf-line-split]
    ["@turf/nearest-point-on-line$default" :as turf-nearest-point-on-line]
    ["@turf/truncate$default" :as turf-truncate]
+   ["@turf/simplify$default" :as turf-simplify]
    ["ol/Feature$default" :as Feature]
    ["ol/events/condition" :as events-condition]
    ["ol/extent" :as extent]
@@ -117,6 +118,16 @@
       ->wkt
       )
   )
+
+(defn simplify-scale [n]
+  (* 0.00001 n))
+
+(defn simplify
+  [fcoll tolerance]
+  (-> fcoll
+      clj->js
+      (turf-simplify #js{:mutate true :tolerance tolerance :highQuality true})
+      (->clj)))
 
 (defn geom-coll->features [geom-coll]
   (->> geom-coll
@@ -502,7 +513,7 @@
   (-> fcoll
       clj->js
       turf-area ;; returns square meters
-      (convertArea "meters" "kilometers") 
+      (convertArea "meters" "kilometers")
       (utils/round-safe 2)
       read-string))
 

--- a/webapp/src/cljs/lipas/ui/map/utils.cljs
+++ b/webapp/src/cljs/lipas/ui/map/utils.cljs
@@ -119,7 +119,16 @@
       )
   )
 
-(defn simplify-scale [n]
+(defn simplify-scale
+  "Scales given (natural) number to a usable simplification tolerance in
+  degrees. The scale was found via experimentation.
+
+  The tolerance is used as the Hausdorff distance parameter for
+  Reimer-Douglas-Peucker simplification algorithm, where the tolerance
+  is the maximum distance between the original and simplified curves.
+
+  0.00001 degrees is between 4-6 meters in Finland's latitude."
+  [n]
   (* 0.00001 n))
 
 (defn simplify

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -167,7 +167,7 @@
 
         ;; Header
         [mui/grid {:item true :xs 12}
-         [:h4 "Yksinkertaista geometrioita"]]
+         [:h4 (tr :map.tools.simplify/headline)]]
 
         ;; Slider
         [mui/grid {:item true :xs 12}
@@ -176,8 +176,7 @@
 
           ;; Less
           [mui/grid {:item true}
-           [mui/typography "Vähemmän"]
-           #_[mui/icon "remove"]]
+           [mui/typography (tr :general/less)]]
 
           ;; The Slider
           [mui/grid {:item true :xs true}
@@ -191,8 +190,7 @@
 
           ;; More
           [mui/grid {:item true}
-           [mui/typography "Enemmän"]
-           #_[mui/icon "add"]]]]
+           [mui/typography (tr :general/more)]]]]
 
         ;; Buttons
         [mui/grid {:item true :xs 12}

--- a/webapp/src/cljs/lipas/ui/mui.cljs
+++ b/webapp/src/cljs/lipas/ui/mui.cljs
@@ -44,6 +44,7 @@
    ["@material-ui/core/Popper$default" :as Popper]
    ["@material-ui/core/Select$default" :as Select]
    ["@material-ui/core/Slide$default" :as Slide]
+   ["@material-ui/core/Slider$default" :as Slider]
    ["@material-ui/core/Snackbar$default" :as Snackbar]
    ["@material-ui/core/SnackbarContent$default" :as SnackbarContent]
    ["@material-ui/core/Step$default" :as Step]
@@ -242,6 +243,7 @@
 #_(def radio-group (r/adapt-react-class RadioGroup))
 (def select (r/adapt-react-class Select))
 (def slide (r/adapt-react-class Slide))
+(def slider (r/adapt-react-class Slider))
 (def snackbar (r/adapt-react-class Snackbar))
 (def snackbar-content (r/adapt-react-class SnackbarContent))
 (def step (r/adapt-react-class Step))


### PR DESCRIPTION
Adds a new "soft-GIS" tool to Lipas to simplify geometries (LineStrings, Polygons). 

Users import GPS tracks and they're usually a mess. Manual cleaning takes a lot of time and effort. 

This tool enables using [Reimer-Douglas-Peucker algorithm](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) via [Turf](https://turfjs.org/docs/#simplify) to clean up the geoms. Doing this automatically is not feasible because defining the threshold requires a human 👁️.

# TODO
- [x] Support simplifying when adding new sites (not only when editing existing ones)
- [x] Test with Polygons
- [x] Test that transition from/to any other edit tool works as expected
- [x] Think what buttons and features should be disabled while simplifying tool is open
- [x] Think what would be a good position for the tool
- [x] Remaining translations (or avoiding translations using icons)

# Screenshots
## Level 0
<img width="748" alt="image" src="https://github.com/lipas-liikuntapaikat/lipas/assets/19185700/bcec5687-f98e-4b07-99f3-bed1d0515053">

## Level 4.5
<img width="730" alt="image" src="https://github.com/lipas-liikuntapaikat/lipas/assets/19185700/7fd2e046-9064-4cb4-a97c-c9d36fd7c2c9">

## Level 10
<img width="743" alt="image" src="https://github.com/lipas-liikuntapaikat/lipas/assets/19185700/ed50416c-94cd-4864-a9b6-98bbd1634f36">

