### PR TITLE
Fix transit direction tool with ^js metadata tag

### DIFF
--- a/webapp/src/cljs/lipas/ui/map/styles.cljs
+++ b/webapp/src/cljs/lipas/ui/map/styles.cljs
@@ -319,7 +319,7 @@
 (defn line-direction-style-fn
   [feature]
   (let [styles           #js[edit-style]
-        geometry         (.getGeometry feature)
+        ^js geometry     (.getGeometry feature)
         travel-direction (.get feature "travel-direction")]
 
     (when (and geometry travel-direction)


### PR DESCRIPTION
Fix transit direction tool in release build, added `^js` metadata tag to an interop call. 