### PR TITLE
Add entrypoint to mapproxy service in compose yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       MAPPROXY_GROUP_ID: 1000
       TZ: Europe/Helsinki
       MML_AUTH:
+    entrypoint: ["/bin/bash", "/start.sh"]
     command: /start.sh
     volumes:
       - './mapproxy:/lipas:z'


### PR DESCRIPTION
Perhaps due updated docker or the new operating system the service stopped working after migrating to new VM's. Fixed by adding entrypoint to docker-compose.yml