### PR TITLE
Type code renewal

### DIFF
--- a/webapp/dev/user.clj
+++ b/webapp/dev/user.clj
@@ -61,4 +61,15 @@
 
   (require '[migratus.core :as migratus])
   (migratus/create nil "activities_status" :sql)
+  (migratus/create nil "roles" :edn)
+
+  (require '[lipas.maintenance :as maintenance])
+  (require '[lipas.backend.core :as core])
+
+  (def robot (core/get-user (db) "robot@lipas.fi"))
+
+  (maintenance/merge-types (db) (search) robot 4530 4510)
+  (maintenance/merge-types (db) (search) robot 4520 4510)
+  (maintenance/merge-types (db) (search) robot 4310 4320)
+
   )

--- a/webapp/src/cljc/lipas/data/materials.cljc
+++ b/webapp/src/cljc/lipas/data/materials.cljc
@@ -48,7 +48,7 @@
    "fiberglass"                    {:fi "Lasikuitu"
                                     :se "Glasfiber"
                                     :en "Fiberglass"}
-   "soil"                          {:fi "Maa / luonnonmukainen"
+   "soil"                          {:fi "Maa/luonnonmukainen"
                                     :se "Jordet"
                                     :en "Soil"}
    "wood"                          {:fi "Puu"
@@ -57,9 +57,9 @@
    "glass"                         {:fi "Lasi"
                                     :se nil
                                     :en "Glass"}
-   "synthetic"                     {:fi "Muovi / synteettinen"
-                                    :se "Plast / syntetisk"
-                                    :en "Plastic / synthetic"}
+   "synthetic"                     {:fi "Muovi/synteettinen"
+                                    :se "Plast/syntetisk"
+                                    :en "Plastic/synthetic"}
    "grass"                         {:fi "Nurmi"
                                     :se "Gräs"
                                     :en "Grass"}

--- a/webapp/src/cljc/lipas/data/prop_types.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types.cljc
@@ -2,11 +2,1819 @@
   "Type codes went through a major overhaul in the summer of 2024. This
   namespace represents the changes made."
   (:require
-   [lipas.data.types :as types]
-   [lipas.data.prop-types-new :as new]
-   [lipas.data.prop-types-old :as old]))
+   [lipas.data.types :as types]))
 
-(def all new/all)
+(def all
+  {:height-m
+   {:name
+    {:fi "Tilan korkeus m", :se "Utrymmets höjd", :en "Venue's height"},
+    :data-type "numeric",
+    :description
+    {:fi "Sisäliikuntatilan korkeus metreinä (matalin kohta)",
+     :se "Motionssalens höjd i meter (från lägsta punkten)",
+     :en ""}},
+   :heating?
+   {:name      {:fi "Lämmitys", :se "Uppvärmning", :en "Heating"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikassa lämmitys",
+     :se "Är idrottsplatsen utrustad med uppvärmning",
+     :en ""}},
+   :field-2-area-m2
+   {:name
+    {:fi "2. kentän ala m2",
+     :se "Andra planens areal m2",
+     :en "2. field's area sq. m"},
+    :data-type "numeric",
+    :description
+    {:fi "2. kentän pinta-ala neliömetreinä",
+     :se "Andra planens areal i kvadratmeter",
+     :en ""}},
+   :surface-material
+   {:name
+    {:fi "Pintamateriaali", :se "Ytmaterial", :en "Surface material"},
+    :data-type "enum-coll",
+    :description
+    {:fi
+     "Liikunta-alueiden pääasiallinen pintamateriaali - tarkempi kuvaus liikuntapaikan eri tilojen pintamateriaalista voidaan antaa pintamateriaalin lisätietokentässä",
+     :se
+     "Idrotts områdets ytmaterial. Friidrottsplanens mittplans pålägg.",
+     :en ""}},
+   :basketball-fields-count
+   {:name
+    {:fi "Koripallokentät lkm",
+     :se "Antalet korgbollsplaner",
+     :en "Basketball fields pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Koripallokenttien lukumäärä",
+     :se "Antalet korgbollsplaner i salen",
+     :en ""}},
+   :surface-material-info
+   {:name
+    {:fi "Pintamateriaali lisätieto",
+     :se "Ytterligare information om ytmaterialen",
+     :en "Surface material information"},
+    :data-type "string",
+    :description
+    {:fi
+     "Syötä pintamateriaalin tarkempi kuvaus-  esim. tekonurmen yleisnimitys ”esim. Kumirouhetekonurmi”, tuotenimi ja tieto täytemateriaalin laadusta (esim. biohajoava/perinteinen kumirouhe).",
+     :se "Ytterilgare information om ytmaterialen",
+     :en ""}},
+   :height-of-basket-or-net-adjustable?
+   {:name
+    {:fi "Korin tai verkon korkeus säädettävissä",
+     :se "Korgens eller nätets höjd är justerbar",
+     :en "Height of the basket or net is adjustable"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :holes-count
+   {:name
+    {:fi "Reikien/väylien lkm",
+     :se "Antal hål/fairways",
+     :en "Number of holes/fairways"},
+    :data-type "numeric",
+    :description
+    {:fi "Väylien lukumäärä", :se "Antalet ranger", :en ""}},
+   :skijump-hill-type
+   {:name
+    {:fi "Hyppyrimäen tyyppi",
+     :se "Hoppbackens typ",
+     :en "Type of ski jump hill"},
+    :data-type "string",
+    :description
+    {:fi "Hyppyrimäen tyyppi (harjoitus, pienmäki, normaali, suurmäki)",
+     :se
+     "Typ av hoppbacke (övningsbacke, liten, normalbacke, storbacke)",
+     :en ""}},
+   :lifts-count
+   {:name      {:fi "Hissit lkm", :se "Antalet skidliftar", :en "Lifts"},
+    :data-type "numeric",
+    :description
+    {:fi "Hiihtohissien lukumäärä",
+     :se "Antal skidliftar i skidcentrumet",
+     :en ""}},
+   :field-3-length-m
+   {:name
+    {:fi "3. kentän pituus m",
+     :se "Tredje planens längd m",
+     :en "3. field's length m"},
+    :data-type "numeric",
+    :description
+    {:fi "3. kentän pituus metreinä",
+     :se "Tredje planens längd i meter",
+     :en ""}},
+   :pool-tracks-count
+   {:name
+    {:fi "1. altaan radat lkm",
+     :se "Första bassängens antal banor",
+     :en "Courses in 1. pool"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan ratojen lukumäärä",
+     :se "Antal banor i första bassängen",
+     :en ""}},
+   :field-2-length-m
+   {:name
+    {:fi "2. kentän pituus m",
+     :se "Andra planens längd m",
+     :en "2. field's length m"},
+    :data-type "numeric",
+    :description
+    {:fi "2. kentän pituus metreinä",
+     :se "Andra planens längd i meter",
+     :en ""}},
+   :plastic-outrun?
+   {:name
+    {:fi "Muovitettu alastulo",
+     :se "Plast-belagd landning",
+     :en "Plastic outrun"},
+    :data-type "boolean",
+    :description
+    {:fi "Muovitettu hyppyrimäen alastulopaikka",
+     :se "Hoppbacken har plast-belagd landningsplats",
+     :en ""}},
+   :automated-timing?
+   {:name
+    {:fi "Automaattinen ajanotto",
+     :se "Automatisk tidtagning",
+     :en "Automatic timing"},
+    :data-type "boolean",
+    :description
+    {:fi "Varustus automaattiseen ajanottoon",
+     :se "Utrustning för automatisk tidtagning",
+     :en ""}},
+   :freestyle-slope?
+   {:name      {:fi "Kumparerinne", :se "Puckelpist", :en "Freestyle slope"},
+    :data-type "boolean",
+    :description
+    {:fi "Hiihtokeskuksessa on kumparerinne",
+     :se "Skidcentret har en puckelpist",
+     :en ""}},
+   :kiosk?
+   {:name      {:fi "Kioski", :se "Kiosk", :en "Kiosk"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikalla kioski tai vastaava",
+     :se "Har idrottsplatsen en kiosk eller något liknande",
+     :en ""}},
+   :summer-usage?
+   {:name      {:fi "Kesäkäyttö", :se "I sommarbruk", :en "Summer usage"},
+    :data-type "boolean",
+    :description
+    {:fi "Käytössä myös kesäisin",
+     :se "Används också under sommaren",
+     :en ""}},
+   :stand-capacity-person
+   {:name
+    {:fi "Katsomon kapasiteetti hlö",
+     :se "Läktarens person kapasitet",
+     :en "Stand size"},
+    :data-type "numeric",
+    :description
+    {:fi "Katsomon koko kapasiteetti, henkilölukumäärä",
+     :se "Läktarens hela person kapasitet",
+     :en ""}},
+   :free-use?
+   {:name
+    {:fi "Kohde on vapaasti käytettävissä",
+     :se "Fri användning",
+     :en "Free access"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Liikuntapaikka on vapaasti käytettävissä ilman vuorovarausta tai pääsymaksua",
+     :se
+     "Motionsplatsen är fri att användas utan tidsbokning eller entréavgift",
+     :en ""}},
+   :pier?
+   {:name        {:fi "Laituri", :se "Brygga", :en "Pier"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :sport-specification
+   {:name
+    {:fi "Lajitarkenne",
+     :se "Sportspecifikation",
+     :en "Sport specification"},
+    :data-type "enum",
+    :opts
+    {"floor-disciplines"
+     {:label
+      {:fi "Lattialajit",
+       :en "Floor disciplines",
+       :se "Golvdiscipliner"},
+      :description
+      {:fi "Voimistelulajit, jotka suoritetaan pääasiassa lattialla.",
+       :en
+       "Gymnastics disciplines that are primarily performed on the floor.",
+       :se "Gymnastikdiscipliner som huvudsakligen utförs på golvet."}},
+     "apparatus-disciplines"
+     {:label
+      {:fi "Telinelajit",
+       :en "Apparatus disciplines",
+       :se "Redskapsgrenar"},
+      :description
+      {:fi "Voimistelulajit, jotka suoritetaan erilaisilla telineillä.",
+       :en
+       "Gymnastics disciplines that are performed on various apparatus.",
+       :se "Gymnastikdiscipliner som utförs på olika redskap."}},
+     "floor-and-apparatus"
+     {:label
+      {:fi "Lattia- ja telinelajit mahdollisia",
+       :en "Both floor and apparatus disciplines possible",
+       :se "Både golv- och redskapsgrenar möjliga"},
+      :description
+      {:fi "Tilassa voidaan harjoitella sekä lattia- että telinelajeja.",
+       :en
+       "The space allows for practicing both floor and apparatus disciplines.",
+       :se
+       "Utrymmet möjliggör träning av både golv- och redskapsgrenar."}},
+     "cheerleading-circus"
+     {:label
+      {:fi "Pääasiassa cheerleading- tai sirkusharjoittelukäyttöön",
+       :en "Mainly for cheerleading or circus training",
+       :se "Huvudsakligen för cheerleading- eller cirkusträning"},
+      :description
+      {:fi
+       "Tila on ensisijaisesti tarkoitettu cheerleading- tai sirkusharjoitteluun.",
+       :en
+       "The space is primarily intended for cheerleading or circus training.",
+       :se
+       "Utrymmet är främst avsett för cheerleading- eller cirkusträning."}},
+     "no-information"
+     {:label
+      {:fi "Ei tietoa", :en "No information", :se "Ingen information"}}},
+    :description
+    {:fi "Valitse voimistelulaji, johon tila on pääasiassa tarkoitettu.",
+     :se "",
+     :en ""}},
+   :may-be-shown-in-excursion-map-fi?
+   {:name
+    {:fi "Saa julkaista Retkikartta.fi-palvelussa",
+     :se "Får publiceras i Utflyktskarta.fi",
+     :en "May be shown in Excursionmap.fi"},
+    :data-type "boolean",
+    :description
+    {:fi "Kohteen tiedot saa julkaista Retkikartta.fi-palvelussa",
+     :se "Information om motionsstället får publiceras i Retkikartta.fi",
+     :en ""}},
+   :sprint-lanes-count
+   {:name
+    {:fi "Etusuorien lkm",
+     :se "Antalet raksträckor (framför läktaren)",
+     :en "Number of sprint lanes"},
+    :data-type "numeric",
+    :description
+    {:fi "Etusuorien lukumäärä",
+     :se "Antalet raksträckor (framför läkataren)",
+     :en ""}},
+   :javelin-throw-places-count
+   {:name
+    {:fi "Keihäänheittopaikat lkm",
+     :se "Spjutkastningsplatser st.",
+     :en "Number of javelin throw places"},
+    :data-type "numeric",
+    :description
+    {:fi "Keihäänheittopaikkojen lukumäärä",
+     :se "Antalet spjutkastningsplatser",
+     :en ""}},
+   :active-space-width-m
+   {:name
+    {:fi "Liikuntakäytössä olevan tilan leveys m",
+     :se "Bredd på aktivt utrymme m",
+     :en "Width of active space m"},
+    :data-type "numeric",
+    :description
+    {:fi "Liikuntakäytössä olevan tilan leveys (m)", :se "", :en ""}},
+   :tennis-courts-count
+   {:name
+    {:fi "Tenniskentät lkm",
+     :se "Antalet tennisplaner",
+     :en "Tennis courts pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Tenniskenttien lukumäärä",
+     :se "Antalet tennisplaner",
+     :en ""}},
+   :ski-service?
+   {:name      {:fi "Suksihuolto", :se "Skidservice", :en "Ski service"},
+    :data-type "boolean",
+    :description
+    {:fi "Suksihuoltopiste löytyy",
+     :se "Det finns en skidservicepunkt",
+     :en ""}},
+   :field-1-length-m
+   {:name
+    {:fi "1. kentän pituus m",
+     :se "Första planens längd m",
+     :en "1. field's length m"},
+    :data-type "numeric",
+    :description
+    {:fi "1. kentän pituus metreinä",
+     :se "Första planens längd i meter",
+     :en ""}},
+   :mirror-wall?
+   {:name      {:fi "Peiliseinä", :se "Spegelvägg", :en "Mirror wall"},
+    :data-type "boolean",
+    :description
+    {:fi "Liikuntatilassa vähintään yhdellä seinällä on kiinteät peilit",
+     :se "",
+     :en ""}},
+   :finish-line-camera?
+   {:name      {:fi "Maalikamera", :se "Målkamera", :en "Finish line camera"},
+    :data-type "boolean",
+    :description
+    {:fi "Liikuntapaikalla on maalikamera",
+     :se "Idrottsplatsen har en målkamera",
+     :en ""}},
+   :travel-mode-info
+   {:name
+    {:fi "Kulkutavat, lisätieto",
+     :se "Resesätt, ytterligare information",
+     :en "Travel Modes, Additional Information"},
+    :data-type "string",
+    :description
+    {:fi "Täsmennä soveltuvia kulkutapoja tarvittaessa",
+     :se "Specificera lämpliga resesätt vid behov",
+     :en "Specify suitable travel modes if necessary"}},
+   :parking-place?
+   {:name
+    {:fi "Parkkipaikka", :se "Parkeringsplats", :en "Parking place"},
+    :data-type "boolean",
+    :description
+    {:fi "Parkkipaikka käytettävissä",
+     :se "Tillgänglig parkeringsplats",
+     :en ""}},
+   :canoeing-club?
+   {:name      {:fi "Melontaseura", :se "", :en "Canoeing club"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko kyseessä melontaseuran tila", :se "", :en ""}},
+   :total-billiard-tables-count
+   {:name
+    {:fi "Biljardipöydät yhteensä lkm",
+     :se "Totalt antal biljardbord",
+     :en "Total number of billiard tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :sledding-hill?
+   {:name      {:fi "Pulkkamäki", :se "Pulkabacke", :en "Sledding hill"},
+    :data-type "boolean",
+    :description
+    {:fi "Kohteessa on pulkkamäki",
+     :se "Det finns en pulkabacke på platsen.",
+     :en "There is a sledding hill at the location."}},
+   :climbing-routes-count
+   {:name
+    {:fi "Kiipeilyreittien lkm",
+     :se "Antalet klättringsrutter",
+     :en "Climbing routes pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Kiipeilyreittien lukumäärä",
+     :se "Antalet klättringsrutter",
+     :en ""}},
+   :outdoor-exercise-machines?
+   {:name
+    {:fi "Kuntoilutelineitä",
+     :se "Gym apparater utomhus",
+     :en "Exercise machines outdoors"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko reitin varrella kuntoilulaitteita",
+     :se "Finns det gym apparater längs rutten",
+     :en ""}},
+   :automated-scoring?
+   {:name
+    {:fi "Kirjanpitoautomaatti",
+     :se "Bokföringsautomat",
+     :en "Automatic scoring"},
+    :data-type "boolean",
+    :description
+    {:fi "Keilaradalla on sähköinen pistelasku",
+     :se "Bowlingbanan har elektroniskt poängräknings system",
+     :en ""}},
+   :mobile-orienteering?
+   {:name
+    {:fi "Mobiilisuunnistusmahdollisuus",
+     :se "Mobilorientering möjlig",
+     :en "Mobile Orienteering Available"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :track-width-m
+   {:name
+    {:fi "Radan leveys m", :se "Banans bredd m", :en "Width of track m"},
+    :data-type "numeric",
+    :description
+    {:fi "Juoksuradan, pyöräilyradan tms. leveys metreinä",
+     :se "Löpbanan, rundbanan el.dyl. bredd i meter",
+     :en ""}},
+   :ice-climbing?
+   {:name      {:fi "Jääkiipeily", :se "Isklättring", :en "Ice climbing"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko jääkiipeily mahdollista kiipeilypaikalla",
+     :se "Finns det möjlighet för isklättring vid klättringsplatsen",
+     :en ""}},
+   :free-use {:name {:fi "Kohde on vapaasti käytettävissä"}},
+   :field-length-m
+   {:name
+    {:fi "Kentän pituus m",
+     :se "Planens längd m",
+     :en "Length of field"},
+    :data-type "numeric",
+    :description
+    {:fi "Kentän/kenttien pituus mahdollisine turva-alueineen metreinä",
+     :se "Planens/planernas längd i meter",
+     :en ""}},
+   :skijump-hill-material
+   {:name
+    {:fi "Vauhtimäen rakennemateriaali",
+     :se "Överbackens konstruktionsmaterial",
+     :en "Ski jump hill material"},
+    :data-type "string",
+    :description
+    {:fi "Vauhtimäen rakennemateriaali",
+     :se "Överbackens konstruktionsmaterial (backhoppning)",
+     :en ""}},
+   :carom-tables-count
+   {:name
+    {:fi "Karapöydät lkm",
+     :se "Antal karombord",
+     :en "Number of carom tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :longest-slope-m
+   {:name
+    {:fi "Pisin rinne m",
+     :se "Längsta slalombacken m",
+     :en "Longest slope m"},
+    :data-type "numeric",
+    :description
+    {:fi "Pisimmän rinteen pituus metreinä",
+     :se "Längsta slalombackens längd i meter",
+     :en ""}},
+   :circular-lanes-count
+   {:name
+    {:fi "Kiertävät radat lkm",
+     :se "Antalet cirkulerande löpbanor",
+     :en "Number of circular lanes"},
+    :data-type "numeric",
+    :description
+    {:fi "Kiertävien juoksuratojen lukumäärä",
+     :se "Antalet cirkulerande löpbanor",
+     :en ""}},
+   :boat-launching-spot?
+   {:name
+    {:fi "Veneen vesillelaskupaikka",
+     :se "Sjösättningsplats för båtar",
+     :en "Place for launching a boat"},
+    :data-type "boolean",
+    :description
+    {:fi "Mahdollisuus veneen vesillelaskuun",
+     :se "Sjösättningsplats för båtar",
+     :en ""}},
+   :parkour-hall-equipment-and-structures
+   {:name
+    {:fi "Parkour-salin varustelu ja rakenteet",
+     :se "Utrustning och strukturer i parkourhallen",
+     :en "Parkour hall equipment and structures"},
+    :data-type "enum-coll",
+    :opts
+    {"fixed-obstacles"
+     {:label
+      {:fi "Kiinteät esteet/rakennelmat",
+       :en "Fixed obstacles/structures",
+       :se "Fasta hinder/strukturer"},
+      :description
+      {:fi
+       "Pysyvästi asennetut esteet tai rakennelmat harjoittelua varten.",
+       :en
+       "Permanently installed obstacles or structures for training purposes.",
+       :se
+       "Permanent installerade hinder eller strukturer för träningsändamål."}},
+     "movable-obstacles"
+     {:label
+      {:fi "Liikkuvat esteet/rakennelmat",
+       :en "Movable obstacles/structures",
+       :se "Flyttbara hinder/strukturer"},
+      :description
+      {:fi
+       "Siirrettävät tai muunneltavat esteet ja rakennelmat harjoittelua varten.",
+       :en
+       "Movable or adjustable obstacles and structures for training purposes.",
+       :se
+       "Flyttbara eller justerbara hinder och strukturer för träningsändamål."}},
+     "floor-acrobatics-area"
+     {:label
+      {:fi "Permanto/akrobatiatila",
+       :en "Floor/acrobatics area",
+       :se "Golv/akrobatikområde"},
+      :description
+      {:fi
+       "Avoin tila lattiaharjoittelua ja akrobaattisia liikkeitä varten.",
+       :en "Open space for floor exercises and acrobatic movements.",
+       :se "Öppet utrymme för golvövningar och akrobatiska rörelser."}},
+     "gym-strength-area"
+     {:label
+      {:fi "Kuntosali-/voimailutila",
+       :en "Gym/strength training area",
+       :se "Gym/styrketräningsområde"},
+      :description
+      {:fi
+       "Alue, joka on varustettu kuntosalilaitteilla ja välineillä voimaharjoittelua varten.",
+       :en
+       "Area equipped with gym machines and equipment for strength training.",
+       :se
+       "Område utrustat med gymmaskiner och utrustning för styrketräning."}}},
+    :description
+    {:fi "Valitse parkour-salissa olevat rakenteet tai varusteet",
+     :se "",
+     :en ""}},
+   :ski-track-traditional?
+   {:name
+    {:fi "Perinteinen latu",
+     :se "Skidspår för klassisk stil",
+     :en "Traditional ski track"},
+    :data-type "boolean",
+    :description
+    {:fi "Perinteisen tyylin hiihtomahdollisuus/latu-ura",
+     :se "Möjlighet att skida klassisk stil",
+     :en ""}},
+   :altitude-difference
+   {:name
+    {:fi "Korkeusero m",
+     :se "Höjdskillnad m",
+     :en "Altitude difference"},
+    :data-type "numeric",
+    :description
+    {:fi "Reitin korkeusero metreinä",
+     :se "Ruttens höjdskillnad i meter",
+     :en ""}},
+   :climbing-wall-height-m
+   {:name
+    {:fi "Kiipeilyseinän korkeus m",
+     :se "Klätterväggens höjd m",
+     :en "Climbing wall height"},
+    :data-type "numeric",
+    :description
+    {:fi "Kiipeilyseinän korkeus metreinä (max)",
+     :se "Klätterväggens höjd i meter (max)",
+     :en ""}},
+   :route-width-m
+   {:name
+    {:fi "Reitin leveys m",
+     :se "Ruttens bredd m",
+     :en "Route's width m"},
+    :data-type "numeric",
+    :description
+    {:fi "Reitin leveys metreinä", :se "Banans bredd i meter", :en ""}},
+   :rapid-canoeing-centre?
+   {:name
+    {:fi "Koskimelontakeskus",
+     :se "Centrum för paddling",
+     :en "Rapid canoeing centre"},
+    :data-type "boolean",
+    :description
+    {:fi "Kilpailujen järjestäminen mahdollista.",
+     :se "Möjligt att arrangera tävlingar.",
+     :en "Competitions possible."}},
+   :beach-length-m
+   {:name
+    {:fi "Rannan pituus m",
+     :se "Strandens längd m",
+     :en "Length of beach m"},
+    :data-type "numeric",
+    :description
+    {:fi "Hoidetun rannan pituus metreinä",
+     :se "Skötta strandens längd i meter",
+     :en ""}},
+   :match-clock?
+   {:name      {:fi "Ottelukello", :se "Matchklocka", :en "Match clock"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikalla ottelukello",
+     :se "Finns det en matchklocka vid idrottsplatsen",
+     :en ""}},
+   :sprint-track-length-m
+   {:name
+    {:fi "Etusuoran pituus m",
+     :se "Raksträckans längd (framför läktaren)",
+     :en "Length of sprint track"},
+    :data-type "numeric",
+    :description
+    {:fi "Juoksuradan etusuoran pituus",
+     :se "Längden på löpbanans raksträcka",
+     :en ""}},
+   :inner-lane-length-m
+   {:name
+    {:fi "Sisäradan pituus m",
+     :se "Innerbanans längd m",
+     :en "Length of inner lane m"},
+    :data-type "numeric",
+    :description
+    {:fi "Sisäradan pituus kiertävissä radoissa",
+     :se "Längden på innerbanan i de cirkulerande banorna",
+     :en ""}},
+   :discus-throw-places
+   {:name
+    {:fi "Kiekonheittopaikat lkm",
+     :se "Diskusplatser st.",
+     :en "Number of discus throw places"},
+    :data-type "numeric",
+    :description
+    {:fi "Kiekonheittopaikkojen lukumäärä",
+     :se "Antalet diskuskastningsplatser",
+     :en ""}},
+   :fields-count
+   {:name
+    {:fi "Kenttien lkm", :se "Antalet planer", :en "Number of fields"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako saman tyypin kenttää liikuntapaikassa on",
+     :se "Hur många planer av samma typ har motionsplatsen",
+     :en ""}},
+   :field-1-width-m
+   {:name
+    {:fi "1. kentän leveys m",
+     :se "Första planens bredd m",
+     :en "1. field's width m"},
+    :data-type "numeric",
+    :description
+    {:fi "1. kentän leveys metreinä",
+     :se "Första planens bredd i meter",
+     :en ""}},
+   :field-3-width-m
+   {:name
+    {:fi "3. kentän leveys m",
+     :se "Tredje planens bredd m",
+     :en "3. field's width m"},
+    :data-type "numeric",
+    :description
+    {:fi "3. kentän leveys metreinä",
+     :se "Tredje planens bredd i meter",
+     :en ""}},
+   :field-2-width-m
+   {:name
+    {:fi "2. kentän leveys m",
+     :se "Andra planens bredd m",
+     :en "2. field's width m"},
+    :data-type "numeric",
+    :description
+    {:fi "2. kentän leveys metreinä",
+     :se "Andra planens bredd i meter",
+     :en ""}},
+   :badminton-courts-count
+   {:name
+    {:fi "Sulkapallokentät lkm",
+     :se "Antalet badmintonsplaner",
+     :en "Badminton courts pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Sulkapallokenttien lukumäärä salissa",
+     :se "Antalet badmintonsplaner i salen",
+     :en ""}},
+   :fitness-stairs-length-m
+   {:name
+    {:fi "Kuntoportaiden pituus m",
+     :se "Längden på tränings trapporna m",
+     :en "Length of the fitness stairs m"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :free-customer-use?
+   {:name
+    {:fi "Vapaa asiakaskäyttö",
+     :se "Fri kundanvändning",
+     :en "Free customer use"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Liikuntapaikka on asiakkaiden käytettävissä esim. kulkukortilla ilman henkilökunnan läsnäoloa. Vapaa asiakaskäyttö voi olla rajattu tiettyihin kellonaikoihin.",
+     :se "",
+     :en ""}},
+   :hammer-throw-places-count
+   {:name
+    {:fi "Moukarinheittopaikat lkm",
+     :se "Antalet släggkastningsplatser",
+     :en "Hammer throw"},
+    :data-type "numeric",
+    :description
+    {:fi "Moukarinheittopaikkojen lukumäärä",
+     :se "Antal platser för att släggkastning",
+     :en ""}},
+   :may-be-shown-in-harrastuspassi-fi?
+   {:name
+    {:fi "Saa julkaista Harrastuspassi.fi-sovelluksessa",
+     :se "Får publiceras i Harrastuspassi.fi",
+     :en "May be shown in Harrastuspassi.fi"},
+    :data-type "boolean",
+    :description
+    {:fi "Kohteen tiedot saa julkaista Harrastuspassi.fi-sovelluksessa",
+     :se
+     "När du kryssat för rutan ”Kan visas på Harrastuspassi.fi” flyttas uppgifterna om idrottsanläggningen automatisk till Harrastuspassi.fi –applikationen.",
+     :en
+     "When the option ”May be shown in Harrastuspassi.fi” is ticked, the information regarding the sport facility will be transferred automatically to the Harrastuspassi.fi application."}},
+   :pool-width-m
+   {:name
+    {:fi "1. altaan leveys m",
+     :se "Första bassängens bredd m",
+     :en "1. pool's width"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan/pääaltaan leveys metreinä",
+     :se "Första/huvudbassängens bredd i meter",
+     :en ""}},
+   :pool-min-depth-m
+   {:name
+    {:fi "1. altaan syvyys min m",
+     :se "1a bassängens djup min m",
+     :en "1. pool's depth min m"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan syvyys matalimmasta päästä metreinä",
+     :se "Första bassängens grundaste punkt i meter.",
+     :en ""}},
+   :padel-courts-count
+   {:name
+    {:fi "Padelkentät lkm",
+     :se "Antalet padelbanor",
+     :en "Number of padel courts"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :hs-point
+   {:name      {:fi "HS-piste", :se "HS-punkt", :en "HS Point"},
+    :data-type "numeric",
+    :description
+    {:fi "Hyppyrimäen HS-piste metreinä",
+     :se "HS-punkten i backhoppning i meter",
+     :en "Ski jumping hill HS point in "}},
+   :ice-rinks-count
+   {:name      {:fi "Kaukalot lkm", :se "Antalet rinkar", :en "Ice rinks"},
+    :data-type "numeric",
+    :description
+    {:fi "Kaukaloiden lukumäärä",
+     :se "Antalet rinkar (hockey) det finns vid idrottsplatsen",
+     :en ""}},
+   :field-1-area-m2
+   {:name
+    {:fi "1. kentän ala m2",
+     :se "Första planens areal m2",
+     :en "1. field's area sq. m"},
+    :data-type "numeric",
+    :description
+    {:fi "1. kentän pinta-ala neliömetreinä",
+     :se "Första planens areal i kvadratmeter",
+     :en ""}},
+   :k-point
+   {:name      {:fi "K-piste", :se "K-punkt", :en "K point"},
+    :data-type "numeric",
+    :description
+    {:fi "Hyppyrimäen k-piste metreinä",
+     :se "Hoppbackens k-punkt i meter",
+     :en ""}},
+   :polevault-places-count
+   {:name
+    {:fi "Seiväshyppypaikat lkm",
+     :se "Antalet stavhoppsplatser",
+     :en "Pole vault"},
+    :data-type "numeric",
+    :description
+    {:fi "Seiväshyppypaikkojen lukumäärä",
+     :se "Antalet stavhoppningsplatser",
+     :en ""}},
+   :group-exercise-rooms-count
+   {:name
+    {:fi "Ryhmäliikuntatilat lkm",
+     :se "Antalet gruppmotions utrymmen",
+     :en "Room for exercise groups"},
+    :data-type "numeric",
+    :description
+    {:fi "Liikuntasalien ja ryhmäliikuntatilojen lukumäärä",
+     :se "Antalet gymnastiksalar och gruppmotions utrymmen",
+     :en ""}},
+   :snowpark-or-street?
+   {:name
+    {:fi "Parkki", :se "Trick/street pist", :en "Snow park/street"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Onko rinnehiihtokeskuksessa ns. temppurinne, snowpark tai vastaava",
+     :se "Har skidcentrumet en trickbana, snowpark eller något liknande",
+     :en ""}},
+   :field-2-flexible-rink?
+   {:name
+    {:fi "2. kenttä: onko joustokaukalo?",
+     :se "Fält 2: finns det flexibel rink?",
+     :en "Field 2: is there a flexible rink?"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :space-divisible
+   {:name
+    {:fi "Tila jaettavissa osiin",
+     :se "Utrymmet kan delas upp",
+     :en "Space can be divided"},
+    :helper-text
+    {:fi "Moneenko osaan tila on jaettavissa (lkm)",
+     :se "Ange antalet delar som utrymmet kan delas in i",
+     :en
+     "Enter the number of sections into which the space can be divided"},
+    :data-type "number",
+    :description
+    {:fi
+     "Onko tila jaettavissa osiin esim. jakoseinien tai -verhojen avulla",
+     :se
+     "Är utrymmet delbart i sektioner, till exempel med skiljeväggar eller gardiner",
+     :en
+     "Is the space divisible into sections, for example, with partition walls or curtains"}},
+   :max-vertical-difference
+   {:name
+    {:fi "Korkeusero max m",
+     :se "Höjdskillnad max m",
+     :en "Max vertical difference"},
+    :data-type "numeric",
+    :description
+    {:fi "Suurin korkeusero rinteissä",
+     :se "Största höjdskillnaden i slalombackorna",
+     :en ""}},
+   :bowling-lanes-count
+   {:name
+    {:fi "Keilaradat lkm",
+     :se "Antalet bowlingbanor",
+     :en "Bowling lanes"},
+    :data-type "numeric",
+    :description
+    {:fi "Keilaratojen lukumäärä", :se "Antalet bowlingbanor", :en ""}},
+   :air-gun-shooting?
+   {:name
+    {:fi "Ilma-aseammunta",
+     :se "Luftgevärsskytte",
+     :en "Air gun shooting"},
+    :data-type "boolean",
+    :description
+    {:fi "Ilma-aseammuntamahdollisuus",
+     :se "Möjlighet för luftgevärsskytte",
+     :en ""}},
+   :gymnastic-routines-count
+   {:name
+    {:fi "Telinevoimistelusarjat lkm",
+     :se "Antalet redskapsgymnastikserier",
+     :en "Gymnastic routines"},
+    :data-type "numeric",
+    :description
+    {:fi "Telinevoimistelun telinesarjojen lukumäärä",
+     :se "Antalet redskap för redskapsgymnastik",
+     :en ""}},
+   :toilet?
+   {:name      {:fi "Yleisö-wc", :se "Allmän toalett", :en "Toilet"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko kohteessa yleiseen käyttöön tarkoitettuja wc-tiloja?",
+     :se "Är allmänna toaletten i användning",
+     :en ""}},
+   :gymnastics-space?
+   {:name
+    {:fi "Telinevoimistelutila",
+     :se "Utrymme för redskapsgymnastik",
+     :en "Space for gymnastics"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntasalissa myös telinevoimistelutila",
+     :se "Har motionssalen också område/utrymme för redskapsgymnastik",
+     :en ""}},
+   :snooker-tables-count
+   {:name
+    {:fi "Snookerpöydät lkm",
+     :se "Antal snookerbord",
+     :en "Number of snooker tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :show-jumping?
+   {:name      {:fi "Esteratsastus", :se "Banhoppning", :en "Show jumping"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Onko ratsastuskentällä/maneesissa esteratsastukseen soveltuva varustus",
+     :se "Har ridplanen/ridhuset utrustning för banhoppning",
+     :en ""}},
+   :shower?
+   {:name      {:fi "Suihku", :se "Dusch", :en "Shower"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko suihku käytettävissä",
+     :se "Är duschen i användning",
+     :en ""}},
+   :rest-places-count
+   {:name
+    {:fi "Taukopaikat lkm",
+     :se "Antalet viloplatser",
+     :en "Rest places"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako taukopaikkaa reitin varrella on",
+     :se "Hur många viloplatser finns det längs med rutten",
+     :en ""}},
+   :changing-rooms?
+   {:name      {:fi "Pukukopit", :se "Omklädningsrum", :en "Changing rooms"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko pukukoppeja", :se "Finns det omklädningsrum", :en ""}},
+   :pistol-shooting?
+   {:name
+    {:fi "Pistooliammunta", :se "Pistolskytte", :en "Pistol shooting"},
+    :data-type "boolean",
+    :description
+    {:fi "Pistooliammuntamahdollisuus",
+     :se "Möjlighet för pistolskytte",
+     :en ""}},
+   :halfpipe-count
+   {:name
+    {:fi "Halfpipe lkm", :se "Antal halfpipe", :en "Halfpipe count"},
+    :data-type "numeric",
+    :description
+    {:fi "Halfpipe, superpipe lukumäärät",
+     :se "Antal halfpipe",
+     :en ""}},
+   :shooting-positions-count
+   {:name
+    {:fi "Ampumapaikat lkm",
+     :se "Antalet skytteplatser",
+     :en "Shooting positions"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako ampumapaikkaa liikuntareitin varrella on",
+     :se "Hur många skytteplatser finns det längs motionsrutten",
+     :en ""}},
+   :running-track-surface-material
+   {:name
+    {:fi "Juoksuradan pintamateriaali",
+     :se "Löpbanans ytmaterial",
+     :en "Surface material for running track"},
+    :data-type "string",
+    :description
+    {:fi "Juoksuradan pintamateriaali/päällyste",
+     :se "Löpbanans ytmaterial/pålägg",
+     :en ""}},
+   :boating-service-class
+   {:name
+    {:fi "Venesatama- tai laituriluokka",
+     :se "Båthamn eller bryggklass",
+     :en "Boat harbor or pier class"},
+    :description
+    {:fi
+     "https://ava.vaylapilvi.fi/ava/Julkaisut/MKL/mkl_2008-1_venesatamien_luokitus.pdf",
+     :se
+     "https://ava.vaylapilvi.fi/ava/Julkaisut/MKL/mkl_2008-1_venesatamien_luokitus.pdf",
+     :en
+     "https://ava.vaylapilvi.fi/ava/Julkaisut/MKL/mkl_2008-1_venesatamien_luokitus.pdf"},
+    :data-type "enum",
+    :opts
+    {"home-harbor"
+     {:label {:fi "Kotisatama", :en "Home harbor", :se "Hemmahamn"},
+      :description
+      {:fi
+       "Satama, jossa veneet pääasiallisesti säilytetään veneilykauden aikana ja jossa veneen omistaja joko omistaa tai hallitsee venepaikan. Satamat ovat yleensä kunnallisia, kaupallisia tai veneseurojen ylläpitämiä satamia.",
+       :en
+       "A harbor where boats are mainly stored during the boating season and where the boat owner either owns or controls the berth. Harbors are usually municipal, commercial, or maintained by boating clubs.",
+       :se
+       "En hamn där båtar huvudsakligen förvaras under båtsäsongen och där båtägaren antingen äger eller kontrollerar båtplatsen. Hamnarna är vanligtvis kommunala, kommersiella eller underhålls av båtklubbar."}},
+     "visiting-harbor"
+     {:label
+      {:fi "Vierassatama (Palvelusatama, Vieraslaituri, Retkisatama)",
+       :en "Visiting harbor",
+       :se "Besökshamn"},
+      :description
+      {:fi
+       "Satama, jossa veneretken tai matkapurjehduksen aikana voi käydä kaupassa, asioimassa, lepäämässä, yöpymässä tai veneen huollossa.",
+       :en
+       "A harbor where during a boating trip or sailing voyage you can go shopping, run errands, rest, stay overnight, or service the boat.",
+       :se
+       "En hamn där du under en båttur eller seglingsresa kan handla, göra ärenden, vila, övernatta eller serva båten."}},
+     "safety-harbor"
+     {:label
+      {:fi "Turvasatama (Suojasatama, Hätäsatama)",
+       :en "Safety harbor",
+       :se "Säkerhetshamn"},
+      :description
+      {:fi
+       "Satama, josta voidaan hakea suojaa tai saada ensiapua tai korjausapua.",
+       :en
+       "A harbor where you can seek shelter or get first aid or repair assistance.",
+       :se
+       "En hamn där man kan söka skydd eller få första hjälp eller reparationshjälp."}},
+     "canoe-pier"
+     {:label {:fi "Melontalaituri", :en "Canoe pier", :se "Kanotbrygga"},
+      :description
+      {:fi "Melontaan tarkoitettu laituri.",
+       :en "Pier intended for canoeing.",
+       :se "Brygga avsedd för kanotpaddling."}},
+     "no-class"
+     {:label
+      {:fi
+       "Kohde ei täytä minkään venesatama- tai laituriluokan vaatimuksia (esim. rantautumispaikka)",
+       :en
+       "The target does not meet the requirements of any marina or dock class (e.g., landing place)",
+       :se
+       "Objektet uppfyller inte kraven för någon småbåtshamn- eller bryggklass (t.ex. landningsplats)"},
+      :description
+      {:fi
+       "Kohde ei täytä minkään venesatama- tai laituriluokan vaatimuksia (esim. rantautumispaikka).",
+       :en
+       "The site does not meet the requirements of any boat harbor or pier class (e.g., landing place).",
+       :se
+       "Platsen uppfyller inte kraven för någon båthamn eller bryggklass (t.ex. landningsplats)."}},
+     "no-information"
+     {:label
+      {:fi "Ei tietoa",
+       :se "Ingen information",
+       :en "No information"}}}},
+   :tatamis-count
+   {:name
+    {:fi "Tatamit ja mattoalueet lkm",
+     :se "Antal tatami- och mattområden",
+     :en "Tatamis and mat areas"},
+    :data-type "numeric",
+    :description
+    {:fi "Tatamien ja mattoalueiden lukumäärä",
+     :se "Antal tatami- och mattområden",
+     :en "Number of tatami and mat areas"}},
+   :lit-route-length-km
+   {:name
+    {:fi "Valaistua reittiä km",
+     :se "Belyst rutt km",
+     :en "Lit route's length km"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako kilometriä reitistä on valaistua",
+     :se "Hur många km av rutten är uppbelyst",
+     :en ""}},
+   :area-m2
+   {:name
+    {:fi "Liikuntapinta-ala m2",
+     :se "Areal m2",
+     :en "Area in square meters"},
+    :data-type "numeric",
+    :description
+    {:fi "Liikuntapaikan liikuntapinta-ala, neliömetreinä",
+     :se "Idrottsplatsens areal i kvadratmeter",
+     :en ""}},
+   :field-width-m
+   {:name
+    {:fi "Kentän leveys m", :se "Planens bredd m", :en "Width of field"},
+    :data-type "numeric",
+    :description
+    {:fi "Kentän/kenttien leveys mahdollisine turva-alueineen metreinä",
+     :se "Planens/planernas bredd i meter",
+     :en ""}},
+   :cosmic-bowling?
+   {:name      {:fi "Hohtokeilaus", :se "Discobowling", :en "Cosmic bowling"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko keilaradalla hohtokeilausmahdollisuus",
+     :se "Har bowlingsbanan möjlighet för discobowling",
+     :en ""}},
+   :travel-modes
+   {:name      {:fi "Kulkutavat", :se "Resesätt", :en "Travel Modes"},
+    :data-type "enum-coll",
+    :opts
+    {"by-foot"
+     {:label {:fi "Jalan", :en "On Foot", :se "Till fots"},
+      :description
+      {:fi "Liikkuminen jalkaisin",
+       :en "Traveling on foot",
+       :se "Att resa till fots"}},
+     "snow-shoes"
+     {:label
+      {:fi "Lumikengillä", :en "With Snowshoes", :se "Med snöskor"},
+      :description
+      {:fi "Liikkuminen lumikengillä",
+       :en "Traveling with snowshoes",
+       :se "Att resa med snöskor"}},
+     "fat-bike"
+     {:label
+      {:fi "Läskipyörällä", :en "With Fat Bike", :se "Med fatbike"},
+      :description
+      {:fi "Liikkuminen läskipyörällä",
+       :en "Traveling with a fat bike",
+       :se "Att resa med fatbike"}}},
+    :description
+    {:fi "Lisää reitille soveltuvat kulkutavat",
+     :se "Lägg till lämpliga resesätt för rutten",
+     :en "Add suitable travel modes for the route"}},
+   :wrestling-mats-count
+   {:name
+    {:fi "Painimatot lkm",
+     :se "Brottarmattor st.",
+     :en "Wrestling mats pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Painimattojen lukumäärä", :se "Antal brottarmattor", :en ""}},
+   :lighting-info
+   {:name
+    {:fi "Valaistuksen lisätieto",
+     :se "Ytterligare information om belysningen",
+     :en "Additional information about the lighting"},
+    :data-type "string",
+    :description
+    {:fi "Esim. lux-määrä tai muu tarkentava tieto",
+     :se "T.ex. lux-mängd eller annan förtydligande information",
+     :en "E.g. lux amount or other specifying information"}},
+   :eu-beach?
+   {:name      {:fi "EU-uimaranta", :se "EU-badstrand", :en "EU beach"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Uimaranta, joka täyttää EU-kriteerit uimaveden laadusta ja valvonnasta",
+     :se
+     "Badstrand, som fyller EU-kriterierna med kvaliteten och övervakningen av badvattnet",
+     :en ""}},
+   :rifle-shooting?
+   {:name
+    {:fi "Kivääriammunta", :se "Gevärbana", :en "Rifle shooting places"},
+    :data-type "boolean",
+    :description
+    {:fi "Kivääriammuntamahdollisuus",
+     :se "Möjlighet för gevärskytte",
+     :en ""}},
+   :swimming-pool-count
+   {:name
+    {:fi "Altaiden lukumäärä",
+     :se "Antalet simbassänger",
+     :en "Number of swimming pools"},
+    :data-type "numeric",
+    :description
+    {:fi
+     "Altaiden lukumäärä yhteensä. Syötä tieto tai laske automaattisesti.",
+     :se "Antalet simbassänger, också terapi bassänger",
+     :en ""}},
+   :pool-water-area-m2
+   {:name
+    {:fi "Vesipinta-ala m2",
+     :se "Bassängernas vatten areal",
+     :en "Pool water area in sq. m"},
+    :data-type "numeric",
+    :description
+    {:fi "Asiakaskäytössä oleva vesipinta-ala yhteensä.",
+     :se "Den totala vattenytan tillgänglig för kunder.",
+     :en "The total water surface area available for customers."}},
+   :highest-obstacle-m
+   {:name
+    {:fi "Korkeimman esteen korkeus m",
+     :se "Höjden på den högsta hindret m",
+     :en "The height of the highest obstacle m"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :year-round-use?
+   {:name
+    {:fi "Ympärivuotinen käyttö",
+     :se "Året runt användning",
+     :en "Year-round Use"},
+    :data-type "boolean",
+    :description
+    {:fi "Kohde on ympärivuotisessa käytössä",
+     :se "Platsen är i användning året runt",
+     :en "The location is in use year-round"}},
+   :curling-lanes-count
+   {:name
+    {:fi "Curling-ratojen lukumäärä",
+     :se "Antal curlingbanor",
+     :en "Count of curling lanes"},
+    :data-type "numeric",
+    :description
+    {:fi "Curling-ratojen lukumäärä",
+     :se "Antal curlingbanor",
+     :en "Number of curling lanes"}},
+   :climbing-wall-width-m
+   {:name
+    {:fi "Kiipeilyseinän leveys m",
+     :se "Klätterväggens bredd m",
+     :en "Climbing wall width"},
+    :data-type "numeric",
+    :description
+    {:fi "Kiipeilyseinän leveys metreinä sivusuunnassa",
+     :se "Bredden på klätterväggen i meter i sidled",
+     :en "Width of the climbing wall in meters laterally"}},
+   :area-km2
+   {:name
+    {:fi "Pinta-ala km2",
+     :se "Areal km2",
+     :en "Area in square kilometres"},
+    :data-type "numeric",
+    :description
+    {:fi "Alueen pinta-ala neliökilometreinä",
+     :se "Områdets areal i kvadratkilometer",
+     :en "Area of the region in square kilometers"}},
+   :scoreboard?
+   {:name      {:fi "Tulostaulu", :se "Resultattavla", :en "Score board"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikalla tulostaulu/sähköinen tulostaulu",
+     :se "Finns det en resultattavla/elektronisk resultattavla på idrottsplatsen",
+     :en "Is there a scoreboard/electronic scoreboard at the sports facility"}},
+   :futsal-fields-count
+   {:name
+    {:fi "Futsal-kentät lkm",
+     :se "Antalet Futsal-planer",
+     :en "Number of futsal fields"},
+    :data-type "numeric",
+    :description
+    {:fi "Futsal-kenttien lukumäärä",
+     :se "Antal futsalplaner",
+     :en "Number of futsal courts"}},
+   :ski-orienteering?
+   {:name
+    {:fi "Hiihtosuunnistus mahdollista",
+     :se "Skidorientering möjlig",
+     :en "Ski Orienteering Possible"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :training-wall?
+   {:name
+    {:fi "Lyöntiseinä",
+     :se "Vägg att träna på tennis",
+     :en "Training wall for tennis"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko tenniskentällä lyöntiseinä",
+     :se "Finns det en träningsvägg vid tennisplanen",
+     :en "Is there a hitting wall on the tennis court"}},
+   :shotput-count
+   {:name
+    {:fi "Kuulantyöntöpaikat lkm",
+     :se "Antalet kulstötningsplatser",
+     :en "Shot put"},
+    :data-type "numeric",
+    :description
+    {:fi "Kuulantyöntöpaikkojen lukumäärä",
+     :se "Antal kulstötningsplatser",
+     :en "Number of shot put areas"}},
+   :active-space-length-m
+   {:name
+    {:fi "Liikuntakäytössä olevan tilan pituus m",
+     :se "Längd på aktivt utrymme m",
+     :en "Length of active space m"},
+    :data-type "numeric",
+    :description
+    {:fi "Liikuntakäytössä olevan tilan pituus (m)", :se "", :en ""}},
+   :longjump-places-count
+   {:name
+    {:fi "Pituus- ja kolmiloikkapaikat lkm",
+     :se "Antalet längd- och trestegshopp platser",
+     :en "Long jump"},
+    :data-type "numeric",
+    :description
+    {:fi "Pituus- ja kolmiloikkapaikkojen lukumäärä",
+     :se "Antal längd- och trestegshoppsplatser",
+     :en "Number of long jump and triple jump areas"}},
+   :football-fields-count
+   {:name
+    {:fi "Jalkapallokentät lkm",
+     :se "Antalet fotbollsplaner",
+     :en "Football fields pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako jalkapallokenttää mahtuu saliin/halliin",
+     :se "Hur många fotbollsplaner ryms i salen/hallen",
+     :en "How many football (soccer) fields can fit in the hall"}},
+   :floorball-fields-count
+   {:name
+    {:fi "Salibandykentät lkm",
+     :se "Antalet innebandyplaner",
+     :en "Floor ball field"},
+    :data-type "numeric",
+    :description
+    {:fi "Salibandykenttien lukumäärä",
+     :se "Antalet innebandyplaner",
+     :en "Number of floorball courts"}},
+   :auxiliary-training-area?
+   {:name
+    {:fi "Oheisharjoittelutila",
+     :se "Kompletterande träningsområde",
+     :en "Auxiliary training area"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Onko kohteessa oheisharjoitteluun soveltuva tila? Oheisharjoittelutila on liikuntapaikan käyttäjille tarkoitettu erillinen pienliikuntatila, jota voidaan käyttää esim. lämmittelyyn tai oheisharjoitteluun. Tilan koko, varustelu ja pintamateriaali ovat oheisharjoitteluun soveltuvia.",
+     :se "Finns det en lämplig plats för kompletterande träning på platsen? En kompletterande träningsyta är en separat mindre träningsyta avsedd för användare av idrottsanläggningen, som kan användas till exempel för uppvärmning eller kompletterande träning. Utrymmets storlek, utrustning och ytskikt är lämpliga för kompletterande träning.",
+     :en "Is there a suitable area for supplementary training at the facility? A supplementary training area is a separate small exercise space intended for users of the sports facility, which can be used, for example, for warm-ups or supplementary training. The size, equipment, and surface material of the area are suitable for supplementary training."}},
+   :equipment-rental?
+   {:name
+    {:fi "Välinevuokraus",
+     :se
+     "Uthyrning av idrottsutrustning t.ex. slalom,skidning, terräncyklar osv.",
+     :en "Equipment rental"},
+    :data-type "boolean",
+    :description
+    {:fi "Välinevuokraus mahdollista",
+     :se "Möjlighet att hyra utrustning",
+     :en "Equipment rental available"}},
+   :slopes-count
+   {:name
+    {:fi "Rinteiden lkm",
+     :se "Antalet slalombackar",
+     :en "Number of slopes"},
+    :data-type "numeric",
+    :description
+    {:fi "Rinteiden määrä yhteensä",
+     :se "Totala antalet slalombackar",
+     :en "Total number of slopes"}},
+   :pool-length-m
+   {:name
+    {:fi "1. altaan pituus m",
+     :se "Första bassängens längd",
+     :en "1. pool's length"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan/pääaltaan pituus metreinä",
+     :se "Första/huvudbassängens längd i meter",
+     :en ""}},
+   :other-pools-count
+   {:name
+    {:fi "Muut altaat lkm",
+     :se "Antalet andra bassänger",
+     :en "Number of other pools"},
+    :data-type "numeric",
+    :description
+    {:fi "Porealtaiden, kylmäaltaiden yms lukumäärä yhteensä",
+     :se "Antalet övriga bassänger såsom bubbelpool, kallbassäng o.dyl.",
+     :en "Total number of hot tubs, cold pools, etc."}},
+   :shortest-slope-m
+   {:name
+    {:fi "Lyhin rinne m",
+     :se "Kortaste slalombacken m",
+     :en "Shortest slope m"},
+    :data-type "numeric",
+    :description
+    {:fi "Lyhimmän rinteen pituus metreinä",
+     :se "Kortaste skidbacken i meter",
+     :en "Length of the shortest slope in meters"}},
+   :pool-tables-count
+   {:name
+    {:fi "Poolpöydät lkm",
+     :se "Antal poolbord",
+     :en "Number of pool tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :squash-courts-count
+   {:name
+    {:fi "Squash-kentät lkm",
+     :se "Antalet squashplaner",
+     :en "Squash courts"},
+    :data-type "numeric",
+    :description
+    {:fi "Squash-kenttien lukumäärä",
+     :se "Antalet squash-planer",
+     :en ""}},
+   :changing-rooms-m2
+   {:name
+    {:fi "Pukukoppien kokonaispinta-ala m²",
+     :se "Omklädningsrummens totala yta m²",
+     :en "Total area of the changing rooms in m²"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :ringette-boundary-markings?
+   {:name
+    {:fi "Ringeten rajamerkinnät",
+     :se "Gränsmarkeringar för ringette",
+     :en "Ringette boundary markings"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko kaukaloissa ringeten rajamerkinnät?", :se "", :en ""}},
+   :boxing-rings-count
+   {:name
+    {:fi "Nyrkkeilykehät lkm",
+     :se "Antalet boxningsringar",
+     :en "Boxing rings pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Nyrkkeilykehien lukumäärä",
+     :se "Antalet boxningsringar",
+     :en ""}},
+   :ice-reduction?
+   {:name      {:fi "Jäätymisenesto", :se "Frostskydd", :en "Ice reduction"},
+    :data-type "boolean",
+    :description
+    {:fi "Jäätymisenestojärjestelmä talviuintipaikassa",
+     :se "Har vinterbadplatsen mekanism för frostskydd",
+     :en ""}},
+   :activity-service-company?
+   {:name
+    {:fi "Ohjelmapalveluyritys", :se "", :en "Activity service company"},
+    :data-type "boolean",
+    :description
+    {:fi "Toimiiko kohteessa ohjelmapalveluyritys.", :se "", :en ""}},
+   :field-1-flexible-rink?
+   {:name
+    {:fi "1. kenttä: onko joustokaukalo?",
+     :se "Fält 1: finns det flexibel rink?",
+     :en "Field 1: is there a flexible rink?"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :fencing-bases-count
+   {:name
+    {:fi "Miekkailualustat lkm",
+     :se "Antalet fäktnings underlag",
+     :en "Fencing bases"},
+    :data-type "numeric",
+    :description
+    {:fi "Miekkailualustojen lukumäärä",
+     :se "Antal underlägg avsedda för fäktning",
+     :en ""}},
+   :weight-lifting-spots-count
+   {:name
+    {:fi "Painonnostopaikat/nostolavat lkm",
+     :se "Antal tyngdlyftningsplatser/lyftplattformar",
+     :en "Number of weightlifting areas/platforms"},
+    :data-type "numeric",
+    :description
+    {:fi
+     "Painnostopaikkojen lukumäärä. Huom. nostolava on painonnostopaikka, joka kestää painojen pudottamisen",
+     :se
+     "Antal tyngdlyftningsplatser. Obs: En lyftplattform är en tyngdlyftningsplats som tål att vikter tappas.",
+     :en
+     "Number of weightlifting areas. Note: A lifting platform is a weightlifting area that can withstand the dropping of weights."}},
+   :landing-places-count
+   {:name
+    {:fi "Alastulomontut lkm",
+     :se "Antalet landningsgropar",
+     :en "Landing places"},
+    :data-type "numeric",
+    :description
+    {:fi "Alastulomonttujen lukumäärä",
+     :se "Antalet landnigsgropar",
+     :en ""}},
+   :bike-orienteering?
+   {:name
+    {:fi "Pyöräsuunnistus mahdollista",
+     :se "Cykelorientering möjlig",
+     :en "Bike Orienteering Possible"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :toboggan-run?
+   {:name      {:fi "Ohjaskelkkamäki", :se "Rodelbana", :en "Toboggan run"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko rinnehiihtokeskuksessa ohjaskelkkamäki",
+     :se "Har skidcentrumet en rodelbana",
+     :en ""}},
+   :sauna?
+   {:name      {:fi "Sauna", :se "Bastu", :en "Sauna"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko sauna käytettävissä",
+     :se "Är bastun i användning",
+     :en ""}},
+   :jumps-count
+   {:name
+    {:fi "Hyppyrien lkm",
+     :se "Antalet hoppbackar",
+     :en "Number of jumps"},
+    :data-type "numeric",
+    :description
+    {:fi "Hyppyrien lukumäärä", :se "Antalet hoppbackar", :en ""}},
+   :table-tennis-count
+   {:name
+    {:fi "Pöytätennispöytien lkm",
+     :se "Antalet bord för bordtennis",
+     :en "Table tennis table count"},
+    :data-type "numeric",
+    :description
+    {:fi "Pingis-/pöytätennispöytien lukumäärä",
+     :se "Antal bordtennisbord (pingisbord)",
+     :en ""}},
+   :pool-max-depth-m
+   {:name
+    {:fi "1. altaan syvyys max m",
+     :se "Första bassängens max djup m",
+     :en "1. pool's depth max m"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan syvyys syvimmästä päästä metreinä",
+     :se "Första bassängens djupaste punkt i meter",
+     :en ""}},
+   :loudspeakers?
+   {:name      {:fi "Äänentoisto", :se "Ljudåtergivning", :en "Loudspeakers"},
+    :data-type "boolean",
+    :description
+    {:fi
+     "Onko liikuntapaikalla välineistö ja valmius kenttäkuulutuksiin",
+     :se
+     "Har motionsplatsen utrustning och färdighet till att göra utrop",
+     :en ""}},
+   :customer-service-point?
+   {:name
+    {:fi "Myynti- tai asiakaspalvelupiste",
+     :en "Sales or customer service point",
+     :se "Försäljnings- eller kundservicepunkt"},
+    :description
+    {:fi
+     "Liikuntapaikalla on pysyvä myynti- tai asiakaspalvelupiste, josta on saatavissa asiakaspalvelua. Myynti- tai asiakaspalvelupiste voi olla rajoitetusti auki liikuntapaikan käyttöaikojen puitteissa.",
+     :se
+     "Det finns en permanent försäljnings- eller kundservicestation på idrottsanläggningen där kundservice är tillgänglig. Försäljnings- eller kundservicestationen kan ha begränsade öppettider inom idrottsanläggningens användningstider.",
+     :en
+     "There is a permanent sales or customer service point at the sports facility, where customer service is available. The sales or customer service point may have limited opening hours within the usage hours of the sports facility."},
+    :data-type "boolean"},
+   :shotgun-shooting?
+   {:name
+    {:fi "Haulikkoammunta",
+     :se "Hagelgevärsskytte",
+     :en "Shotgun shooting"},
+    :data-type "boolean",
+    :description
+    {:fi "Haulikkoammuntamahdollisuus",
+     :se "Möjlighet för hagelskytte",
+     :en ""}},
+   :water-point
+   {:name        {:fi "Vesipiste", :en "Water point", :se "Vattenpunkt"},
+    :description {:fi "", :se "", :en ""},
+    :data-type   "enum",
+    :opts
+    {"year-round"
+     {:label {:fi "Ympärivuotinen", :se "Året runt", :en "Year-round"}},
+     "seasonal"
+     {:label
+      {:fi "Kausittaisesti käytössä",
+       :se "Säsongsvis i bruk",
+       :en "Seasonally in use"}}}},
+   :lit-slopes-count
+   {:name
+    {:fi "Valaistut rinteet lkm",
+     :se "Antalet belysta slalombackar",
+     :en "Number of lit slopes"},
+    :data-type "numeric",
+    :description
+    {:fi "Montako rinnettä on valaistu",
+     :se "Hur många belysta slalombackar finns det",
+     :en ""}},
+   :green?
+   {:name      {:fi "Puttausviheriö", :se "Puttnings green", :en "Green"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko golfkentällä puttausviheriö",
+     :se "Finns det en puttnings green vid golfbanan",
+     :en ""}},
+   :free-rifle-shooting?
+   {:name
+    {:fi "Pienoiskivääriammunta",
+     :se "Miniatyrgevärsskytte",
+     :en "Free rifle shooting"},
+    :data-type "boolean",
+    :description
+    {:fi "Pienoiskivääriammuntamahdollisuus",
+     :se "Möjlighet förminiatyrgevärskytte",
+     :en ""}},
+   :winter-usage?
+   {:name      {:fi "Talvikäyttö", :se "Vinterbruk", :en "Winter usage"},
+    :data-type "boolean",
+    :description
+    {:fi "Liikuntapaikka on käytössä myös talvisin",
+     :se "Motionsplatsen är i bruk under vintern",
+     :en ""}},
+   :ligthing?
+   {:name      {:fi "Valaistus", :se "Belysning", :en "Lighting"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikka valaistu",
+     :se "Är idrottsplatsen uppbelyst",
+     :en ""}},
+   :field-3-area-m2
+   {:name
+    {:fi "3. kentän ala m2",
+     :se "Tredje planens areal m2",
+     :en "3. field's area sq. m"},
+    :data-type "numeric",
+    :description
+    {:fi "3. kentän pinta-ala neliömetreinä",
+     :se "Tredje planens areal i kvadratmeter",
+     :en ""}},
+   :accessibility-info
+   {:name
+    {:fi "Linkki esteettömyystietoon",
+     :se "Länk till tillgänglighetsinformation",
+     :en "Link to accessibility information"},
+    :data-type "string",
+    :description
+    {:fi
+     "Syötä linkki verkkosivulle, jossa on kuvattu kohteen esteettömyyteen liittyvät tiedot",
+     :se
+     "Ange länken till webbplatsen där information om objektets tillgänglighet beskrivs.",
+     :en
+     "Enter the link to the website where the accessibility information of the location is described."}},
+   :covered-stand-person-count
+   {:name
+    {:fi "Katettua katsomoa hlö",
+     :se "Takbeläggda läktarens person mängd",
+     :en "Stand with roof"},
+    :data-type "numeric",
+    :description
+    {:fi "Katetun katsomon henkilömäärä",
+     :se "Hur mycket av läktaren är täckt med tak, antalet personer",
+     :en ""}},
+   :playground?
+   {:name      {:fi "Leikkipuisto", :se "Lekpark", :en "Playground"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko liikuntapaikan yhteydessä leikkipuisto",
+     :se "Finns det en lekpark i samband med idrottsplatsen",
+     :en ""}},
+   :handball-fields-count
+   {:name
+    {:fi "Käsipallokentät lkm",
+     :se "Antalet handbollsplaner",
+     :en "Handball fields pcs"},
+    :data-type "numeric",
+    :description
+    {:fi "Käsipallokenttien lukumäärä salissa",
+     :se "Antalet handbollsplaner som ryms i salen/hallen",
+     :en ""}},
+   :p-point
+   {:name      {:fi "P-piste", :se "P-punkt", :en "P point"},
+    :data-type "numeric",
+    :description
+    {:fi "Hyppyrimäen P-piste metreinä",
+     :se "Hoppbackens P-punkt i meter",
+     :en ""}},
+   :inruns-material
+   {:name
+    {:fi "Vauhtimäen latumateriaali",
+     :se "Överbackens spårmaterial",
+     :en "Inrun's material"},
+    :data-type "string",
+    :description
+    {:fi "Hyppyrimäen vauhtimäen materiaali",
+     :se "Hoppbackens spårmaterial vid överbacken",
+     :en ""}},
+   :pyramid-tables-count
+   {:name
+    {:fi "Pyramidipöydät lkm",
+     :se "Antal pyramidbord",
+     :en "Number of pyramid tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :basketball-field-type
+   {:name
+    {:fi "Koripallokentän tyyppi",
+     :se "Korgbollsplanens typ",
+     :en "Type of basketball field"},
+    :data-type "string",
+    :description
+    {:fi
+     "Onko liikuntapaikka normaali koripallokenttä, minikoripallokenttä vai yhden korin koripallokenttä",
+     :se
+     "Har idrottsplaten en normal korgbollsplan, mini-korgbollsplan eller bara en korg",
+     :en ""}},
+   :kaisa-tables-count
+   {:name
+    {:fi "Kaisapöydät lkm",
+     :se "Antal kaisabord",
+     :en "Number of kaisa tables"},
+    :data-type   "numeric",
+    :description {:fi "", :se "", :en ""}},
+   :volleyball-fields-count
+   {:name
+    {:fi "Lentopallokentät lkm",
+     :se "Antalet volleybollplaner",
+     :en "Volleyball field"},
+    :data-type "numeric",
+    :description
+    {:fi "Lentopallokenttien lukumäärä",
+     :se "Antalet volleybollplaner",
+     :en ""}},
+   :boat-places-count
+   {:name
+    {:fi "Venepaikat lkm", :se "Antalet båtplats", :en "Boat places"},
+    :data-type "numeric",
+    :description
+    {:fi "Venepaikkojen lukumäärä", :se "Antalet båtplatser", :en ""}},
+   :pool-temperature-c
+   {:name
+    {:fi "1. altaan lämpö c",
+     :se "Första bassängens temperatur c",
+     :en "1. pool's temperature c"},
+    :data-type "numeric",
+    :description
+    {:fi "1. altaan veden lämpötila celsiusasteina",
+     :se "Första bassängens vatten temperatur i celcius",
+     :en ""}},
+   :climbing-wall?
+   {:name      {:fi "Kiipeilyseinä", :se "Klättervägg", :en "Climbing wall"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko kohteessa kiipeilyseinä",
+     :se "Finns det en klättervägg på platsen",
+     :en "Is there a climbing wall at the location"}},
+   :ski-track-freestyle?
+   {:name
+    {:fi "Luistelu-ura", :se "Fristils spår", :en "Freestyle ski track"},
+    :data-type "boolean",
+    :description
+    {:fi "Vapaan tyylin latu-ura/luistelu-ura",
+     :se "Skidspår för fristil",
+     :en ""}},
+   :spinning-hall?
+   {:name      {:fi "Spinning-sali", :se "Spinning sal", :en "Spinning hall"},
+    :data-type "boolean",
+    :description
+    {:fi "Salissa spinning-varustus",
+     :se "Salen har spinning utrustning",
+     :en ""}},
+   :other-platforms?
+   {:name
+    {:fi "Muut hyppytelineet",
+     :se "Andra hoppställningar",
+     :en "Other platforms"},
+    :data-type "boolean",
+    :description
+    {:fi "Uimahyppytelineet rannalla",
+     :se "Hopptornen vid stranden",
+     :en ""}},
+   :school-use?
+   {:name
+    {:fi "Koululiikuntapaikka",
+     :se "Skolidrottsplats",
+     :en "Sport facility in school use"},
+    :data-type "boolean",
+    :description
+    {:fi "Liikuntapaikkaa käytetään koulujen liikuntatunneilla",
+     :se "Idrottsplatsen används under skolornas gymnastiktimmar",
+     :en ""}},
+   :highjump-places-count
+   {:name
+    {:fi "Korkeushyppypaikat lkm",
+     :se "Antalet höjdhopps platser",
+     :en "High jump"},
+    :data-type "numeric",
+    :description
+    {:fi "Korkeushppypaikkojen lukumäärä",
+     :se "Antalet höjdhoppsplatser",
+     :en ""}},
+   :light-roof?
+   {:name
+    {:fi "Kevytkate", :se "Lättvikts takläggning", :en "Light roof"},
+    :data-type "boolean",
+    :description
+    {:fi "Kentälle voidaan asentaa kevytkate tai muu tilapäinen katos",
+     :se
+     "På planen kan installeras en lättvikts takläggning eller något annat tillfälligt tak",
+     :en ""}},
+   :route-length-km
+   {:name
+    {:fi "Reitin pituus km",
+     :se "Ruttens längd km",
+     :en "Route's length km"},
+    :data-type "numeric",
+    :description
+    {:fi "Reitin pituus kilometreinä",
+     :se "Ruttens längd i kilometer",
+     :en ""}},
+   :field-3-flexible-rink?
+   {:name
+    {:fi "3. kenttä: onko joustokaukalo?",
+     :se "Fält 3: finns det flexibel rink?",
+     :en "Field 3: is there a flexible rink?"},
+    :data-type   "boolean",
+    :description {:fi "", :se "", :en ""}},
+   :exercise-machines-count
+   {:name
+    {:fi "Kuntoilulaitteet lkm",
+     :se "Antalet gym apparater",
+     :en "Number of exercise machines"},
+    :data-type "numeric",
+    :description
+    {:fi "Kuntoilulaitteiden lukumäärä",
+     :se "Antalet gym apparater",
+     :en ""}},
+   :track-type
+   {:name        {:fi "Ratatyyppi", :se "Typ av bana", :en "Type of track"},
+    :data-type   "string",
+    :description {:fi "Radan tyyppi", :se "Banans typ", :en ""}},
+   :training-spot-surface-material
+   {:name
+    {:fi "Suorituspaikan pintamateriaali",
+     :se "Prestationsplatsens ytmaterial",
+     :en "Surface material for training spot"},
+    :data-type "string",
+    :description
+    {:fi "Esim. keihäänheittopaikan pintamateriaali/päällys",
+     :se "T.ex. spjutkastningsplatsens ytmaterial/överläggning",
+     :en ""}},
+   :range?
+   {:name
+    {:fi "Harjoitusalue/range", :se "Övningszon/Range", :en "Range"},
+    :data-type "boolean",
+    :description
+    {:fi "Onko golfin harjoitusalue/range",
+     :se "Finns det övningsområde/range för golf",
+     :en ""}},
+   :track-length-m
+   {:name
+    {:fi "Radan pituus m",
+     :se "Banans längd i m",
+     :en "Length of track m"},
+    :data-type "numeric",
+    :description
+    {:fi "Juoksuradan, pyöräilyradan tms. pituus metreinä",
+     :se "Löpbanans, rundbanans el.dyl. längd i meter",
+     :en ""}}})
 
 (def used
   (let [used (set (mapcat (comp keys :props second) types/all))]

--- a/webapp/src/cljc/lipas/data/prop_types.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types.cljc
@@ -12,14 +12,14 @@
     :description
     {:fi "Sisäliikuntatilan korkeus metreinä (matalin kohta)",
      :se "Motionssalens höjd i meter (från lägsta punkten)",
-     :en ""}},
+     :en "Height of the indoor sports facility in meters (lowest point)"}},
    :heating?
    {:name      {:fi "Lämmitys", :se "Uppvärmning", :en "Heating"},
     :data-type "boolean",
     :description
     {:fi "Onko liikuntapaikassa lämmitys",
      :se "Är idrottsplatsen utrustad med uppvärmning",
-     :en ""}},
+     :en "Is there heating in the sports facility"}},
    :field-2-area-m2
    {:name
     {:fi "2. kentän ala m2",
@@ -29,7 +29,7 @@
     :description
     {:fi "2. kentän pinta-ala neliömetreinä",
      :se "Andra planens areal i kvadratmeter",
-     :en ""}},
+     :en "2. field's area in square meters"}},
    :surface-material
    {:name
     {:fi "Pintamateriaali", :se "Ytmaterial", :en "Surface material"},
@@ -38,8 +38,8 @@
     {:fi
      "Liikunta-alueiden pääasiallinen pintamateriaali - tarkempi kuvaus liikuntapaikan eri tilojen pintamateriaalista voidaan antaa pintamateriaalin lisätietokentässä",
      :se
-     "Idrotts områdets ytmaterial. Friidrottsplanens mittplans pålägg.",
-     :en ""}},
+     "Huvudsakligt ytskikt för idrottsområden - en mer detaljerad beskrivning av ytskiktet i olika delar av idrottsanläggningen kan ges i tilläggsinformationsfältet för ytskikt.",
+     :en "Primary surface material of sports areas - a more detailed description of the surface material in different parts of the sports facility can be provided in the additional information field for surface material."}},
    :basketball-fields-count
    {:name
     {:fi "Koripallokentät lkm",
@@ -49,7 +49,7 @@
     :description
     {:fi "Koripallokenttien lukumäärä",
      :se "Antalet korgbollsplaner i salen",
-     :en ""}},
+     :en "The number of basketball courts"}},
    :surface-material-info
    {:name
     {:fi "Pintamateriaali lisätieto",
@@ -59,8 +59,8 @@
     :description
     {:fi
      "Syötä pintamateriaalin tarkempi kuvaus-  esim. tekonurmen yleisnimitys ”esim. Kumirouhetekonurmi”, tuotenimi ja tieto täytemateriaalin laadusta (esim. biohajoava/perinteinen kumirouhe).",
-     :se "Ytterilgare information om ytmaterialen",
-     :en ""}},
+     :se "Ange en mer detaljerad beskrivning av ytskiktet - till exempel den allmänna beteckningen för konstgräs t.ex. gummigranulatkonstgräs, produktnamn och information om fyllnadsmaterialets kvalitet (t.ex. biologiskt nedbrytbart/traditionellt gummigranulat).",
+     :en "Enter a more detailed description of the surface material - for example, the general name for artificial turf “e.g., rubber granulate artificial turf,” product name, and information about the quality of the infill material (e.g., biodegradable/traditional rubber granulate)."}},
    :height-of-basket-or-net-adjustable?
    {:name
     {:fi "Korin tai verkon korkeus säädettävissä",
@@ -86,14 +86,14 @@
     {:fi "Hyppyrimäen tyyppi (harjoitus, pienmäki, normaali, suurmäki)",
      :se
      "Typ av hoppbacke (övningsbacke, liten, normalbacke, storbacke)",
-     :en ""}},
+     :en "Type of ski jump (training hill, small hill, normal hill, large hill)"}},
    :lifts-count
    {:name      {:fi "Hissit lkm", :se "Antalet skidliftar", :en "Lifts"},
     :data-type "numeric",
     :description
     {:fi "Hiihtohissien lukumäärä",
      :se "Antal skidliftar i skidcentrumet",
-     :en ""}},
+     :en "Number of ski lifts"}},
    :field-3-length-m
    {:name
     {:fi "3. kentän pituus m",
@@ -103,17 +103,17 @@
     :description
     {:fi "3. kentän pituus metreinä",
      :se "Tredje planens längd i meter",
-     :en ""}},
+     :en "Length of the third field in meters"}},
    :pool-tracks-count
    {:name
     {:fi "1. altaan radat lkm",
      :se "Första bassängens antal banor",
-     :en "Courses in 1. pool"},
+     :en "Lanes in 1. pool"},
     :data-type "numeric",
     :description
     {:fi "1. altaan ratojen lukumäärä",
      :se "Antal banor i första bassängen",
-     :en ""}},
+     :en "Number of lanes in the first pool"}},
    :field-2-length-m
    {:name
     {:fi "2. kentän pituus m",
@@ -123,7 +123,7 @@
     :description
     {:fi "2. kentän pituus metreinä",
      :se "Andra planens längd i meter",
-     :en ""}},
+     :en "Length of the second field in meters"}},
    :plastic-outrun?
    {:name
     {:fi "Muovitettu alastulo",
@@ -133,7 +133,7 @@
     :description
     {:fi "Muovitettu hyppyrimäen alastulopaikka",
      :se "Hoppbacken har plast-belagd landningsplats",
-     :en ""}},
+     :en "Plastic-coated landing area of the ski jump"}},
    :automated-timing?
    {:name
     {:fi "Automaattinen ajanotto",
@@ -143,28 +143,28 @@
     :description
     {:fi "Varustus automaattiseen ajanottoon",
      :se "Utrustning för automatisk tidtagning",
-     :en ""}},
+     :en "Equipment for automatic timing"}},
    :freestyle-slope?
    {:name      {:fi "Kumparerinne", :se "Puckelpist", :en "Freestyle slope"},
     :data-type "boolean",
     :description
     {:fi "Hiihtokeskuksessa on kumparerinne",
      :se "Skidcentret har en puckelpist",
-     :en ""}},
+     :en "The ski resort has a mogul slope."}},
    :kiosk?
    {:name      {:fi "Kioski", :se "Kiosk", :en "Kiosk"},
     :data-type "boolean",
     :description
     {:fi "Onko liikuntapaikalla kioski tai vastaava",
      :se "Har idrottsplatsen en kiosk eller något liknande",
-     :en ""}},
+     :en "Is there a kiosk or similar facility at the sports venue"}},
    :summer-usage?
    {:name      {:fi "Kesäkäyttö", :se "I sommarbruk", :en "Summer usage"},
     :data-type "boolean",
     :description
     {:fi "Käytössä myös kesäisin",
-     :se "Används också under sommaren",
-     :en ""}},
+     :se "Tillgänglig även på sommaren",
+     :en "Available also in the summer"}},
    :stand-capacity-person
    {:name
     {:fi "Katsomon kapasiteetti hlö",
@@ -174,7 +174,7 @@
     :description
     {:fi "Katsomon koko kapasiteetti, henkilölukumäärä",
      :se "Läktarens hela person kapasitet",
-     :en ""}},
+     :en "Total capacity of the stands, number of people"}},
    :free-use?
    {:name
     {:fi "Kohde on vapaasti käytettävissä",
@@ -295,7 +295,7 @@
     :description
     {:fi "Tenniskenttien lukumäärä",
      :se "Antalet tennisplaner",
-     :en ""}},
+     :en "Number of tennis courts"}},
    :ski-service?
    {:name      {:fi "Suksihuolto", :se "Skidservice", :en "Ski service"},
     :data-type "boolean",
@@ -312,21 +312,21 @@
     :description
     {:fi "1. kentän pituus metreinä",
      :se "Första planens längd i meter",
-     :en ""}},
+     :en "Length of the first field in meters"}},
    :mirror-wall?
    {:name      {:fi "Peiliseinä", :se "Spegelvägg", :en "Mirror wall"},
     :data-type "boolean",
     :description
     {:fi "Liikuntatilassa vähintään yhdellä seinällä on kiinteät peilit",
-     :se "",
-     :en ""}},
+     :se "I idrottsutrymmet finns fasta speglar på minst en vägg.",
+     :en "The sports facility has fixed mirrors on at least one wall."}},
    :finish-line-camera?
    {:name      {:fi "Maalikamera", :se "Målkamera", :en "Finish line camera"},
     :data-type "boolean",
     :description
     {:fi "Liikuntapaikalla on maalikamera",
      :se "Idrottsplatsen har en målkamera",
-     :en ""}},
+     :en "The sports facility has a finish line camera."}},
    :travel-mode-info
    {:name
     {:fi "Kulkutavat, lisätieto",
@@ -344,7 +344,7 @@
     :description
     {:fi "Parkkipaikka käytettävissä",
      :se "Tillgänglig parkeringsplats",
-     :en ""}},
+     :en "Parking available"}},
    :canoeing-club?
    {:name      {:fi "Melontaseura", :se "", :en "Canoeing club"},
     :data-type "boolean",
@@ -373,7 +373,7 @@
     :description
     {:fi "Kiipeilyreittien lukumäärä",
      :se "Antalet klättringsrutter",
-     :en ""}},
+     :en "Number of climbing routes"}},
    :outdoor-exercise-machines?
    {:name
     {:fi "Kuntoilutelineitä",
@@ -383,7 +383,7 @@
     :description
     {:fi "Onko reitin varrella kuntoilulaitteita",
      :se "Finns det gym apparater längs rutten",
-     :en ""}},
+     :en "Are there fitness equipment along the route"}},
    :automated-scoring?
    {:name
     {:fi "Kirjanpitoautomaatti",
@@ -393,7 +393,7 @@
     :description
     {:fi "Keilaradalla on sähköinen pistelasku",
      :se "Bowlingbanan har elektroniskt poängräknings system",
-     :en ""}},
+     :en "The bowling alley has electronic scoring."}},
    :mobile-orienteering?
    {:name
     {:fi "Mobiilisuunnistusmahdollisuus",
@@ -408,14 +408,14 @@
     :description
     {:fi "Juoksuradan, pyöräilyradan tms. leveys metreinä",
      :se "Löpbanan, rundbanan el.dyl. bredd i meter",
-     :en ""}},
+     :en "Width of the running track, cycling track, etc., in meters"}},
    :ice-climbing?
    {:name      {:fi "Jääkiipeily", :se "Isklättring", :en "Ice climbing"},
     :data-type "boolean",
     :description
     {:fi "Onko jääkiipeily mahdollista kiipeilypaikalla",
      :se "Finns det möjlighet för isklättring vid klättringsplatsen",
-     :en ""}},
+     :en "Is ice climbing possible at the climbing site"}},
    :free-use {:name {:fi "Kohde on vapaasti käytettävissä"}},
    :field-length-m
    {:name
@@ -426,7 +426,7 @@
     :description
     {:fi "Kentän/kenttien pituus mahdollisine turva-alueineen metreinä",
      :se "Planens/planernas längd i meter",
-     :en ""}},
+     :en "Length of the field(s) including any safety areas in meters"}},
    :skijump-hill-material
    {:name
     {:fi "Vauhtimäen rakennemateriaali",
@@ -436,7 +436,7 @@
     :description
     {:fi "Vauhtimäen rakennemateriaali",
      :se "Överbackens konstruktionsmaterial (backhoppning)",
-     :en ""}},
+     :en "Construction material of the inrun"}},
    :carom-tables-count
    {:name
     {:fi "Karapöydät lkm",
@@ -453,7 +453,7 @@
     :description
     {:fi "Pisimmän rinteen pituus metreinä",
      :se "Längsta slalombackens längd i meter",
-     :en ""}},
+     :en "Length of the longest slope in meters"}},
    :circular-lanes-count
    {:name
     {:fi "Kiertävät radat lkm",
@@ -463,7 +463,7 @@
     :description
     {:fi "Kiertävien juoksuratojen lukumäärä",
      :se "Antalet cirkulerande löpbanor",
-     :en ""}},
+     :en "Number of circular running tracks"}},
    :boat-launching-spot?
    {:name
     {:fi "Veneen vesillelaskupaikka",
@@ -473,7 +473,7 @@
     :description
     {:fi "Mahdollisuus veneen vesillelaskuun",
      :se "Sjösättningsplats för båtar",
-     :en ""}},
+     :en "Possibility for boat launching"}},
    :parkour-hall-equipment-and-structures
    {:name
     {:fi "Parkour-salin varustelu ja rakenteet",
@@ -529,8 +529,8 @@
        "Område utrustat med gymmaskiner och utrustning för styrketräning."}}},
     :description
     {:fi "Valitse parkour-salissa olevat rakenteet tai varusteet",
-     :se "",
-     :en ""}},
+     :se "Välj de strukturer eller utrustningar som finns i parkourhallen",
+     :en "Select the structures or equipment available in the parkour gym"}},
    :ski-track-traditional?
    {:name
     {:fi "Perinteinen latu",
@@ -540,7 +540,7 @@
     :description
     {:fi "Perinteisen tyylin hiihtomahdollisuus/latu-ura",
      :se "Möjlighet att skida klassisk stil",
-     :en ""}},
+     :en "Classic style skiing track available"}},
    :altitude-difference
    {:name
     {:fi "Korkeusero m",
@@ -550,7 +550,7 @@
     :description
     {:fi "Reitin korkeusero metreinä",
      :se "Ruttens höjdskillnad i meter",
-     :en ""}},
+     :en "Elevation difference of the route in meters"}},
    :climbing-wall-height-m
    {:name
     {:fi "Kiipeilyseinän korkeus m",
@@ -560,7 +560,7 @@
     :description
     {:fi "Kiipeilyseinän korkeus metreinä (max)",
      :se "Klätterväggens höjd i meter (max)",
-     :en ""}},
+     :en "Height of the climbing wall in meters (max)"}},
    :route-width-m
    {:name
     {:fi "Reitin leveys m",
@@ -588,14 +588,14 @@
     :description
     {:fi "Hoidetun rannan pituus metreinä",
      :se "Skötta strandens längd i meter",
-     :en ""}},
+     :en "Length of the maintained beach in meters"}},
    :match-clock?
    {:name      {:fi "Ottelukello", :se "Matchklocka", :en "Match clock"},
     :data-type "boolean",
     :description
     {:fi "Onko liikuntapaikalla ottelukello",
      :se "Finns det en matchklocka vid idrottsplatsen",
-     :en ""}},
+     :en "Is there a match clock at the sports facility"}},
    :sprint-track-length-m
    {:name
     {:fi "Etusuoran pituus m",
@@ -605,7 +605,7 @@
     :description
     {:fi "Juoksuradan etusuoran pituus",
      :se "Längden på löpbanans raksträcka",
-     :en ""}},
+     :en "Length of the home straight of the running track"}},
    :inner-lane-length-m
    {:name
     {:fi "Sisäradan pituus m",
@@ -615,7 +615,7 @@
     :description
     {:fi "Sisäradan pituus kiertävissä radoissa",
      :se "Längden på innerbanan i de cirkulerande banorna",
-     :en ""}},
+     :en "Length of the inside lane in circular tracks"}},
    :discus-throw-places
    {:name
     {:fi "Kiekonheittopaikat lkm",
@@ -625,7 +625,7 @@
     :description
     {:fi "Kiekonheittopaikkojen lukumäärä",
      :se "Antalet diskuskastningsplatser",
-     :en ""}},
+     :en "Number of discus throw areas"}},
    :fields-count
    {:name
     {:fi "Kenttien lkm", :se "Antalet planer", :en "Number of fields"},
@@ -633,7 +633,7 @@
     :description
     {:fi "Montako saman tyypin kenttää liikuntapaikassa on",
      :se "Hur många planer av samma typ har motionsplatsen",
-     :en ""}},
+     :en "How many of the same type of fields are there at the sports facility"}},
    :field-1-width-m
    {:name
     {:fi "1. kentän leveys m",
@@ -643,7 +643,7 @@
     :description
     {:fi "1. kentän leveys metreinä",
      :se "Första planens bredd i meter",
-     :en ""}},
+     :en "Width of the first field in meters"}},
    :field-3-width-m
    {:name
     {:fi "3. kentän leveys m",
@@ -653,7 +653,7 @@
     :description
     {:fi "3. kentän leveys metreinä",
      :se "Tredje planens bredd i meter",
-     :en ""}},
+     :en "Width of the third field in meters"}},
    :field-2-width-m
    {:name
     {:fi "2. kentän leveys m",
@@ -663,7 +663,7 @@
     :description
     {:fi "2. kentän leveys metreinä",
      :se "Andra planens bredd i meter",
-     :en ""}},
+     :en "Width of the second field in meters"}},
    :badminton-courts-count
    {:name
     {:fi "Sulkapallokentät lkm",
@@ -673,7 +673,7 @@
     :description
     {:fi "Sulkapallokenttien lukumäärä salissa",
      :se "Antalet badmintonsplaner i salen",
-     :en ""}},
+     :en "Number of badminton courts in the hall"}},
    :fitness-stairs-length-m
    {:name
     {:fi "Kuntoportaiden pituus m",
@@ -690,8 +690,8 @@
     :description
     {:fi
      "Liikuntapaikka on asiakkaiden käytettävissä esim. kulkukortilla ilman henkilökunnan läsnäoloa. Vapaa asiakaskäyttö voi olla rajattu tiettyihin kellonaikoihin.",
-     :se "",
-     :en ""}},
+     :se "Idrottsanläggningen är tillgänglig för kunder, t.ex. med ett passerkort, utan personal närvarande. Fri kundanvändning kan vara begränsad till vissa tider.",
+     :en "The sports facility is available for customer use, e.g., with an access card, without staff presence. Free customer access may be limited to certain hours."}},
    :hammer-throw-places-count
    {:name
     {:fi "Moukarinheittopaikat lkm",
@@ -701,7 +701,7 @@
     :description
     {:fi "Moukarinheittopaikkojen lukumäärä",
      :se "Antal platser för att släggkastning",
-     :en ""}},
+     :en "Number of hammer throw areas"}},
    :may-be-shown-in-harrastuspassi-fi?
    {:name
     {:fi "Saa julkaista Harrastuspassi.fi-sovelluksessa",
@@ -733,7 +733,7 @@
     :description
     {:fi "1. altaan syvyys matalimmasta päästä metreinä",
      :se "Första bassängens grundaste punkt i meter.",
-     :en ""}},
+     :en "The depth of the shallowest end of the pool in meters."}},
    :padel-courts-count
    {:name
     {:fi "Padelkentät lkm",
@@ -754,7 +754,7 @@
     :description
     {:fi "Kaukaloiden lukumäärä",
      :se "Antalet rinkar (hockey) det finns vid idrottsplatsen",
-     :en ""}},
+     :en "The number of rinks."}},
    :field-1-area-m2
    {:name
     {:fi "1. kentän ala m2",
@@ -764,14 +764,14 @@
     :description
     {:fi "1. kentän pinta-ala neliömetreinä",
      :se "Första planens areal i kvadratmeter",
-     :en ""}},
+     :en "The area of the field in square meters."}},
    :k-point
    {:name      {:fi "K-piste", :se "K-punkt", :en "K point"},
     :data-type "numeric",
     :description
     {:fi "Hyppyrimäen k-piste metreinä",
      :se "Hoppbackens k-punkt i meter",
-     :en ""}},
+     :en "The K-point of the ski jumping hill in meters"}},
    :polevault-places-count
    {:name
     {:fi "Seiväshyppypaikat lkm",
@@ -781,7 +781,7 @@
     :description
     {:fi "Seiväshyppypaikkojen lukumäärä",
      :se "Antalet stavhoppningsplatser",
-     :en ""}},
+     :en "The number of pole vault areas."}},
    :group-exercise-rooms-count
    {:name
     {:fi "Ryhmäliikuntatilat lkm",
@@ -791,7 +791,7 @@
     :description
     {:fi "Liikuntasalien ja ryhmäliikuntatilojen lukumäärä",
      :se "Antalet gymnastiksalar och gruppmotions utrymmen",
-     :en ""}},
+     :en "The number of sports halls and group exercise spaces"}},
    :snowpark-or-street?
    {:name
     {:fi "Parkki", :se "Trick/street pist", :en "Snow park/street"},
@@ -800,7 +800,7 @@
     {:fi
      "Onko rinnehiihtokeskuksessa ns. temppurinne, snowpark tai vastaava",
      :se "Har skidcentrumet en trickbana, snowpark eller något liknande",
-     :en ""}},
+     :en "Is there a so-called adventure slope, snowpark, or similar area in the ski resort"}},
    :field-2-flexible-rink?
    {:name
     {:fi "2. kenttä: onko joustokaukalo?",
@@ -835,7 +835,7 @@
     :description
     {:fi "Suurin korkeusero rinteissä",
      :se "Största höjdskillnaden i slalombackorna",
-     :en ""}},
+     :en "The greatest elevation difference in the slopes"}},
    :bowling-lanes-count
    {:name
     {:fi "Keilaradat lkm",
@@ -853,7 +853,7 @@
     :description
     {:fi "Ilma-aseammuntamahdollisuus",
      :se "Möjlighet för luftgevärsskytte",
-     :en ""}},
+     :en "Availability of air gun shooting"}},
    :gymnastic-routines-count
    {:name
     {:fi "Telinevoimistelusarjat lkm",
@@ -863,14 +863,14 @@
     :description
     {:fi "Telinevoimistelun telinesarjojen lukumäärä",
      :se "Antalet redskap för redskapsgymnastik",
-     :en ""}},
+     :en "The number of apparatus for gymnastics routines"}},
    :toilet?
    {:name      {:fi "Yleisö-wc", :se "Allmän toalett", :en "Toilet"},
     :data-type "boolean",
     :description
     {:fi "Onko kohteessa yleiseen käyttöön tarkoitettuja wc-tiloja?",
      :se "Är allmänna toaletten i användning",
-     :en ""}},
+     :en "Are there public restroom facilities available at the location"}},
    :gymnastics-space?
    {:name
     {:fi "Telinevoimistelutila",
@@ -880,7 +880,7 @@
     :description
     {:fi "Onko liikuntasalissa myös telinevoimistelutila",
      :se "Har motionssalen också område/utrymme för redskapsgymnastik",
-     :en ""}},
+     :en "Is there also a gymnastics area in the sports hall"}},
    :snooker-tables-count
    {:name
     {:fi "Snookerpöydät lkm",
@@ -895,14 +895,14 @@
     {:fi
      "Onko ratsastuskentällä/maneesissa esteratsastukseen soveltuva varustus",
      :se "Har ridplanen/ridhuset utrustning för banhoppning",
-     :en ""}},
+     :en "Is there equipment suitable for show jumping in the riding arena/indoor arena"}},
    :shower?
    {:name      {:fi "Suihku", :se "Dusch", :en "Shower"},
     :data-type "boolean",
     :description
     {:fi "Onko suihku käytettävissä",
      :se "Är duschen i användning",
-     :en ""}},
+     :en "Is there a shower available"}},
    :rest-places-count
    {:name
     {:fi "Taukopaikat lkm",
@@ -912,7 +912,7 @@
     :description
     {:fi "Montako taukopaikkaa reitin varrella on",
      :se "Hur många viloplatser finns det längs med rutten",
-     :en ""}},
+     :en "How many rest areas are there along the route"}},
    :changing-rooms?
    {:name      {:fi "Pukukopit", :se "Omklädningsrum", :en "Changing rooms"},
     :data-type "boolean",
@@ -925,7 +925,7 @@
     :description
     {:fi "Pistooliammuntamahdollisuus",
      :se "Möjlighet för pistolskytte",
-     :en ""}},
+     :en "Availability of pistol shooting"}},
    :halfpipe-count
    {:name
     {:fi "Halfpipe lkm", :se "Antal halfpipe", :en "Halfpipe count"},
@@ -933,7 +933,7 @@
     :description
     {:fi "Halfpipe, superpipe lukumäärät",
      :se "Antal halfpipe",
-     :en ""}},
+     :en "The number of halfpipes and superpipes"}},
    :shooting-positions-count
    {:name
     {:fi "Ampumapaikat lkm",
@@ -943,7 +943,7 @@
     :description
     {:fi "Montako ampumapaikkaa liikuntareitin varrella on",
      :se "Hur många skytteplatser finns det längs motionsrutten",
-     :en ""}},
+     :en "How many shooting spots are there along the exercise route"}},
    :running-track-surface-material
    {:name
     {:fi "Juoksuradan pintamateriaali",
@@ -953,7 +953,7 @@
     :description
     {:fi "Juoksuradan pintamateriaali/päällyste",
      :se "Löpbanans ytmaterial/pålägg",
-     :en ""}},
+     :en "The surface material/overlay of the running track"}},
    :boating-service-class
    {:name
     {:fi "Venesatama- tai laituriluokka",
@@ -1046,7 +1046,7 @@
     :description
     {:fi "Montako kilometriä reitistä on valaistua",
      :se "Hur många km av rutten är uppbelyst",
-     :en ""}},
+     :en "How many kilometers of the route are illuminated"}},
    :area-m2
    {:name
     {:fi "Liikuntapinta-ala m2",
@@ -1056,7 +1056,7 @@
     :description
     {:fi "Liikuntapaikan liikuntapinta-ala, neliömetreinä",
      :se "Idrottsplatsens areal i kvadratmeter",
-     :en ""}},
+     :en "The sports area of the facility in square meters"}},
    :field-width-m
    {:name
     {:fi "Kentän leveys m", :se "Planens bredd m", :en "Width of field"},
@@ -1064,14 +1064,14 @@
     :description
     {:fi "Kentän/kenttien leveys mahdollisine turva-alueineen metreinä",
      :se "Planens/planernas bredd i meter",
-     :en ""}},
+     :en "The width of the field(s), including any safety zones, in meters"}},
    :cosmic-bowling?
    {:name      {:fi "Hohtokeilaus", :se "Discobowling", :en "Cosmic bowling"},
     :data-type "boolean",
     :description
     {:fi "Onko keilaradalla hohtokeilausmahdollisuus",
      :se "Har bowlingsbanan möjlighet för discobowling",
-     :en ""}},
+     :en "Is there an option for glow bowling at the bowling alley"}},
    :travel-modes
    {:name      {:fi "Kulkutavat", :se "Resesätt", :en "Travel Modes"},
     :data-type "enum-coll",
@@ -1126,7 +1126,7 @@
      "Uimaranta, joka täyttää EU-kriteerit uimaveden laadusta ja valvonnasta",
      :se
      "Badstrand, som fyller EU-kriterierna med kvaliteten och övervakningen av badvattnet",
-     :en ""}},
+     :en "A swimming beach that meets EU criteria for bathing water quality and monitoring"}},
    :rifle-shooting?
    {:name
     {:fi "Kivääriammunta", :se "Gevärbana", :en "Rifle shooting places"},
@@ -1134,7 +1134,7 @@
     :description
     {:fi "Kivääriammuntamahdollisuus",
      :se "Möjlighet för gevärskytte",
-     :en ""}},
+     :en "Availability of rifle shooting"}},
    :swimming-pool-count
    {:name
     {:fi "Altaiden lukumäärä",
@@ -1145,7 +1145,7 @@
     {:fi
      "Altaiden lukumäärä yhteensä. Syötä tieto tai laske automaattisesti.",
      :se "Antalet simbassänger, också terapi bassänger",
-     :en ""}},
+     :en "Total number of pools. Enter the information or calculate automatically."}},
    :pool-water-area-m2
    {:name
     {:fi "Vesipinta-ala m2",
@@ -1326,7 +1326,7 @@
     :description
     {:fi "1. altaan/pääaltaan pituus metreinä",
      :se "Första/huvudbassängens längd i meter",
-     :en ""}},
+     :en "The length of the pool/main pool in meters."}},
    :other-pools-count
    {:name
     {:fi "Muut altaat lkm",
@@ -1363,7 +1363,7 @@
     :description
     {:fi "Squash-kenttien lukumäärä",
      :se "Antalet squash-planer",
-     :en ""}},
+     :en "The number of squash courts"}},
    :changing-rooms-m2
    {:name
     {:fi "Pukukoppien kokonaispinta-ala m²",
@@ -1388,14 +1388,14 @@
     :description
     {:fi "Nyrkkeilykehien lukumäärä",
      :se "Antalet boxningsringar",
-     :en ""}},
+     :en "The number of boxing rings"}},
    :ice-reduction?
    {:name      {:fi "Jäätymisenesto", :se "Frostskydd", :en "Ice reduction"},
     :data-type "boolean",
     :description
     {:fi "Jäätymisenestojärjestelmä talviuintipaikassa",
      :se "Har vinterbadplatsen mekanism för frostskydd",
-     :en ""}},
+     :en "Anti-freeze system at the winter swimming location"}},
    :activity-service-company?
    {:name
     {:fi "Ohjelmapalveluyritys", :se "", :en "Activity service company"},
@@ -1418,7 +1418,7 @@
     :description
     {:fi "Miekkailualustojen lukumäärä",
      :se "Antal underlägg avsedda för fäktning",
-     :en ""}},
+     :en "The number of fencing mats"}},
    :weight-lifting-spots-count
    {:name
     {:fi "Painonnostopaikat/nostolavat lkm",
@@ -1441,7 +1441,7 @@
     :description
     {:fi "Alastulomonttujen lukumäärä",
      :se "Antalet landnigsgropar",
-     :en ""}},
+     :en "The number of landing pits"}},
    :bike-orienteering?
    {:name
     {:fi "Pyöräsuunnistus mahdollista",
@@ -1455,14 +1455,14 @@
     :description
     {:fi "Onko rinnehiihtokeskuksessa ohjaskelkkamäki",
      :se "Har skidcentrumet en rodelbana",
-     :en ""}},
+     :en "Is there a guided sledding slope at the ski resort?"}},
    :sauna?
    {:name      {:fi "Sauna", :se "Bastu", :en "Sauna"},
     :data-type "boolean",
     :description
     {:fi "Onko sauna käytettävissä",
      :se "Är bastun i användning",
-     :en ""}},
+     :en "Is there a sauna available"}},
    :jumps-count
    {:name
     {:fi "Hyppyrien lkm",
@@ -1480,7 +1480,7 @@
     :description
     {:fi "Pingis-/pöytätennispöytien lukumäärä",
      :se "Antal bordtennisbord (pingisbord)",
-     :en ""}},
+     :en "The number of table tennis tables"}},
    :pool-max-depth-m
    {:name
     {:fi "1. altaan syvyys max m",
@@ -1490,7 +1490,7 @@
     :description
     {:fi "1. altaan syvyys syvimmästä päästä metreinä",
      :se "Första bassängens djupaste punkt i meter",
-     :en ""}},
+     :en "The depth of the deepest end of the pool in meter"}},
    :loudspeakers?
    {:name      {:fi "Äänentoisto", :se "Ljudåtergivning", :en "Loudspeakers"},
     :data-type "boolean",
@@ -1499,7 +1499,7 @@
      "Onko liikuntapaikalla välineistö ja valmius kenttäkuulutuksiin",
      :se
      "Har motionsplatsen utrustning och färdighet till att göra utrop",
-     :en ""}},
+     :en "Does the sports facility have equipment and readiness for making announcements"}},
    :customer-service-point?
    {:name
     {:fi "Myynti- tai asiakaspalvelupiste",
@@ -1522,7 +1522,7 @@
     :description
     {:fi "Haulikkoammuntamahdollisuus",
      :se "Möjlighet för hagelskytte",
-     :en ""}},
+     :en "Availability of shotgun shooting"}},
    :water-point
    {:name        {:fi "Vesipiste", :en "Water point", :se "Vattenpunkt"},
     :description {:fi "", :se "", :en ""},
@@ -1544,14 +1544,14 @@
     :description
     {:fi "Montako rinnettä on valaistu",
      :se "Hur många belysta slalombackar finns det",
-     :en ""}},
+     :en "How many slopes are illuminated"}},
    :green?
    {:name      {:fi "Puttausviheriö", :se "Puttnings green", :en "Green"},
     :data-type "boolean",
     :description
     {:fi "Onko golfkentällä puttausviheriö",
      :se "Finns det en puttnings green vid golfbanan",
-     :en ""}},
+     :en "Is there a putting green on the golf course"}},
    :free-rifle-shooting?
    {:name
     {:fi "Pienoiskivääriammunta",
@@ -1561,7 +1561,7 @@
     :description
     {:fi "Pienoiskivääriammuntamahdollisuus",
      :se "Möjlighet förminiatyrgevärskytte",
-     :en ""}},
+     :en "Availability of small bore rifle shooting"}},
    :winter-usage?
    {:name      {:fi "Talvikäyttö", :se "Vinterbruk", :en "Winter usage"},
     :data-type "boolean",
@@ -1575,7 +1575,7 @@
     :description
     {:fi "Onko liikuntapaikka valaistu",
      :se "Är idrottsplatsen uppbelyst",
-     :en ""}},
+     :en "Is the sports facility illuminated"}},
    :field-3-area-m2
    {:name
     {:fi "3. kentän ala m2",
@@ -1585,7 +1585,7 @@
     :description
     {:fi "3. kentän pinta-ala neliömetreinä",
      :se "Tredje planens areal i kvadratmeter",
-     :en ""}},
+     :en "The area of the field in square meters"}},
    :accessibility-info
    {:name
     {:fi "Linkki esteettömyystietoon",
@@ -1608,14 +1608,14 @@
     :description
     {:fi "Katetun katsomon henkilömäärä",
      :se "Hur mycket av läktaren är täckt med tak, antalet personer",
-     :en ""}},
+     :en "The seating capacity of the covered grandstand"}},
    :playground?
    {:name      {:fi "Leikkipuisto", :se "Lekpark", :en "Playground"},
     :data-type "boolean",
     :description
     {:fi "Onko liikuntapaikan yhteydessä leikkipuisto",
      :se "Finns det en lekpark i samband med idrottsplatsen",
-     :en ""}},
+     :en "Is there a playground associated with the sports facility"}},
    :handball-fields-count
    {:name
     {:fi "Käsipallokentät lkm",
@@ -1625,14 +1625,14 @@
     :description
     {:fi "Käsipallokenttien lukumäärä salissa",
      :se "Antalet handbollsplaner som ryms i salen/hallen",
-     :en ""}},
+     :en "The number of handball courts in the hall"}},
    :p-point
    {:name      {:fi "P-piste", :se "P-punkt", :en "P point"},
     :data-type "numeric",
     :description
     {:fi "Hyppyrimäen P-piste metreinä",
      :se "Hoppbackens P-punkt i meter",
-     :en ""}},
+     :en "The P-point of the ski jumping hill in meters"}},
    :inruns-material
    {:name
     {:fi "Vauhtimäen latumateriaali",
@@ -1642,7 +1642,7 @@
     :description
     {:fi "Hyppyrimäen vauhtimäen materiaali",
      :se "Hoppbackens spårmaterial vid överbacken",
-     :en ""}},
+     :en "The material of the take-off ramp of the ski jumping hill"}},
    :pyramid-tables-count
    {:name
     {:fi "Pyramidipöydät lkm",
@@ -1661,7 +1661,7 @@
      "Onko liikuntapaikka normaali koripallokenttä, minikoripallokenttä vai yhden korin koripallokenttä",
      :se
      "Har idrottsplaten en normal korgbollsplan, mini-korgbollsplan eller bara en korg",
-     :en ""}},
+     :en "Is the sports facility a standard basketball court, a mini basketball court, or a one-basket basketball court"}},
    :kaisa-tables-count
    {:name
     {:fi "Kaisapöydät lkm",
@@ -1678,7 +1678,7 @@
     :description
     {:fi "Lentopallokenttien lukumäärä",
      :se "Antalet volleybollplaner",
-     :en ""}},
+     :en "The number of volleyball courts"}},
    :boat-places-count
    {:name
     {:fi "Venepaikat lkm", :se "Antalet båtplats", :en "Boat places"},
@@ -1694,7 +1694,7 @@
     :description
     {:fi "1. altaan veden lämpötila celsiusasteina",
      :se "Första bassängens vatten temperatur i celcius",
-     :en ""}},
+     :en "The water temperature of the pool in degrees Celsius"}},
    :climbing-wall?
    {:name      {:fi "Kiipeilyseinä", :se "Klättervägg", :en "Climbing wall"},
     :data-type "boolean",
@@ -1709,14 +1709,14 @@
     :description
     {:fi "Vapaan tyylin latu-ura/luistelu-ura",
      :se "Skidspår för fristil",
-     :en ""}},
+     :en "Free style track/skating track"}},
    :spinning-hall?
    {:name      {:fi "Spinning-sali", :se "Spinning sal", :en "Spinning hall"},
     :data-type "boolean",
     :description
     {:fi "Salissa spinning-varustus",
      :se "Salen har spinning utrustning",
-     :en ""}},
+     :en "Spinning equipment in the hall"}},
    :other-platforms?
    {:name
     {:fi "Muut hyppytelineet",
@@ -1726,7 +1726,7 @@
     :description
     {:fi "Uimahyppytelineet rannalla",
      :se "Hopptornen vid stranden",
-     :en ""}},
+     :en "Diving boards at the beach"}},
    :school-use?
    {:name
     {:fi "Koululiikuntapaikka",
@@ -1736,7 +1736,7 @@
     :description
     {:fi "Liikuntapaikkaa käytetään koulujen liikuntatunneilla",
      :se "Idrottsplatsen används under skolornas gymnastiktimmar",
-     :en ""}},
+     :en "The sports facility is used for school physical education classes"}},
    :highjump-places-count
    {:name
     {:fi "Korkeushyppypaikat lkm",
@@ -1746,7 +1746,7 @@
     :description
     {:fi "Korkeushppypaikkojen lukumäärä",
      :se "Antalet höjdhoppsplatser",
-     :en ""}},
+     :en "The number of high jump areas"}},
    :light-roof?
    {:name
     {:fi "Kevytkate", :se "Lättvikts takläggning", :en "Light roof"},
@@ -1755,7 +1755,7 @@
     {:fi "Kentälle voidaan asentaa kevytkate tai muu tilapäinen katos",
      :se
      "På planen kan installeras en lättvikts takläggning eller något annat tillfälligt tak",
-     :en ""}},
+     :en "A lightweight cover or another temporary canopy can be installed on the field"}},
    :route-length-km
    {:name
     {:fi "Reitin pituus km",
@@ -1765,7 +1765,7 @@
     :description
     {:fi "Reitin pituus kilometreinä",
      :se "Ruttens längd i kilometer",
-     :en ""}},
+     :en "The length of the route in kilometers"}},
    :field-3-flexible-rink?
    {:name
     {:fi "3. kenttä: onko joustokaukalo?",
@@ -1782,11 +1782,11 @@
     :description
     {:fi "Kuntoilulaitteiden lukumäärä",
      :se "Antalet gym apparater",
-     :en ""}},
+     :en "The number of exercise machines"}},
    :track-type
    {:name        {:fi "Ratatyyppi", :se "Typ av bana", :en "Type of track"},
     :data-type   "string",
-    :description {:fi "Radan tyyppi", :se "Banans typ", :en ""}},
+    :description {:fi "Radan tyyppi", :se "Banans typ", :en "The type of the track"}},
    :training-spot-surface-material
    {:name
     {:fi "Suorituspaikan pintamateriaali",
@@ -1796,7 +1796,7 @@
     :description
     {:fi "Esim. keihäänheittopaikan pintamateriaali/päällys",
      :se "T.ex. spjutkastningsplatsens ytmaterial/överläggning",
-     :en ""}},
+     :en "E.g. the surface material/overlay of the javelin throw area."}},
    :range?
    {:name
     {:fi "Harjoitusalue/range", :se "Övningszon/Range", :en "Range"},
@@ -1804,7 +1804,7 @@
     :description
     {:fi "Onko golfin harjoitusalue/range",
      :se "Finns det övningsområde/range för golf",
-     :en ""}},
+     :en "Is there a golf practice area/range"}},
    :track-length-m
    {:name
     {:fi "Radan pituus m",
@@ -1814,7 +1814,7 @@
     :description
     {:fi "Juoksuradan, pyöräilyradan tms. pituus metreinä",
      :se "Löpbanans, rundbanans el.dyl. längd i meter",
-     :en ""}}})
+     :en "The length of the running track, cycling track, etc., in meters"}}})
 
 (def used
   (let [used (set (mapcat (comp keys :props second) types/all))]

--- a/webapp/src/cljc/lipas/data/prop_types.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types.cljc
@@ -6,7 +6,7 @@
    [lipas.data.prop-types-new :as new]
    [lipas.data.prop-types-old :as old]))
 
-(def all old/all)
+(def all new/all)
 
 (def used
   (let [used (set (mapcat (comp keys :props second) types/all))]

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -212,15 +212,23 @@
                :en ""}})
 
       ;; Add new :space-divisible prop
+
+      ;; Toteutus esim: Valinta Kyllä/Ei -> Jos kyllä, täydennettävä
+      ;; kenttä "Tila voidaan jakaa x osaan" (voidaan syöttää lukuarvo
+      ;; esim. 2, joka tarkoittaa että tila voidaan jakaa kahteen
+      ;; osaan).
       (assoc :space-divisible
-             {:name      {:fi "Tila jaettavissa osiin"
-                          :se "Utrymmet kan delas upp"
-                          :en "Space can be divided"}
-              :data-type "boolean"
+             {:name        {:fi "Tila jaettavissa osiin"
+                            :se "Utrymmet kan delas upp"
+                            :en "Space can be divided"}
+              :helper-text {:fi "Syötä numero moneenko osaan tila on jaettavissa"
+                            :se "Ange antalet delar som utrymmet kan delas in i"
+                            :en "Enter the number of sections into which the space can be divided"}
+              :data-type   "number"
               :description
-              {:fi ""
-               :se ""
-               :en ""}})
+              {:fi "Onko tila jaettavissa osiin esim. jakoseinien tai -verhojen avulla"
+               :se "Är utrymmet delbart i sektioner, till exempel med skiljeväggar eller gardiner?"
+               :en "Is the space divisible into sections, for example, with partition walls or curtains?"}})
 
       ;; Add new :auxiliary-training-area prop
       (assoc :auxiliary-training-area

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -255,36 +255,36 @@
                           :se "Sportspecifikation"
                           :en "Sport specification"}
               :data-type "enum"
-              :opts {"floor-disciplines"
-                     {:label {:fi "Lattialajit" :en "Floor disciplines" :se "Golvdiscipliner"}
-                      :description
-                      {:fi "Voimistelulajit, jotka suoritetaan pääasiassa lattialla."
-                       :en "Gymnastics disciplines that are primarily performed on the floor."
-                       :se "Gymnastikdiscipliner som huvudsakligen utförs på golvet."}}
+              :opts      {"floor-disciplines"
+                          {:label {:fi "Lattialajit" :en "Floor disciplines" :se "Golvdiscipliner"}
+                           :description
+                           {:fi "Voimistelulajit, jotka suoritetaan pääasiassa lattialla."
+                            :en "Gymnastics disciplines that are primarily performed on the floor."
+                            :se "Gymnastikdiscipliner som huvudsakligen utförs på golvet."}}
 
-                     "apparatus-disciplines"
-                     {:label {:fi "Telinelajit" :en "Apparatus disciplines" :se "Redskapsgrenar"}
-                      :description
-                      {:fi "Voimistelulajit, jotka suoritetaan erilaisilla telineillä."
-                       :en "Gymnastics disciplines that are performed on various apparatus."
-                       :se "Gymnastikdiscipliner som utförs på olika redskap."}}
+                          "apparatus-disciplines"
+                          {:label {:fi "Telinelajit" :en "Apparatus disciplines" :se "Redskapsgrenar"}
+                           :description
+                           {:fi "Voimistelulajit, jotka suoritetaan erilaisilla telineillä."
+                            :en "Gymnastics disciplines that are performed on various apparatus."
+                            :se "Gymnastikdiscipliner som utförs på olika redskap."}}
 
-                     "floor-and-apparatus"
-                     {:label {:fi "Lattia- ja telinelajit mahdollisia" :en "Both floor and apparatus disciplines possible" :se "Både golv- och redskapsgrenar möjliga"}
-                      :description
-                      {:fi "Tilassa voidaan harjoitella sekä lattia- että telinelajeja."
-                       :en "The space allows for practicing both floor and apparatus disciplines."
-                       :se "Utrymmet möjliggör träning av både golv- och redskapsgrenar."}}
+                          "floor-and-apparatus"
+                          {:label {:fi "Lattia- ja telinelajit mahdollisia" :en "Both floor and apparatus disciplines possible" :se "Både golv- och redskapsgrenar möjliga"}
+                           :description
+                           {:fi "Tilassa voidaan harjoitella sekä lattia- että telinelajeja."
+                            :en "The space allows for practicing both floor and apparatus disciplines."
+                            :se "Utrymmet möjliggör träning av både golv- och redskapsgrenar."}}
 
-                     "cheerleading-circus"
-                     {:label {:fi "Pääasiassa cheerleading- tai sirkusharjoittelukäyttöön" :en "Mainly for cheerleading or circus training" :se "Huvudsakligen för cheerleading- eller cirkusträning"}
-                      :description
-                      {:fi "Tila on ensisijaisesti tarkoitettu cheerleading- tai sirkusharjoitteluun."
-                       :en "The space is primarily intended for cheerleading or circus training."
-                       :se "Utrymmet är främst avsett för cheerleading- eller cirkusträning."}}
+                          "cheerleading-circus"
+                          {:label {:fi "Pääasiassa cheerleading- tai sirkusharjoittelukäyttöön" :en "Mainly for cheerleading or circus training" :se "Huvudsakligen för cheerleading- eller cirkusträning"}
+                           :description
+                           {:fi "Tila on ensisijaisesti tarkoitettu cheerleading- tai sirkusharjoitteluun."
+                            :en "The space is primarily intended for cheerleading or circus training."
+                            :se "Utrymmet är främst avsett för cheerleading- eller cirkusträning."}}
 
-                     "no-information"
-                     {:label {:fi "Ei tietoa" :en "No information" :se "Ingen information"}}}
+                          "no-information"
+                          {:label {:fi "Ei tietoa" :en "No information" :se "Ingen information"}}}
 
               :description
               {:fi ""
@@ -330,33 +330,33 @@
                           :se "Utrustning och strukturer i parkourhallen"
                           :en "Parkour hall equipment and structures"}
               :data-type "enum-coll"
-              :opts {"fixed-obstacles"
-                     {:label {:fi "Kiinteät esteet / rakennelmat" :en "Fixed obstacles / structures" :se "Fasta hinder / strukturer"}
-                      :description
-                      {:fi "Pysyvästi asennetut esteet tai rakennelmat harjoittelua varten."
-                       :en "Permanently installed obstacles or structures for training purposes."
-                       :se "Permanent installerade hinder eller strukturer för träningsändamål."}}
+              :opts      {"fixed-obstacles"
+                          {:label {:fi "Kiinteät esteet / rakennelmat" :en "Fixed obstacles / structures" :se "Fasta hinder / strukturer"}
+                           :description
+                           {:fi "Pysyvästi asennetut esteet tai rakennelmat harjoittelua varten."
+                            :en "Permanently installed obstacles or structures for training purposes."
+                            :se "Permanent installerade hinder eller strukturer för träningsändamål."}}
 
-                     "movable-obstacles"
-                     {:label {:fi "Liikkuvat esteet / rakennelmat" :en "Movable obstacles / structures" :se "Flyttbara hinder / strukturer"}
-                      :description
-                      {:fi "Siirrettävät tai muunneltavat esteet ja rakennelmat harjoittelua varten."
-                       :en "Movable or adjustable obstacles and structures for training purposes."
-                       :se "Flyttbara eller justerbara hinder och strukturer för träningsändamål."}}
+                          "movable-obstacles"
+                          {:label {:fi "Liikkuvat esteet / rakennelmat" :en "Movable obstacles / structures" :se "Flyttbara hinder / strukturer"}
+                           :description
+                           {:fi "Siirrettävät tai muunneltavat esteet ja rakennelmat harjoittelua varten."
+                            :en "Movable or adjustable obstacles and structures for training purposes."
+                            :se "Flyttbara eller justerbara hinder och strukturer för träningsändamål."}}
 
-                     "floor-acrobatics-area"
-                     {:label {:fi "Permanto/akrobatiatila" :en "Floor/acrobatics area" :se "Golv/akrobatikområde"}
-                      :description
-                      {:fi "Avoin tila lattiaharjoittelua ja akrobaattisia liikkeitä varten."
-                       :en "Open space for floor exercises and acrobatic movements."
-                       :se "Öppet utrymme för golvövningar och akrobatiska rörelser."}}
+                          "floor-acrobatics-area"
+                          {:label {:fi "Permanto/akrobatiatila" :en "Floor/acrobatics area" :se "Golv/akrobatikområde"}
+                           :description
+                           {:fi "Avoin tila lattiaharjoittelua ja akrobaattisia liikkeitä varten."
+                            :en "Open space for floor exercises and acrobatic movements."
+                            :se "Öppet utrymme för golvövningar och akrobatiska rörelser."}}
 
-                     "gym-strength-area"
-                     {:label {:fi "Kuntosali-/voimailutila" :en "Gym/strength training area" :se "Gym/styrketräningsområde"}
-                      :description
-                      {:fi "Alue, joka on varustettu kuntosalilaitteilla ja välineillä voimaharjoittelua varten."
-                       :en "Area equipped with gym machines and equipment for strength training."
-                       :se "Område utrustat med gymmaskiner och utrustning för styrketräning."}}}
+                          "gym-strength-area"
+                          {:label {:fi "Kuntosali-/voimailutila" :en "Gym/strength training area" :se "Gym/styrketräningsområde"}
+                           :description
+                           {:fi "Alue, joka on varustettu kuntosalilaitteilla ja välineillä voimaharjoittelua varten."
+                            :en "Area equipped with gym machines and equipment for strength training."
+                            :se "Område utrustat med gymmaskiner och utrustning för styrketräning."}}}
               :description
               {:fi ""
                :se ""
@@ -497,6 +497,118 @@
       ;;  Laskenta mahdollista tehdä automaattisesti syötettyjen altaiden perusteella (lasketaan yksinkertaisesti kaikki altaat yhteen tai luvun voi tarvittaessa korjata käsin, samaan tapaan kuin reittien pituuslaskuri toimii)
       (assoc-in [:swimming-pool-count :description :fi] "Altaiden lukumäärä yhteensä. Syötä tieto tai laske automaattisesti.")
       (assoc-in [:pool-water-area-m2 :description :fi] "Asiakaskäytössä oleva vesipinta-ala yhteensä.")
+
+
+      ;;; Maasto ja loput ;;;
+
+      ;; Add new pulkkamäki prop-type
+      (assoc :sledding-hill?
+             {:name
+              {:fi "Pulkkamäki"
+               :se "Pulkabacke"
+               :en "Sledding hill"}
+              :data-type "boolean"
+              :description
+              {:fi "Kohteessa on pulkkamäki"
+               :se "Det finns en pulkabacke på platsen."
+               :en "There is a sledding hill at the location."}})
+
+
+      ;; Add new kulkutavat prop-type
+      (assoc :travel-modes
+             {:name      {:fi "Kulkutavat"
+                          :se "Resesätt"
+                          :en "Travel Modes"}
+              :data-type "enum-coll"
+              :opts      {"by-foot"
+                          {:label {:fi "Jalan" :en "On Foot" :se "Till fots"}
+                           :description
+                           {:fi "Liikkuminen jalkaisin"
+                            :en "Traveling on foot"
+                            :se "Att resa till fots"}}
+
+                          "snow-shoes"
+                          {:label {:fi "Lumikengillä" :en "With Snowshoes" :se "Med snöskor"}
+                           :description
+                           {:fi "Liikkuminen lumikengillä"
+                            :en "Traveling with snowshoes"
+                            :se "Att resa med snöskor"}}
+
+                          "fat-bike"
+                          {:label {:fi "Läskipyörällä" :en "With Fat Bike" :se "Med fatbike"}
+                           :description
+                           {:fi "Liikkuminen läskipyörällä"
+                            :en "Traveling with a fat bike"
+                            :se "Att resa med fatbike"}}}
+              :description
+              {:fi "Lisää reitille soveltuvat kulkutavat"
+               :se "Lägg till lämpliga resesätt för rutten"
+               :en "Add suitable travel modes for the route"}})
+
+      ;; Add new travel-mode-info prop-type
+      (assoc :travel-mode-info
+             {:name      {:fi "Kulkutavat, lisätieto"
+                          :se "Resesätt, ytterligare information"
+                          :en "Travel Modes, Additional Information"}
+              :data-type "string"
+              :description
+              {:fi "Täsmennä soveltuvia kulkutapoja tarvittaessa"
+               :se "Specificera lämpliga resesätt vid behov"
+               :en "Specify suitable travel modes if necessary"}})
+
+      ;; Add new HS point prop-type
+      (assoc :hs-point
+             {:name      {:fi "HS-piste", :se "HS-punkt", :en "HS Point"}
+              :data-type "numeric"
+              :description
+              {:fi "Hyppyrimäen HS-piste metreinä"
+               :se "HS-punkten i backhoppning i meter"
+               :en "Ski jumping hill HS point in "}})
+
+      ;; Add new mobile-orienteering-available? prop-type
+      (assoc :mobile-orienteering?
+             {:name      {:fi "Mobiilisunnistusmahdollisuus"
+                          :se "Mobilorientering möjlig"
+                          :en "Mobile Orienteering Available"}
+              :data-type "boolean"
+              :description
+              {:fi ""
+               :se ""
+               :en ""}})
+
+      ;; Add new bike-orienteering-available? prop-type
+      (assoc :bike-orienteering?
+             {:name      {:fi "Pyöräsuunnistus mahdollista"
+                          :se "Cykelorientering möjlig"
+                          :en "Bike Orienteering Possible"}
+              :data-type "boolean"
+              :description
+              {:fi ""
+               :se ""
+               :en ""}})
+
+      ;; Add new ski-orienteering? prop-type
+      (assoc :ski-orienteering?
+             {:name      {:fi "Hiihtosuunnistus mahdollista"
+                          :se "Skidorientering möjlig"
+                          :en "Ski Orienteering Possible"}
+              :data-type "boolean"
+              :description
+              {:fi ""
+               :se ""
+               :en ""}})
+
+      ;; Add new ympärivuotinen käyttö prop-type
+      (assoc :year-round-use?
+             {:name      {:fi "Ympärivuotinen käyttö"
+                          :se "Året runt användning"
+                          :en "Year-round Use"}
+              :data-type "boolean"
+              :description
+              {:fi "Kohde on ympärivuotisessa käytössä"
+               :se "Platsen är i användning året runt"
+               :en "The location is in use year-round"}})
+
 
       ))
 

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -134,7 +134,6 @@
                :se "T.ex. lux-mängd eller annan förtydligande information"
                :en "E.g. lux amount or other specifying information"}})
 
-
       ;; Update :weight-lifting-spots-count name and description
       (assoc-in [:weight-lifting-spots-count :name]
                 {:fi "Painonnostopaikat/nostolavat lkm"

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -163,6 +163,12 @@
                  :se "Länk till tillgänglighetsinformation"
                  :en "Link to accessibility information"})
 
+      ;; Update :accessibility-info description
+      (assoc-in [:accessibility-info :description]
+                {:fi "Syötä linkki verkkosivulle, jossa on kuvattu kohteen esteettömyyteen liittyvät tiedot"
+                 :se "Ange länken till webbplatsen där information om objektets tillgänglighet beskrivs."
+                 :en "Enter the link to the website where the accessibility information of the location is described."})
+
       ;; Update Halfpipe name
       (assoc-in [:halfpipe-count :name]
                 {:fi "Halfpipe lkm"
@@ -615,3 +621,9 @@
 (def used
   (let [used (set (mapcat (comp keys :props second) types/all))]
     (select-keys all used)))
+
+(comment
+  (require '[clojure.pprint :as pprint])
+  #?(:clj (spit "/tmp/prop-types.edn" (with-out-str (pprint/pprint all))))
+
+  )

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -123,8 +123,8 @@
                  :se "Antal hål/fairways"
                  :en "Number of holes/fairways"})
 
-      ;; Add new :ligthing-info prop
-      (assoc :ligthing-info
+      ;; Add new :lighting-info prop
+      (assoc :lighting-info
              {:name      {:fi "Valaistuksen lisätieto"
                           :se "Ytterligare information om belysningen"
                           :en "Additional information about the lighting"}

--- a/webapp/src/cljc/lipas/data/prop_types_new.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_new.cljc
@@ -231,7 +231,7 @@
                :en "Is the space divisible into sections, for example, with partition walls or curtains?"}})
 
       ;; Add new :auxiliary-training-area prop
-      (assoc :auxiliary-training-area
+      (assoc :auxiliary-training-area?
              {:name      {:fi "Oheisharjoittelutila"
                           :se "Kompletterande träningsområde"
                           :en "Auxiliary training area"}
@@ -242,11 +242,50 @@
                :en ""}})
 
       ;; Add new :sport-specification prop
+
+      ;; Ominaisuuden nimi esim. "Lajitarkenne". Vastaava
+      ;; toiminnallisuus kuin veneilyn palvelupaikoissa - eli
+      ;; lisätiedoissa voidaan tarkentaa, minkä voimistelulajin
+      ;; harrastamiseen kohde on pääasiassa tarkoitettu. Vaihtoehdot:
+      ;; a. Lattialajit b. Telinelajit c. Lattia- ja telinelajit
+      ;; mahdollisia d. Pääasiassa cheerleading- tai
+      ;; sirkusharjoittelukäyttöön e. Ei tietoa
       (assoc :sport-specification
              {:name      {:fi "Lajitarkenne"
                           :se "Sportspecifikation"
                           :en "Sport specification"}
-              :data-type "string"
+              :data-type "enum"
+              :opts {"floor-disciplines"
+                     {:label {:fi "Lattialajit" :en "Floor disciplines" :se "Golvdiscipliner"}
+                      :description
+                      {:fi "Voimistelulajit, jotka suoritetaan pääasiassa lattialla."
+                       :en "Gymnastics disciplines that are primarily performed on the floor."
+                       :se "Gymnastikdiscipliner som huvudsakligen utförs på golvet."}}
+
+                     "apparatus-disciplines"
+                     {:label {:fi "Telinelajit" :en "Apparatus disciplines" :se "Redskapsgrenar"}
+                      :description
+                      {:fi "Voimistelulajit, jotka suoritetaan erilaisilla telineillä."
+                       :en "Gymnastics disciplines that are performed on various apparatus."
+                       :se "Gymnastikdiscipliner som utförs på olika redskap."}}
+
+                     "floor-and-apparatus"
+                     {:label {:fi "Lattia- ja telinelajit mahdollisia" :en "Both floor and apparatus disciplines possible" :se "Både golv- och redskapsgrenar möjliga"}
+                      :description
+                      {:fi "Tilassa voidaan harjoitella sekä lattia- että telinelajeja."
+                       :en "The space allows for practicing both floor and apparatus disciplines."
+                       :se "Utrymmet möjliggör träning av både golv- och redskapsgrenar."}}
+
+                     "cheerleading-circus"
+                     {:label {:fi "Pääasiassa cheerleading- tai sirkusharjoittelukäyttöön" :en "Mainly for cheerleading or circus training" :se "Huvudsakligen för cheerleading- eller cirkusträning"}
+                      :description
+                      {:fi "Tila on ensisijaisesti tarkoitettu cheerleading- tai sirkusharjoitteluun."
+                       :en "The space is primarily intended for cheerleading or circus training."
+                       :se "Utrymmet är främst avsett för cheerleading- eller cirkusträning."}}
+
+                     "no-information"
+                     {:label {:fi "Ei tietoa" :en "No information" :se "Ingen information"}}}
+
               :description
               {:fi ""
                :se ""
@@ -290,7 +329,34 @@
              {:name      {:fi "Parkour-salin varustelu ja rakenteet"
                           :se "Utrustning och strukturer i parkourhallen"
                           :en "Parkour hall equipment and structures"}
-              :data-type "string"
+              :data-type "enum-coll"
+              :opts {"fixed-obstacles"
+                     {:label {:fi "Kiinteät esteet / rakennelmat" :en "Fixed obstacles / structures" :se "Fasta hinder / strukturer"}
+                      :description
+                      {:fi "Pysyvästi asennetut esteet tai rakennelmat harjoittelua varten."
+                       :en "Permanently installed obstacles or structures for training purposes."
+                       :se "Permanent installerade hinder eller strukturer för träningsändamål."}}
+
+                     "movable-obstacles"
+                     {:label {:fi "Liikkuvat esteet / rakennelmat" :en "Movable obstacles / structures" :se "Flyttbara hinder / strukturer"}
+                      :description
+                      {:fi "Siirrettävät tai muunneltavat esteet ja rakennelmat harjoittelua varten."
+                       :en "Movable or adjustable obstacles and structures for training purposes."
+                       :se "Flyttbara eller justerbara hinder och strukturer för träningsändamål."}}
+
+                     "floor-acrobatics-area"
+                     {:label {:fi "Permanto/akrobatiatila" :en "Floor/acrobatics area" :se "Golv/akrobatikområde"}
+                      :description
+                      {:fi "Avoin tila lattiaharjoittelua ja akrobaattisia liikkeitä varten."
+                       :en "Open space for floor exercises and acrobatic movements."
+                       :se "Öppet utrymme för golvövningar och akrobatiska rörelser."}}
+
+                     "gym-strength-area"
+                     {:label {:fi "Kuntosali-/voimailutila" :en "Gym/strength training area" :se "Gym/styrketräningsområde"}
+                      :description
+                      {:fi "Alue, joka on varustettu kuntosalilaitteilla ja välineillä voimaharjoittelua varten."
+                       :en "Area equipped with gym machines and equipment for strength training."
+                       :se "Område utrustat med gymmaskiner och utrustning för styrketräning."}}}
               :description
               {:fi ""
                :se ""
@@ -426,7 +492,7 @@
       (assoc-in [:highest-obstacle-m :description :fi] "Korkeimman esteen korkeus (m)")
       ;;  Pintamateriaalikentän valittavissa seuraavista ne ominaisuudet, jotka saliin sopivat: a) Kiinteät esteet / rakennelmat b) Liikkuvat esteet / rakennelmat c) Permanto/akrobatiatila d) Kuntosali-/voimailutila
       (assoc-in [:parkour-hall-equipment-and-structures :description :fi] "Valitse parkour-salissa olevat rakenteet tai varusteet")
-      (assoc-in [:ringette-boundary-markings :description :fi] "Onko kaukaloissa ringeten rajamerkinnät?")
+      (assoc-in [:ringette-boundary-markings? :description :fi] "Onko kaukaloissa ringeten rajamerkinnät?")
       (assoc-in [:swimming-pool-count :name :fi] "Altaiden lukumäärä")
       ;;  Laskenta mahdollista tehdä automaattisesti syötettyjen altaiden perusteella (lasketaan yksinkertaisesti kaikki altaat yhteen tai luvun voi tarvittaessa korjata käsin, samaan tapaan kuin reittien pituuslaskuri toimii)
       (assoc-in [:swimming-pool-count :description :fi] "Altaiden lukumäärä yhteensä. Syötä tieto tai laske automaattisesti.")

--- a/webapp/src/cljc/lipas/data/prop_types_old.cljc
+++ b/webapp/src/cljc/lipas/data/prop_types_old.cljc
@@ -804,9 +804,9 @@
      :en ""}},
    :curling-lanes-count
    {:name
-    {:fi "Curling-ratojen lkm",
+    {:fi "Curling-ratojen lukumäärä",
      :se "Antal curlingbanor",
-     :en "How many curling lanes"},
+     :en "Count of curling lanes"},
     :data-type "numeric",
     :description
     {:fi "Curling-ratojen lukumäärä",

--- a/webapp/src/cljc/lipas/data/styles.cljc
+++ b/webapp/src/cljc/lipas/data/styles.cljc
@@ -412,7 +412,7 @@
     :stroke {:color "#000000"}},
    103
    {:shape "polygon",
-    :fill {:color "#57fba0"},
+    :fill {:color "#57fbc4"},
     :stroke {:color "#000000", :width 1.5}},
    201
    {:shape "circle",
@@ -743,7 +743,7 @@
    4407
    {:shape "linestring",
     :stroke
-    {:color "#f77ec3",
+    {:color "#827e3b",
      :width 3.5,
      :line-cap "round",
      :line-join "round",
@@ -779,12 +779,12 @@
    1190
    {:shape "circle",
     :radius 9,
-    :fill {:color "#f2d3ef"},
+    :fill {:color "#f0c0eb"},
     :stroke {:color "#000000"}}
    ;; Golfkenttä (alue)
    1650
    {:shape "polygon",
-    :fill {:color "#9efa52"},
+    :fill {:color "#c9ff05"},
     :stroke {:color "#000000" :width 1.5}}
    ;; Sisäleikki-/aktiviteettipuisto:
    2225
@@ -798,16 +798,17 @@
     :radius 9,
     :fill {:color "#9afcc0"},
     :stroke {:color "#000000"}}
+   ;; Vesiurheilukeskus
    3250
    {:shape "circle",
     :radius 9,
-    :fill {:color "#6e6d91"},
+    :fill {:color "#60669c"},
     :stroke {:color "#000000"}}
    ;; Jousiammuntamaastorata
    4840
    {:shape "circle",
     :radius 9,
-    :fill {:color "#948938"},
+    :fill {:color "#dcc210"},
     :stroke {:color "#000000"}}
    ;; Monikäyttöalueet ja virkistysmetsät, joissa on virkistyspalveluita
    106

--- a/webapp/src/cljc/lipas/data/styles.cljc
+++ b/webapp/src/cljc/lipas/data/styles.cljc
@@ -126,11 +126,6 @@
     :radius 9,
     :fill {:color "#8fed75"},
     :stroke {:color "#000000"}},
-   1190
-   {:shape "circle",
-    :radius 9,
-    :fill {:color "#ffffff"},
-    :stroke {:color "#000000"}},
    4422
    {:shape "linestring",
     :stroke
@@ -154,10 +149,6 @@
     :radius 9,
     :fill {:color "#73d28b"},
     :stroke {:color "#004800"}},
-   106
-   {:shape "polygon",
-    :fill {:color "#50e76a"},
-    :stroke {:color "#000000", :width 1.5}},
    4610
    {:shape "circle",
     :radius 9,
@@ -217,11 +208,6 @@
     :radius 9,
     :fill {:color "#00c100"},
     :stroke {:color "#ff5500"}},
-   4840
-   {:shape "circle",
-    :radius 9,
-    :fill {:color "#dcc210"},
-    :stroke {:color "#aa0000"}},
    1510
    {:shape "circle",
     :radius 9,
@@ -523,10 +509,6 @@
     :radius 9,
     :fill {:color "#62d53c"},
     :stroke {:color "#000000"}},
-   1650
-   {:shape "polygon",
-    :fill {:color "#62d53c"},
-    :stroke {:color "#000000" :width 1.5}},
    2250
    {:shape "square",
     :radius 9,
@@ -757,18 +739,79 @@
      :line-join "round",
      :line-dash [5 2]},
     :fill {:color "#000000"}}
+   ;; Rullahiihtorata
+   4407
+   {:shape "linestring",
+    :stroke
+    {:color "#f77ec3",
+     :width 3.5,
+     :line-cap "round",
+     :line-join "round",
+     :line-dash [5 2]},
+    :fill {:color "#000000"}}
+   ;; Monikäyttöreitti
+   4406
+   {:shape "linestring",
+    :stroke
+    {:color "#665e8a",
+     :width 3.5,
+     :line-cap "round",
+     :line-join "round",
+     :line-dash [5 2]},
+    :fill {:color "#000000"}}
+   ;; Koiravaljakkoreitti
+   4441
+   {:shape "linestring",
+    :stroke
+    {:color "#80a172",
+     :width 3.5,
+     :line-cap "round",
+     :line-join "round",
+     :line-dash [5 2]},
+    :fill {:color "#000000"}}
+   ;; Ovaalirata
+   6150
+   {:shape "circle",
+    :radius 9,
+    :fill {:color "#f0c39e"},
+    :stroke {:color "#000000"}}
+   ;;Pulkkamäki
+   1190
+   {:shape "circle",
+    :radius 9,
+    :fill {:color "#f2d3ef"},
+    :stroke {:color "#000000"}}
+   ;; Golfkenttä (alue)
+   1650
+   {:shape "polygon",
+    :fill {:color "#9efa52"},
+    :stroke {:color "#000000" :width 1.5}}
+   ;; Sisäleikki-/aktiviteettipuisto:
    2225
    {:shape "square",
     :radius 9,
-    :fill {:color "#ac6c46"},
+    :fill {:color "#d9936a"},
     :stroke {:color "#000000"}}
+   ;; Biljardisali
    2620
    {:shape "square",
     :radius 9,
-    :fill {:color "#ac6c46"},
+    :fill {:color "#9afcc0"},
     :stroke {:color "#000000"}}
    3250
    {:shape "circle",
     :radius 9,
-    :fill {:color "#aaaaff"},
-    :stroke {:color "#000000"}}})
+    :fill {:color "#6e6d91"},
+    :stroke {:color "#000000"}}
+   ;; Jousiammuntamaastorata
+   4840
+   {:shape "circle",
+    :radius 9,
+    :fill {:color "#948938"},
+    :stroke {:color "#000000"}}
+   ;; Monikäyttöalueet ja virkistysmetsät, joissa on virkistyspalveluita
+   106
+   {:shape "polygon",
+    :fill {:color "#99d18f"},
+    :stroke {:color "#000000" :width 1.5}}
+   })

--- a/webapp/src/cljc/lipas/data/styles.cljc
+++ b/webapp/src/cljc/lipas/data/styles.cljc
@@ -300,7 +300,7 @@
     :stroke {:color "#000000"}},
    109
    {:shape "polygon",
-    :fill {:color "#94d024"},
+    :fill {:color "#1f805f"},
     :stroke {:color "#000000", :width 1.5}},
    5160
    {:shape "square",
@@ -453,7 +453,7 @@
     :stroke {:color "#000000"}},
    107
    {:shape "polygon",
-    :fill {:color "#daab0c"},
+    :fill {:color "#c18bd6"},
     :stroke {:color "#000000", :width 1.5}},
    6110
    {:shape "circle",
@@ -743,7 +743,7 @@
    4407
    {:shape "linestring",
     :stroke
-    {:color "#827e3b",
+    {:color "#b0a92c",
      :width 3.5,
      :line-cap "round",
      :line-join "round",
@@ -784,7 +784,7 @@
    ;; Golfkenttä (alue)
    1650
    {:shape "polygon",
-    :fill {:color "#c9ff05"},
+    :fill {:color "#daab0c"},
     :stroke {:color "#000000" :width 1.5}}
    ;; Sisäleikki-/aktiviteettipuisto:
    2225

--- a/webapp/src/cljc/lipas/data/types.cljc
+++ b/webapp/src/cljc/lipas/data/types.cljc
@@ -1971,7 +1971,7 @@
     :main-category 6000,
     :status        "active",
     :sub-category  6100,
-    :geometry-type "LineString",
+    :geometry-type "Point",
     :props
     {:surface-material                   {:priority 0},
      :surface-material-info              {:priority 0},

--- a/webapp/src/cljc/lipas/data/types.cljc
+++ b/webapp/src/cljc/lipas/data/types.cljc
@@ -1,24 +1,4630 @@
 (ns lipas.data.types
-  "Type codes went through a major overhaul in the summer of 2024. This
-  namespace hosts a controlled place to roll-out the changes."
+  "Categorization of sports sites."
   (:require
-   [lipas.data.types-old :as old]
-   [lipas.data.types-new :as new]
    [lipas.utils :as utils]))
 
 (def main-categories
-  new/main-categories)
+  {0
+   {:type-code 0,
+    :name
+    {:fi "Virkistyskohteet ja palvelut",
+     :se "Rekreationsanläggningar och tjänster",
+     :en "Recreational destinations and services"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p37350"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.2"]}},
+   1000
+   {:type-code 1000,
+    :name
+    {:fi "Ulkokentät ja liikuntapuistot",
+     :se "Utomhusplaner och idrottsparker",
+     :en "Outdoor fields and sports parks"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p69291"
+      "http://www.yso.fi/onto/koko/p67276"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.2"]}},
+   2000
+   {:type-code 2000,
+    :name
+    {:fi "Sisäliikuntatilat",
+     :se "Anläggningar för inomhusidrott",
+     :en "Indoor sports facilities"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p69660"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.1"]}},
+   3000
+   {:type-code 3000,
+    :name
+    {:fi "Vesiliikuntapaikat",
+     :se "Anläggningar för vattenidrott",
+     :en "Water sports facilities"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p18621"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.1"
+      "http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.2"]}},
+   4000
+   {:type-code 4000,
+    :name
+    {:fi "Maastoliikuntapaikat",
+     :se "Anläggningar för terrängidrott",
+     :en "Cross-country sports facilities"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p12424"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.2"]}},
+   5000
+   {:type-code 5000,
+    :name
+    {:fi "Veneily, ilmailu ja moottoriurheilu",
+     :se "Anläggningar för båtsport, flygsport och motorsport",
+     :en "Boating, aviation and motor sports"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p34055"
+      "http://www.yso.fi/onto/koko/p36083"
+      "http://www.yso.fi/onto/koko/p18298"
+      "http://www.yso.fi/onto/koko/p75772"
+      "http://www.yso.fi/onto/koko/p31773"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.2"]}},
+   6000
+   {:type-code 6000,
+    :name
+    {:fi "Eläinurheilualueet",
+     :se "Anläggningar för djursport",
+     :en "Animal sports areas"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10416"
+      "http://www.yso.fi/onto/koko/p8973"],
+     :service-classes
+     ["http://uri.suomi.fi/codelist/ptv/ptvserclass2/code/P27.1"]}},
+   7000
+   {:type-code 7000,
+    :name
+    {:fi "Huoltorakennukset",
+     :se "Servicebyggnader",
+     :en "Maintenance/service buildings"},
+    :ptv {:ontology-urls [], :service-classes []}}})
 
 (def sub-categories
-  new/sub-categories)
+  {2100
+   {:type-code 2100,
+    :name
+    {:fi "Kuntoilukeskukset ja liikuntasalit",
+     :se "Konditionsidrottscentra och idrottssalar",
+     :en "Fitness centres and sports halls"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p30560"
+      "http://www.yso.fi/onto/koko/p85878"]},
+    :main-category "2000"},
+   5200
+   {:type-code 5200,
+    :name
+    {:fi "Urheiluilmailualueet",
+     :se "Områden för flygsport",
+     :en "Sport aviation areas"},
+    :main-category "5000"},
+   4200
+   {:type-code 4200,
+    :name
+    {:fi "Katetut talviurheilupaikat",
+     :se "Vintersportplatser under tak",
+     :en "Covered winter sports facilities"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p8460"]},
+    :main-category "4000"},
+   2200
+   {:type-code 2200,
+    :name
+    {:fi "Liikuntahallit", :se "Idrottshallar", :en "Sports halls"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p33522"]},
+    :main-category "2000"},
+   1
+   {:type-code 1,
+    :name
+    {:fi "Virkistys- ja retkeilyalueet",
+     :se "Rekreations- och friluftsområden",
+     :en "Recreational and outdoor areas "},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p37350"
+      "http://www.yso.fi/onto/koko/p33303"]},
+    :main-category "0"},
+   7000
+   {:type-code 7000,
+    :name
+    {:fi "Huoltotilat",
+     :se "Servicebyggnader",
+     :en "Maintenance/service buildings"},
+    :main-category "7000"},
+   4400
+   {:type-code 4400,
+    :name
+    {:fi "Liikunta- ja ulkoilureitit",
+     :se "Idrotts- och friluftsleder",
+     :en "Sports and outdoor recreation routes "},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p32315"]},
+    :main-category "4000"},
+   1300
+   {:type-code 1300,
+    :name {:fi "Pallokentät", :se "Bollplaner", :en "Ball games courts"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p75504"]},
+    :main-category "1000"},
+   6100
+   {:type-code 6100,
+    :name {:fi "Hevosurheilu", :se "Hästsport", :en "Equestrian sports"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p35523"]},
+    :main-category "6000"},
+   4700
+   {:type-code 4700,
+    :name
+    {:fi "Kiipeilypaikat",
+     :se "Klättringsplatser",
+     :en "Climbing venues"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p4261"]},
+    :main-category "4000"},
+   3100
+   {:type-code 3100,
+    :name
+    {:fi "Uima-altaat, hallit ja kylpylät",
+     :se "Simbassänger, hallar och badinrättningar",
+     :en "Indoor swimming pools, halls and spas"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p1459"
+      "http://www.yso.fi/onto/koko/p11070"
+      "http://www.yso.fi/onto/koko/p35112"]},
+    :main-category "3000"},
+   2500
+   {:type-code 2500,
+    :name {:fi "Jäähallit", :se "Ishallar", :en "Ice-skating arenas"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p11376"]},
+    :main-category "2000"},
+   1200
+   {:type-code 1200,
+    :name
+    {:fi "Yleisurheilukentät ja -paikat",
+     :se "Planer och platser för friidrott",
+     :en "Athletics fields and venues"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p85607"]},
+    :main-category "1000"},
+   5300
+   {:type-code 5300,
+    :name
+    {:fi "Moottoriurheilualueet",
+     :se "Områden för motorsport",
+     :en "Motor sports areas"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p31773"]},
+    :main-category "5000"},
+   1600
+   {:type-code 1600,
+    :name {:fi "Golfkentät", :se "Golfbanor", :en "Golf courses"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p32648"]},
+    :main-category "1000"},
+   1500
+   {:type-code 1500,
+    :name
+    {:fi "Jääurheilualueet ja luonnonjäät",
+     :se "Isidrottsområden och naturisar",
+     :en "Ice sports areas and sites with natural ice"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p75572"]},
+    :main-category "1000"},
+   6200
+   {:type-code 6200,
+    :name {:fi "Koiraurheilu", :se "Hundsport", :en "Dog sports"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p72589"]},
+    :main-category "6000"},
+   3200
+   {:type-code 3200,
+    :name
+    {:fi "Maauimalat ja uimarannat",
+     :se "Utebassänger och badstränder",
+     :en "Open air pools and beaches"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p32279"
+      "http://www.yso.fi/onto/koko/p76123"
+      "http://www.yso.fi/onto/koko/p13459"]},
+    :main-category "3000"},
+   2
+   {:type-code 2,
+    :name
+    {:fi "Retkeilyn palvelut",
+     :se "Utflyktstjänster",
+     :en "Hiking facilities"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p36881"]},
+    :main-category "0"},
+   1100
+   {:type-code 1100,
+    :name
+    {:fi "Lähiliikunta ja liikuntapuistot",
+     :se "Närmotion och idrottsparker",
+     :en "Neighbourhood sports facilities and parks "},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p84486"
+      "http://www.yso.fi/onto/koko/p69291"]},
+    :main-category "1000"},
+   4100
+   {:type-code 4100,
+    :name
+    {:fi "Laskettelurinteet ja rinnehiihtokeskukset",
+     :se "Slalombackar och alpina skidcentra",
+     :en "Ski slopes and downhill ski resorts"},
+    :ptv
+    {:ontology-urls
+     ["http://www.yso.fi/onto/koko/p10549"
+      "http://www.yso.fi/onto/koko/p84378"
+      "http://www.yso.fi/onto/koko/p4432"]},
+    :main-category "4000"},
+   5100
+   {:type-code 5100,
+    :name
+    {:fi "Veneurheilupaikat",
+     :se "Platser för båtsport",
+     :en "Boating sports facilities"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p75772"]},
+    :main-category "5000"},
+   2600
+   {:type-code 2600,
+    :name
+    {:fi "Keilahallit ja biljardisalit",
+     :se "Bowlinghallar och biljardsalonger",
+     :en "Bowling alleys and billiard halls"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p9812"]},
+    :main-category "2000"},
+   2300
+   {:type-code 2300,
+    :name
+    {:fi "Yksittäiset lajikohtaiset sisäliikuntapaikat",
+     :se "Enstaka grenspecifika anläggningar för inomhusidrott",
+     :en "Indoor venues for various sports "},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p66287"]},
+    :main-category "2000"},
+   4300
+   {:type-code 4300,
+    :name {:fi "Hyppyrimäet", :se "Hoppbackar", :en "Ski jumping hills"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p72457"]},
+    :main-category "4000"},
+   4500
+   {:type-code 4500,
+    :name
+    {:fi "Suunnistusalueet",
+     :se "Orienteringsområden",
+     :en "Orienteering areas"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p5355"]},
+    :main-category "4000"},
+   :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p18298"]},
+   4600
+   {:type-code 4600,
+    :name
+    {:fi "Maastohiihtokeskukset",
+     :se "Längdåkningscentra",
+     :en "Cross-country ski resorts"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p75831"]},
+    :main-category "4000"},
+   4800
+   {:type-code 4800,
+    :name
+    {:fi "Ampumaurheilupaikat",
+     :se "Sportskytteplatser",
+     :en "Shooting sports facilities"},
+    :ptv {:ontology-urls ["http://www.yso.fi/onto/koko/p25336"]},
+    :main-category "4000"}})
 
-(def all new/all)
+(def all
+  {1530
+   {:description
+    {:fi
+     "Luisteluun, jääkiekkoon, kaukalopalloon, curlingiin tai muuhun jääurheiluun tarkoitettu kaukalo. Käytössä talvikaudella.",
+     :se
+     "Rink avsedd för skridskoåkning, ishockey, rinkbandy osv. Används under vintersäsongen.",
+     :en "Rink intended for ice-skating, ice hockey, rink bandy, etc."},
+    :tags          {:fi ["jääkiekkokaukalo"]},
+    :name          {:fi "Kaukalo", :se "Rink", :en "Rink"},
+    :type-code     1530,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   1520
+   {:description
+    {:fi
+     "Luisteluun tarkoitettu luonnonmukainen kenttä. Jäädytetään käyttökuntoon talvikaudelle.",
+     :se "Plan avsedd för skridskoåkning. Används under vintersäsongen.",
+     :en "Field intended for ice-skating."},
+    :tags          {:fi []},
+    :name
+    {:fi "Luistelukenttä", :se "Skridskobana", :en "Ice-skating field"},
+    :type-code     1520,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :fields-count                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   2320
+   {:description
+    {:fi
+     "Pysyvästi voimisteluun varustettu tila. Voimistelutilassa on erilaisia kiinteitä voimistelutelineitä ja -rakenteita (esim. volttimonttu, rekki tai trampoliini). Myös cheerleadingin ja sirkusharjoittelun olosuhteet luetaan voimistelutiloiksi. Tarkempi olosuhdetieto kerrotaan lisätiedoissa.",
+     :se "Permanent utrustning för att träna redskapsgymnastik.",
+     :en "Space permanently equipped for artistic gymnastics."},
+    :tags          {:fi ["monttu" "rekki" "nojapuut"]},
+    :name
+    {:fi "Voimistelutila",
+     :se "Utrymme för redskapsgymnastik",
+     :en "Artistic gymnastics facility"},
+    :type-code     2320,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :sport-specification                {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :space-divisible                    {:priority 0},
+     :gymnastic-routines-count           {:priority 0},
+     :area-m2                            {:priority 1},
+     :landing-places-count               {:priority 0},
+     :school-use?                        {:priority 0}}},
+   6130
+   {:description
+    {:fi
+     "Pysyvästi esteratsastukseen varusteltu kenttä tai alue ulkona.",
+     :se "Bana med permanent utrustning för banhoppning",
+     :en "Field permanently equipped for show jumping. Outdoors."},
+    :tags          {:fi ["ratsastuskenttä"]},
+    :name
+    {:fi "Esteratsastuskenttä/-alue",
+     :se "Bana för banhoppning",
+     :en "Show jumping field"},
+    :type-code     6130,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0}}},
+   1395
+   {:description
+    {:fi
+     "Yksi tai useampi pöytätennispöytä ulkona. Pöytätennispöydän tulee olla sijoitettu niin, että pelaamiseen on riittävä tila pöydän ympärillä. Pöydän tulee olla pelikäyttöön soveltuva.",
+     :se
+     "Ett eller flera bordtennisbord utomhus. Bordet är lämpligt för spel och bör vara placerat så att det finns tillräckligt utrymme för spel.",
+     :en
+     "One or more outdoor table tennis tables in the same area. The table must be positioned so that there is enough space for playing. The table must be suitable for the sport."},
+    :tags          {:fi ["pöytätennis" "pingis" "ping pong"]},
+    :name
+    {:fi "Pöytätennisalue",
+     :se "Område med bordtennisbord",
+     :en "Table tennis area"},
+    :type-code     1395,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :table-tennis-count                 {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :water-point                        {:priority 0},
+     :lighting-info                      {:priority 0}}},
+   6210
+   {:description
+    {:fi
+     "Koiran koulutukseen, agilityyn tai muuhun harjoittamiseen varattu ulkoalue.",
+     :se
+     "Område reserverat för hundträning, agility eller annan hundhobby.",
+     :en "Area reserved for dog training, agility or other dog sports."},
+    :tags          {:fi ["agility" "koirakenttä"]},
+    :name
+    {:fi "Koiraurheilualue",
+     :se "Område för hundsport",
+     :en "Dog sports area"},
+    :type-code     6210,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6200,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :track-length-m                     {:priority 0}}},
+   1370
+   {:description
+    {:fi
+     "Tennikseen tarkoitettu kenttä. Mahdollinen lyöntiseinä ja kentän pintamateriaali merkitään lisätietoihin.",
+     :se
+     "En eller flera tennisbanor på samma område. Antalet banor, ytmaterial mm i karakteristika. Även uppgift om slagväggen.",
+     :en
+     "One or more tennis courts in the same area. Number of courts, surface material, etc. specified in properties, including information about a potential hit wall."},
+    :tags          {:fi ["tenniskenttä"]},
+    :name
+    {:fi "Tenniskenttä",
+     :se "Område med tennisbanor",
+     :en "Tennis court area"},
+    :type-code     1370,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :training-wall?                     {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   1360
+   {:description
+    {:fi
+     "Pesäpalloon tarkoitettu kenttä. Jos kentän yhteydessä on katsomoita, lisätään kentän nimeen stadion-sana. Vähintään kansallisen tason pelipaikka. Pintamateriaali on esim. hiekka, hiekkatekonurmi tai muu synteettinen päällyste. Kentän koko on vähintään 50 x 100 m.",
+     :se
+     "En bobollsplan, kan ha flera läktare. Minimikrav: spelplats på nationell nivå. Sand, konstgräs med sand / annan syntetisk beläggning. >50 x 100 m.",
+     :en
+     "Finnish baseball field, may include stands. Can host at least national-level games. Sand, artificial turf / other synthetic surface, > 50 x 100 m. "},
+    :tags          {:fi ["pesäpallostadion"]},
+    :name
+    {:fi "Pesäpallokenttä", :se "Bobollsplan", :en "Baseball field"},
+    :type-code     1360,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :covered-stand-person-count         {:priority 0},
+     :school-use?                        {:priority 0}}},
+   110
+   {:description
+    {:fi
+     "Erämaalailla perustetut alueet pohjoisimmassa Lapissa. Metsähallitus tietolähteenä.",
+     :se
+     "Grundade enligt ödemarkslagen, i nordligaste Lappland. Källa: Forststyrelsen.",
+     :en
+     "Areas located in northernmost Lapland, established based on the Wildeness Act (1991/62). Source of information  Metsähallitus."},
+    :tags          {:fi []},
+    :name
+    {:fi "Erämaa-alue", :se "Vildmarksområden", :en "Wilderness area"},
+    :type-code     110,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2360
+   {:description
+    {:fi "Pysyvästi käytössä oleva ampumarata sisätiloissa.",
+     :se "Permanent skjutbana inomhus.",
+     :en "Permanent indoor shooting range."},
+    :tags          {:fi ["ilmakivääri" "ilma-ase" "ammunta"]},
+    :name
+    {:fi "Sisäampumarata",
+     :se "Inomhusskjutbana",
+     :en "Indoor shooting range"},
+    :type-code     2360,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :air-gun-shooting?                  {:priority 0},
+     :pistol-shooting?                   {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :area-m2                            {:priority 1},
+     :rifle-shooting?                    {:priority 0},
+     :free-rifle-shooting?               {:priority 0},
+     :school-use?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   5310
+   {:description
+    {:fi
+     "Useiden eri moottoriurheilun lajien suorituspaikkoja, huoltotilat olemassa.",
+     :se
+     "Platser för flera olika motorsportgrenar, serviceutrymmen finns.",
+     :en "Venues for various motor sports; service premises available."},
+    :tags          {:fi []},
+    :name
+    {:fi "Moottoriurheilukeskus",
+     :se "Centrum för motorsport",
+     :en "Motor sports centre"},
+    :type-code     5310,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :covered-stand-person-count         {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   1560
+   {:description
+    {:fi
+     "Alamäkiluistelua varten vuosittain rakennettava rata. Käytössä talvikaudella.",
+     :se "Permanent bana byggd för utförsåkning.",
+     :en "Permanent track built for downhill skating. "},
+    :tags          {:fi ["luistelu" "alamäkiluistelu"]},
+    :name
+    {:fi "Alamäkiluistelurata",
+     :se "Skridskobana för utförsåkning",
+     :en "Downhill skating track"},
+    :type-code     1560,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :lifts-count                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 0},
+     :altitude-difference                {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   205
+   {:description
+    {:fi "Rantautumiseen osoitettu paikka, ei järjestettyjä palveluita.",
+     :se "Plats som anvisats för ilandstigning, inga ordnade tjänster.",
+     :en "Place intended for landing by boat, no services provided."},
+    :tags          {:fi ["laituri" "taukopaikka"]},
+    :name
+    {:fi "Rantautumispaikka",
+     :se "Ilandstigningsplats",
+     :en "Boat dock"},
+    :type-code     205,
+    :main-category 0,
+    :status        "deprecated",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:toilet?                            {:priority 0},
+     :boat-launching-spot?               {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :pier?                              {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2150
+   {:description
+    {:fi
+     "Muun rakennuksen yhteydessä oleva avoin liikuntatila, joka sopii monipuolisesti erilaisten liikuntamuotojen harrastamiseen. Salin liikuntapinta-ala vaihtelee tyypillisesti alle 300 neliöstä noin 750 neliöön. Esim. koulurakennuksessa sijaitseva liikuntasali.",
+     :se
+     "En idrottssal som är ansluten till en annan byggnad. Storlek och höjd anges i karakteristika.",
+     :en
+     "A gymnastics hall connected to another building. Size and height specified in properties."},
+    :tags          {:fi ["jumppasali" "voimistelusali"]},
+    :name          {:fi "Liikuntasali", :se "Idrottssal", :en "Gymnastics hall"},
+    :type-code     2150,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2100,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :basketball-fields-count            {:priority 0},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :space-divisible                    {:priority 0},
+     :gymnastics-space?                  {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :futsal-fields-count                {:priority 0},
+     :football-fields-count              {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :handball-fields-count              {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :spinning-hall?                     {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2210
+   {:description
+    {:fi
+     "Liikuntahalli on itsenäinen rakennus, jossa voi olla useita liikuntatiloja tai osiin jaettavissa oleva pääsali.",
+     :se
+     "Idrottshall med utrymmen för flera idrottsgrenar eller med ett i mindre sektioner indelbart huvudidrottsutrymme. Storleken varierar mellan ca 750 och 4999 m2. Inkluderar inomhusaktivitetsparker med faciliteter för flera fysiska aktiviteter.",
+     :en
+     "Building containing facilities for various sports or the main sports area can be split into smaller sections. Hall size varies between app. 750 - 4999 square meters. Includes indoor activity parks with facilities for multiple physical activities."},
+    :tags          {:fi ["urheilutalo" "urheiluhalli"]},
+    :name          {:fi "Liikuntahalli", :se "Idrottshall", :en "Sports hall "},
+    :type-code     2210,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :basketball-fields-count            {:priority 0},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :sprint-lanes-count                 {:priority 0},
+     :javelin-throw-places-count         {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 1},
+     :circular-lanes-count               {:priority 0},
+     :match-clock?                       {:priority 0},
+     :inner-lane-length-m                {:priority 0},
+     :discus-throw-places                {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :hammer-throw-places-count          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 0},
+     :polevault-places-count             {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :space-divisible                    {:priority 0},
+     :toilet?                            {:priority 0},
+     :gymnastics-space?                  {:priority 0},
+     :running-track-surface-material     {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :futsal-fields-count                {:priority 0},
+     :shotput-count                      {:priority 0},
+     :longjump-places-count              {:priority 0},
+     :football-fields-count              {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :squash-courts-count                {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :handball-fields-count              {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :climbing-wall?                     {:priority 0},
+     :school-use?                        {:priority 0},
+     :highjump-places-count              {:priority 0}}},
+   101
+   {:description
+    {:fi
+     "Sijaitsevat taajamissa, max 1 km asutuksesta. Toimivat kävely-, leikki-, oleskelu-, lenkkeily- ja pyöräilypaikkoina. Kaavamerkintä V tai VL. Esimerkkejä lähi- tai ulkoilupuistoista: leikkipuistot, liikennepuistot, perhepuistot, oleskelupuistot, keskuspuistot ja kirkkopuistot.",
+     :se
+     "I tätorter, i omedelbar närhet till bebyggelse. Avsedd för daglig användning. Plats för lek, vistelse och promenader. Planbeteckning VL. Till exempel en lekpark.",
+     :en
+     "In population centres, in or near residential areas. Intended for daily use. Used for play, recreation and walks. Plan symbol VL. E.g. a playground."},
+    :tags          {:fi ["puisto" "lähiliikuntapaikka"]},
+    :name
+    {:fi "Lähi-/ulkoilupuisto", :se "Närpark", :en "Neighbourhood park"},
+    :type-code     101,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:playground?                        {:priority 0},
+     :area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :water-point                        {:priority 0},
+     :toilet?                            {:priority 0}}},
+   102
+   {:description
+    {:fi
+     "Päivittäin käytettäviä alueita, max 1 km asunnoista. Toimivat kävely-, leikki-, oleskelu-, lenkkeily- ja pyöräilypaikkoina. Kevyt liikenne voi mennä ulkoilupuiston läpi. Voi sisältää puistoa, metsää, peltoa, niittyä, vesialuetta. Kaavamerkintä V tai VL.",
+     :se
+     "Områden avsedda för daglig använding, max på 1 kilometers avstånd från bebyggelse. Fungerar som ett område för promenader, lekar, vistelse, joggning och cykling. Lätt trafikled kan fara igenom friluftsparken. Området kan bestå av park, skog, åker, äng och vattenled. Planbeteckning V eller VL.",
+     :en
+     "Used daily, max. 1 km from residential areas. Intended for walks, play, recreation, jogging and cycling. There may be bicycle and pedestrian traffic across the park. May consist of park, forest, fields, meadows, bodies of water. Symbol V or VL."},
+    :tags          {:fi ["puisto"]},
+    :name          {:fi "Ulkoilupuisto", :se "Friluftspark", :en "Leisure park"},
+    :type-code     102,
+    :main-category 0,
+    :status        "deprecated",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:playground?                        {:priority 0},
+     :area-km2                           {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   7000
+   {:description
+    {:fi
+     "Liikuntapaikan tai -paikkojen yhteydessä oleva, liikuntapaikan ylläpitoa tai käyttöä palveleva rakennus. Voi sisältää varastoja, pukuhuoneita, suihkutiloja yms.",
+     :se "Servicebyggnader i anslutning till idrottsanläggningar.",
+     :en "Maintenance buildings in connection with sports facilities."},
+    :tags          {:fi ["konesuoja" "huoltotila"]},
+    :name
+    {:fi "Huoltorakennukset",
+     :se "Servicebyggnader",
+     :en "Maintenance/service buildings"},
+    :type-code     7000,
+    :main-category 7000,
+    :status        "active",
+    :sub-category  7000,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :sauna?                             {:priority 0},
+     :school-use?                        {:priority 0}}},
+   1110
+   {:description
+    {:fi
+     "Liikuntapuisto on useita liikuntapaikkoja käsittävä liikunta-alue. Liikuntapuistossa voi olla esim. erilaisia kenttiä, uimaranta, kuntorata, monitoimihalli, leikkipuisto jne. koottuna samalle alueelle. Lipakseen tallennetaan sekä tieto liikuntapuistosta että yksittäiset liikuntapaikat, joita puisto sisältää. Liikuntapaikat lasketaan omiksi paikoikseen.",
+     :se
+     "En idrottspark är ett idrottsområde med flera idrottsplatser. Där kan finnas olika planer, badstrand, konditionsbana, allaktivitetshall, lekpark osv samlade på samma område. I Lipas lagras uppgifter om såväl idrottsparken som enstaka faciliteter som finns i parken. Varje motionsplats räknas som en plats.",
+     :en
+     "A sports park is an area including several sports facilities, e.g., different fields, beach, a jogging track, a multi-purpose hall, a playground. 'Lipas' contains information both on the sports park and the individual sports facilities found there. The sports facilities are listed as individual items in the classification."},
+    :tags          {:fi ["puisto" "lähiliikunta" "lähiliikuntapaikka"]},
+    :name          {:fi "Liikuntapuisto", :se "Idrottspark", :en "Sports park"},
+    :type-code     1110,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Polygon",
+    :props
+    {:free-use?                          {:priority 0},
+     :fields-count                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :playground?                        {:priority 0},
+     :school-use?                        {:priority 0}}},
+   3250
+   {:description
+    {:fi
+     "Vesiurheilukeskuksessa on vesistössä sijaitsevia liikuntapalveluita tai palvelukokonaisuus, joka voi muodostua erilaisista veden päällä tai vedessä olevista suorituspaikoista tai -radoista."},
+    :tags          {:fi []},
+    :name          {:fi "Vesiurheilukeskus"},
+    :type-code     3250,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3200,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :pool-water-area-m2                 {:priority 0},
+     :sauna?                             {:priority 0},
+     :customer-service-point?            {:priority 0}}},
+   6220
+   {:description
+    {:fi
+     "Erityisesti koiraharrastusta, agilityä, koulutusta tms. varten varustettu halli.",
+     :se
+     "Hall som utrustats särskilt för hundhobby, agility, träning osv.",
+     :en
+     "Hall specifically equipped for dog sports, agility, training, etc."},
+    :tags          {:fi ["agility" "koirahalli"]},
+    :name
+    {:fi "Koiraurheiluhalli",
+     :se "Hundsporthall",
+     :en "Dog sports hall"},
+    :type-code     6220,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6200,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 0}}},
+   4530
+   {:description
+    {:fi
+     "Pyöräillen tapahtuvaan suunnistamiseen, alueesta on pyöräsuunnistukseen soveltuva kartta.",
+     :se "Karta över område som lämpar sig för cykelorientering.",
+     :en "A map for mountain bike orienteering available."},
+    :tags          {:fi []},
+    :name
+    {:fi "Pyöräsuunnistusalue",
+     :se "Cykelorienteringsområde",
+     :en " Mountain bike orienteering area"},
+    :type-code     4530,
+    :main-category 4000,
+    :status        "deprecated",
+    :sub-category  4500,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4720
+   {:description
+    {:fi
+     "Merkitty luonnon kallio, jota voi käyttää kiipeilyyn. Jääkiipeily lisätietoihin. Myös boulderointikalliot.",
+     :se
+     "Märkt berg i naturen. Isklättring i tilläggsinformation. Även berg för bouldering.",
+     :en
+     "Marked natural cliff. Ice climbing specified in additional information. Also includes bouldering cliffs."},
+    :tags          {:fi []},
+    :name          {:fi "Kiipeilykallio", :se "Klätterberg", :en "Climbing rock"},
+    :type-code     4720,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4700,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :climbing-routes-count              {:priority 0},
+     :ice-climbing?                      {:priority 0},
+     :climbing-wall-height-m             {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :climbing-wall-width-m              {:priority 1},
+     :ligthing?                          {:priority 0}}},
+   1330
+   {:description
+    {:fi
+     "Rantalentopallokenttä, pehmeä alusta. Kohde voi sijaita muuallakin kuin rannalla.",
+     :se
+     "Beachvolleybollplan, mjuk grund. Kan också ha annat läge än stranden.",
+     :en
+     "Beach volleyball court, soft basement. May also be located far from a beach."},
+    :tags          {:fi ["rantalentopallo" "rantalentopallokenttä"]},
+    :name
+    {:fi "Beachvolley-/rantalentopallokenttä",
+     :se "Beachvolleyplan",
+     :en "Beach volleyball court"},
+    :type-code     1330,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                    {:priority 1},
+     :surface-material-info               {:priority 0},
+     :height-of-basket-or-net-adjustable? {:priority 0},
+     :free-use?                           {:priority 0},
+     :field-length-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi?  {:priority 0},
+     :toilet?                             {:priority 0},
+     :area-m2                             {:priority 1},
+     :field-width-m                       {:priority 1},
+     :lighting-info                       {:priority 0},
+     :water-point                         {:priority 0},
+     :ligthing?                           {:priority 1},
+     :school-use?                         {:priority 0}}},
+   206
+   {:description
+    {:fi
+     "Rakennettu tulentekopaikka tai keittokatos. Kohde voi olla esimerkiksi maasta eristetty katoksellinen tulisija tai tulisija avotulelle. Tulentekopaikan tarkempi kuvaus ja tieto mahdollisista rajoituksista lisätietoihin.",
+     :se "En byggd eldningsplats eller ett kokskjul. Objektet kan till exempel vara en eldstad med tak som är isolerad från marken eller en eldstad för öppen eld. En mer detaljerad beskrivning av eldningsplatsen och information om eventuella begränsningar finns i ytterligare information.",
+     :en "A constructed fireplace or cooking shelter. The site can be, for example, a covered fireplace isolated from the ground or a fireplace for open fires. A more detailed description of the fireplace and information about any possible restrictions can be found in the additional information."},
+    :tags
+    {:fi
+     ["nuotiopaikka"
+      "keittokatos"
+      "grillauspaikka"
+      "ruoka"
+      "taukopaikka"]},
+    :name
+    {:fi "Ruoanlaitto- / tulentekopaikka",
+     :se "Matlagningsplats",
+     :en "Cooking facilities"},
+    :type-code     206,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :toilet?                            {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :free-use?                          {:priority 0}}},
+   4830
+   {:description
+    {:fi
+     "Ulkona tai sisällä sijaitseva jousiammuntarata. Radan käyttö edellyttää erillistä lupaa, seuran jäsenyyttä tai harjoitusvuoroa.  Radan varustus ja soveltuvat lajit kuvataan lisätiedoissa.",
+     :se "Ute eller inne. Utrustning och grenar i karakteristika.",
+     :en
+     "Outdoors or indoors. Equipment and the various sports detailed in properties."},
+    :tags          {:fi ["jousiampumarata"]},
+    :name
+    {:fi "Jousiammuntarata", :se "Bågskyttebana", :en "Archery range"},
+    :type-code     4830,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4800,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :track-width-m                      {:priority 0},
+     :free-customer-use?                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :track-length-m                     {:priority 1}}},
+   1180
+   {:description
+    {:fi "Frisbeegolfin pelaamiseen rakennettu rata.",
+     :se "En bana byggt för frisbeegolf.",
+     :en "Track built for disc golf. "},
+    :tags          {:fi []},
+    :name
+    {:fi "Frisbeegolfrata",
+     :se "Frisbeegolfbana",
+     :en "Disc golf course"},
+    :type-code     1180,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :holes-count                        {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :altitude-difference                {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :school-use?                        {:priority 0},
+     :track-type                         {:priority 0},
+     :range?                             {:priority 0},
+     :track-length-m                     {:priority 0}}},
+   4422
+   {:description
+    {:fi
+     "Moottorikelkkailuun tarkoitettu reitti, jolla ei ole tehty virallista reittitoimitusta. Reitillä on kuitenkin ylläpitäjä ja maanomistajien lupa.",
+     :se "Ingen ruttexpedition.",
+     :en "No official approval."},
+    :tags          {:fi []},
+    :name
+    {:fi "Moottorikelkkaura",
+     :se "Snöskoterspår",
+     :en "Unofficial snowmobile route"},
+    :type-code     4422,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :route-length-km                    {:priority 1},
+     :rest-places-count                  {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4430
+   {:description
+    {:fi
+     "Ratsastukseen ja/tai kärryillä ajoon tarkoitettu reitti. Sallitut käyttötavat kerrotaan reitin tarkemmissa tiedoissa.",
+     :se
+     "Led avsedd för ridning och/eller häst med kärra. Användningsanvisningar i karakteristika.",
+     :en
+     "Route intended for horseback riding and/or carriage riding. Different uses specified in additional information."},
+    :tags          {:fi ["ratsastusreitti"]},
+    :name          {:fi "Hevosreitti", :se "Hästled", :en "Horse track"},
+    :type-code     4430,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :route-width-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   204
+   {:description
+    {:fi
+     "Luonnon tarkkailuun tarkoitettu rakennelma, lintutorni tai vastaava.",
+     :se
+     "Anordning avsedd för observationer i  naturen, t ex fågeltorn.",
+     :en
+     "Structure built for nature observation. E.g. bird observation tower."},
+    :tags          {:fi ["lintutorni" "näkötorni" "torni"]},
+    :name
+    {:fi "Luontotorni", :se "Naturtorn", :en "Nature observation tower"},
+    :type-code     204,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:toilet?                            {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :free-use?                          {:priority 0}}},
+   106
+   {:description
+    {:fi
+     "Monikäyttöalueiksi voidaan nimittää jokaisenoikeuksin ulkoiluun käytettäviä maa- ja metsätalousalueita. Monikäyttöalueita ovat erityisesti rakentamattomat rannat ja taajamien läheiset maa- ja metsätalousalueet. Kaavamerkintä MU. Virkistysmetsien metsätaloudessa on huomioitu mm. maisemalliset arvot, ja ne on perustettu Metsähallituksen päätöksellä. Virkistysmetsien osalta Lipas-aineisto perustuu Metsähallituksen tietoihin.",
+     :se
+     "Områden för mångsidig användning kan kallas jord- och skogsbruksområden som används för rekreation med allemansrätten. Områden för mångsidig användning är särskilt obebyggda stränder och jord- och skogsbruksområden nära tätorter. Planbeteckning MU. Inom skogsbruket i rekreationsskogar har man beaktat bl.a. landskapsvärden, och de har inrättats genom beslut av Forststyrelsen. När det gäller rekreationsskogar baseras Lipas-materialet på uppgifter från Forststyrelsen.",
+     :en
+     "Multi-use areas can be designated as agricultural and forestry areas used for outdoor activities under everyman's rights. Multi-use areas are particularly undeveloped shores and agricultural and forestry areas near urban areas. Plan designation MU. In the forestry of recreational forests, landscape values, among other things, have been considered, and they have been established by a decision of Metsähallitus. For recreational forests, the Lipas data is based on information from Metsähallitus."},
+    :tags          {:fi ["ulkoilualue" "virkistysalue"]},
+    :name
+    {:fi "Monikäyttöalue tai virkistysmetsä, jossa on virkistyspalveluita",
+     :se "Mångbruksområde eller rekreationsskog med rekreationstjänster",
+     :en "Multi-use area or recreational forest with recreational services"},
+    :type-code     106,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2620
+   {:description
+    {:fi
+     "Biljardisali on biljardin pelaamiseen tarkoitettu tila. Biljardipöytien määrä ja tyyppi kuvataan lisätiedoissa."},
+    :tags          {:fi []},
+    :name          {:fi "Biljardisali"},
+    :type-code     2620,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2600,
+    :geometry-type "Point",
+    :props
+    {:total-billiard-tables-count        {:priority 0},
+     :carom-tables-count                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :snooker-tables-count               {:priority 0},
+     :pool-tables-count                  {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :pyramid-tables-count               {:priority 0},
+     :kaisa-tables-count                 {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4610
+   {:description
+    {:fi
+     "Ampumahiihdon harjoitteluun tarkoitettu alue, jossa on ainakin latu ja ampumapaikka/-paikkoja. ",
+     :se
+     "Annat träningsområde för skidskytte. Spår och skjutplats finns.",
+     :en
+     "Other training area for biathlon. Ski track and shooting range."},
+    :tags          {:fi ["ampumapaikka"]},
+    :name
+    {:fi "Ampumahiihdon harjoittelualue",
+     :se "Träningsområde för skidskytte",
+     :en "Training area for biathlon"},
+    :type-code     4610,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4600,
+    :geometry-type "Point",
+    :props
+    {:stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :lit-route-length-km                {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ski-track-freestyle?               {:priority 0},
+     :route-length-km                    {:priority 0}}},
+   2610
+   {:description
+    {:fi
+     "Keilailuun varustettu halli. Ratojen määrä ja palveluvarustus kirjataan lisätietoihin.",
+     :se "Antalet banor och serviceutrustning i karakteristika.",
+     :en "Number of alleys and service facilities in properties."},
+    :tags          {:fi []},
+    :name          {:fi "Keilahalli", :se "Bowlinghall", :en "Bowling alley"},
+    :type-code     2610,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2600,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :bowling-lanes-count                {:priority 1},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :cosmic-bowling?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2110
+   {:description
+    {:fi
+     "Erilasia liikuntapalveluita ja -tiloja tarjoava kuntokeskus. Kohteessa voi olla esimerkiksi kuntosali- ja ryhmäliikuntatiloja.",
+     :se
+     "Olika motionstjänster och -utrymmen, t ex gym och gruppidrottsutrymmen.",
+     :en
+     "Different sports services and premises, e.g., gym, group exercise premises. "},
+    :tags          {:fi ["kuntosali" "kuntoilu"]},
+    :name
+    {:fi "Kuntokeskus",
+     :se "Konditionsidrottscentrum",
+     :en "Fitness centre"},
+    :type-code     2110,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-customer-use?                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :area-m2                            {:priority 1},
+     :weight-lifting-spots-count         {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :spinning-hall?                     {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 0}}},
+   3120
+   {:description
+    {:fi
+     "Yksittäinen tai useampi pieni uima-allas muun kuin uimahallin tai kylpylän yhteydessä. Uima-allastilat voivat olla pääasiassa esim. kuntoutus- tai terapiakäytössä. Altaiden määrä ja vesipinta-ala kerrotaan ominaisuustiedoissa.",
+     :se "Enstaka simbassäng , ofta i anslutning till en annan byggnad.",
+     :en
+     "Individual swimming pool, often in connection with other buildings."},
+    :tags          {:fi []},
+    :name          {:fi "Uima-allastila", :se "Simbassäng", :en "Swimming pool"},
+    :type-code     3120,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3100,
+    :geometry-type "Point",
+    :props
+    {:pool-tracks-count                  {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :pool-width-m                       {:priority 0},
+     :pool-min-depth-m                   {:priority 0},
+     :swimming-pool-count                {:priority 0},
+     :pool-water-area-m2                 {:priority 1},
+     :pool-length-m                      {:priority 1},
+     :pool-max-depth-m                   {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :pool-temperature-c                 {:priority 0},
+     :school-use?                        {:priority 0}}},
+   104
+   {:description
+    {:fi
+     "Sijaitsevat kauempana taajamasta, automatkan päässä. Monipuolinen polku- ja reittiverkosto. Käyttö painottuu viikonloppuihin ja loma-aikoihin. Palvelevat usein useaa kuntaa. Kaavamerkintä VR.",
+     :se
+     "Ett område på bil avstånd från tätorten, Området har en stor variation av stig- och ruttnätverk. Användningen av området fokuserar sig mest till helgerna och semester tiderna. Området betjänar oftast mer än en kommun. Planbeteckning VR.",
+     :en
+     "Located further away from population centres, accessible by car. Complex network of paths and routes. Use concentrated during weekends and holidays. Often serves several municipalities. Symbol VR."},
+    :tags          {:fi ["virkistysalue"]},
+    :name          {:fi "Retkeilyalue", :se "Utflyktsområde", :en "Hiking area"},
+    :type-code     104,
+    :main-category 0,
+    :status        "deprecated",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :area-km2                           {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2330
+   {:description
+    {:fi "Pysyvästi pöytätennikseen varustettu tila.",
+     :se "Permanent utrustning för att träna bordtennis.",
+     :en "Space permanently equipped for table tennis."},
+    :tags          {:fi ["pingis" "pingispöytä"]},
+    :name
+    {:fi "Pöytätennistila",
+     :se "Utrymme för bordtennis",
+     :en "Table tennis venue"},
+    :type-code     2330,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :active-space-width-m               {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :active-space-length-m              {:priority 0},
+     :table-tennis-count                 {:priority 1},
+     :school-use?                        {:priority 0}}},
+   2280
+   {:description
+    {:fi
+     "Tenniksen pelaamiseen varusteltu halli. Kenttien lukumäärä ja pintamateriaali kerrotaan kohteen lisätiedoissa.",
+     :se "Antalet banor i karakteristika.",
+     :en "Number of courts specified in properties."},
+    :tags          {:fi []},
+    :name          {:fi "Tennishalli", :se "Tennishall", :en "Tennis hall"},
+    :type-code     2280,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :tennis-courts-count                {:priority 1},
+     :field-length-m                     {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :squash-courts-count                {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   6140
+   {:description
+    {:fi "Raviurheilun harjoitus- tai kilparata.",
+     :se "Övnings- eller tävlingsbana för travsport.",
+     :en "Training or competition track for horse racing."},
+    :tags          {:fi []},
+    :name          {:fi "Ravirata", :se "Travbana", :en "Horse racing track"},
+    :type-code     6140,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :track-width-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :covered-stand-person-count         {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   2140
+   {:description
+    {:fi
+     "Sali, jossa voi harrastaa kamppailulajeja kuten painia, nyrkkeilyä tai budolajeja. Tilan koko ja varustus kerrotaan kohteen lisätiedoissa.",
+     :se
+     "Sal där man kan utöva självförsvarsgrenar, t ex brottning, boxning. Storleken anges i karakteristika.",
+     :en
+     "Hall for self-defence sports, e.g., wrestling, boxing. Size specified in properties. "},
+    :tags          {:fi ["paini" "judo" "tatami"]},
+    :name
+    {:fi "Kamppailulajien sali",
+     :se "Sal för kampsport",
+     :en "Martial arts hall"},
+    :type-code     2140,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :space-divisible                    {:priority 0},
+     :tatamis-count                      {:priority 0},
+     :area-m2                            {:priority 1},
+     :wrestling-mats-count               {:priority 0},
+     :boxing-rings-count                 {:priority 0},
+     :weight-lifting-spots-count         {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 0}}},
+   4220
+   {:description
+    {:fi
+     "Hiihtoon tarkoitettu katettu tila (esim. tunneli, putki, halli).",
+     :se
+     "Utrymme avsett för skidåkning under tak (tunnel, rör, hall el dyl).",
+     :en
+     "Covered space (tunnel, tube, hall, etc.) intended for skiing."},
+    :tags          {:fi []},
+    :name          {:fi "Hiihtotunneli", :se "Skidtunnel", :en "Ski tunnel"},
+    :type-code     4220,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4200,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :altitude-difference                {:priority 1},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   2230
+   {:description
+    {:fi
+     "Ensisijaisesti jalkapalloiluun tarkoitettu halli. Halli voi olla ympärivuotisessa käytössä tai erikseen talviajalle pystytettävä kevythalli. Kentän pintamateriaalina on yleensä tekonurmi.",
+     :se
+     "Hall avsedd för fotboll. Ytmaterial, antalet planer och storlek i karakteristika.",
+     :en
+     "Hall intended for football. Surface material, number and size of courts specified in properties."},
+    :tags          {:fi []},
+    :name
+    {:fi "Jalkapallohalli", :se "Fotbollshall", :en "Football hall"},
+    :type-code     2230,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :basketball-fields-count            {:priority 0},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :sprint-track-length-m              {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :football-fields-count              {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   1350
+   {:description
+    {:fi
+     "Suuri jalkapallokenttä, katsomoita. Vähintään kansallisen tason pelipaikka.",
+     :se
+     "Stor fotbollsplan, flera läktare. Minimikrav: spelplats på nationell nivå.",
+     :en
+     "Large football field, stands. Can host at least national-level games."},
+    :tags          {:fi ["jalkapallokenttä"]},
+    :name
+    {:fi "Jalkapallostadion",
+     :se "Fotbollsstadion",
+     :en "Football stadium"},
+    :type-code     1350,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :covered-stand-person-count         {:priority 0},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   4840
+   {:description
+    {:fi
+     "Maastoon rakennettu jousiammuntarata. Radan käyttö edellyttää erillistä lupaa, seuran jäsenyyttä tai harjoitusvuoroa.  ",
+     :se "Bågskyttebana byggd i terrängen.",
+     :en "Archery course built in rough terrain."},
+    :tags          {:fi ["jousiampumarata"]},
+    :name
+    {:fi "Jousiammuntamaastorata",
+     :se "Terrängbana för bågskytte",
+     :en "Field archery course"},
+    :type-code     4840,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4800,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :free-customer-use?                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :track-length-m                     {:priority 1}}},
+   113
+   {:description
+    {:fi
+     "Vapaa-ajankalastukseen sopiva alue. Kohteessa voi olla palvelurakenteita.",
+     :se
+     "Område eller en plats i ett naturligt vattendrag som ställts i ordning för fritidsfiske.",
+     :en
+     "Natural aquatic destination equipped and maintained for recreational fishing."},
+    :tags          {:fi ["kalastusalue" "kalastuspaikka"]},
+    :name
+    {:fi "Kalastuskohde (alue)",
+     :se "Område eller plats för fiske",
+     :en "Fishing area/spot "},
+    :type-code     113,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :pier?                              {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :equipment-rental?                  {:priority 0}}},
+   1510
+   {:description
+    {:fi
+     "Koneellisesti tai keinotekoisesti jäähdytetty ulkokenttä. Kentän koko ja varustustiedot löytyvät lisätiedoista. Käytössä talvikaudella.",
+     :se
+     "En utomhusbana som är mekaniskt eller artificiellt kyld. Information om banans storlek och utrustning finns i ytterligare information. Används under vintersäsongen.",
+     :en
+     "An outdoor rink that is mechanically or artificially cooled. Details about the size and equipment of the rink can be found in the additional information. Used during the winter season."},
+    :tags          {:fi ["luistelukenttä" "luistelu"]},
+    :name
+    {:fi "Tekojääkenttä/tekojäärata",
+     :se "Konstis",
+     :en "Mechanically frozen open-air ice rink"},
+    :type-code     1510,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :fields-count                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   5350
+   {:description
+    {:fi
+     "Pääasiallisesti kiihdytysautoiluun tai kiihdytysmoottoripyöräilyyn käytetty rata.",
+     :se "Huvudsakligen för accelerationskörning.",
+     :en "Mainly for drag racing."},
+    :tags          {:fi []},
+    :name
+    {:fi "Kiihdytysrata", :se "Accelerationsbana", :en "Dragstrip"},
+    :type-code     5350,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :covered-stand-person-count         {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   2225
+   {:description
+    {:fi
+     "Sisäleikkipuistot ovat yleensä pienille lapsille tarkoitettuja liikunnallisia leikkipaikkoja. Sisäaktiviteettipuistot ovat tyypillisesti lapsille ja nuorille tarkoitettuja liikuntakeskuksia, jotka sisältävät erilaisia liikunnallisia kohteita."},
+    :tags          {:fi []},
+    :name          {:fi "Sisäleikki-/sisäaktiviteettipuisto"},
+    :type-code     2225,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:customer-service-point? {:priority 0},
+     :height-m                {:priority 0},
+     :area-m2                 {:priority 0}}},
+   4440
+   {:description
+    {:fi
+     "Hiihtolatu, jossa on aina tai tiettyinä aikoina koirahiihto sallittua. Perinteinen tyyli tai vapaa tyyli.",
+     :se
+     "Ett skidspår där det alltid eller vissa tider är tillåtet att åka med hundspann. Klassisk stil eller fristil.",
+     :en
+     "Ski track on which dog skijoring is allowed either always or at given times. Traditional or free style."},
+    :tags          {:fi ["koiralatu"]},
+    :name
+    {:fi "Koirahiihtolatu",
+     :se "Spår för hundspann",
+     :en "Dog skijoring track"},
+    :type-code     4440,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :ski-track-freestyle?               {:priority 0},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   2520
+   {:description
+    {:fi
+     "Kilpajäähalli on jääurheilun kilpailu- ja ottelutapahtumiin soveltuva jäähalli. Katsomon koko, kenttien lukumäärä ja muut tarkemmat tiedot kuvataan lisätiedoissa.",
+     :se
+     "Läktare finns, storleken på läktaren anges i karakteristika, likaså antalet planer.",
+     :en
+     "Includes bleachers, whose size is specified in properties. Number of fields, heating, changing rooms, etc., specified in properties."},
+    :tags          {:fi ["jäähalli"]},
+    :additional-type
+    {:small       {:fi "Pieni kilpahalli > 500 hlö", :en nil, :se nil},
+     :competition {:fi "Kilpahalli < 3000 hlö", :en nil, :se nil},
+     :large       {:fi "Suurhalli > 3000 hlö", :en nil, :se nil}},
+    :name
+    {:fi "Kilpajäähalli",
+     :se "Tävlingsishall",
+     :en "Competition ice arena"},
+    :type-code     2520,
+    :keywords      {:fi ["Jäähalli"], :en [], :se []},
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 1},
+     :field-2-flexible-rink?             {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :curling-lanes-count                {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :ringette-boundary-markings?        {:priority 0},
+     :field-1-flexible-rink?             {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :school-use?                        {:priority 0},
+     :field-3-flexible-rink?             {:priority 0}}},
+   4710
+   {:description
+    {:fi
+     "Rakennettu kiipeilyseinä ulkona, köysikiipeilyrata tai vastaava kiipeilyä varten rakennettu paikka. Myös rakennetut boulderointipaikat. Paikan tarkempi kuvaus ominaisuustietoihin.",
+     :se
+     "Byggd klättervägg utomhus, klätterbana eller annan plats byggd för klättring. Även platser för bouldering. Precisering i karakteristika.",
+     :en
+     "Built outdoor climbing wall, rope climbing path or other place built for climbing. Also bouldering venues. Clarification in 'properties'."},
+    :tags          {:fi ["kiipeilyseinä" "köysikiipeily"]},
+    :name
+    {:fi "Ulkokiipeilypaikka",
+     :se "Utomhusklätterplats",
+     :en "Open-air climbing venue"},
+    :type-code     4710,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4700,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :climbing-routes-count              {:priority 0},
+     :ice-climbing?                      {:priority 0},
+     :climbing-wall-height-m             {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :climbing-wall-width-m              {:priority 1},
+     :ligthing?                          {:priority 0},
+     :school-use?                        {:priority 0}}},
+   304
+   {:description
+    {:fi
+     "Tavallisen arkiliikunnan taukopaikka, päiväkäyttöön. Lisätietoihin merkitään kohteessa olevat palvelut, esim. kahvio, vuokrauspiste tai opastuspiste.",
+     :se "Rastplats för bruk under dagen, vardagsmotion.",
+     :en "Rest area for regular daily sports, for daytime use."},
+    :tags          {:fi ["tupa" "taukopaikka" "ulkoilumaja" "hiihtomaja"]},
+    :name
+    {:fi "Ulkoilumaja/hiihtomaja",
+     :se "Friluftsstuga/skidstuga",
+     :en "Outdoor/ski lodge "},
+    :type-code     304,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:toilet?                            {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :free-use?                          {:priority 0}}},
+   4412
+   {:description
+    {:fi
+     "Pyöräilyreitti, joka kulkee enimmäkseen päällystetyillä teillä tai sorateillä. Reitti voi olla merkitty maastoon tai se on digitaalisesti opastettu.",
+     :se "Cykelled, ej för mountainbikar.",
+     :en "Biking route, not intended for cross-country biking."},
+    :tags          {:fi []},
+    :name          {:fi "Pyöräilyreitti", :se "Cykelled", :en "Biking route"},
+    :type-code     4412,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :route-length-km                    {:priority 1}}},
+   4820
+   {:description
+    {:fi
+     "Ampumarata jossa myös palveluita. SM-kisojen järjestäminen mahdollista.",
+     :se "Skjutbana med tjänster. Möjligt att arrangera FM-tävlingar.",
+     :en
+     "Shooting range with services. National competitions possible."},
+    :tags          {:fi ["ampumapaikka" "ammunta"]},
+    :name
+    {:fi "Ampumaurheilukeskus",
+     :se "Sportskyttecentrum",
+     :en "Shooting sports centre"},
+    :type-code     4820,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4800,
+    :geometry-type "Point",
+    :props
+    {:stand-capacity-person              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :air-gun-shooting?                  {:priority 0},
+     :toilet?                            {:priority 0},
+     :pistol-shooting?                   {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :rifle-shooting?                    {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :shotgun-shooting?                  {:priority 0},
+     :free-rifle-shooting?               {:priority 0},
+     :ligthing?                          {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   1170
+   {:description
+    {:fi "Ratapyöräilyä varten rakennettu paikka, ulkona (velodromi).",
+     :se "Utomhus, velodrom.",
+     :en "For track racing outdoors (velodrome)."},
+    :tags          {:fi ["velodromi"]},
+    :name
+    {:fi "Pyöräilyrata/velodromi",
+     :se "Velodrom",
+     :en "Velodrome"},
+    :type-code     1170,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   6150
+   {:description
+    {:fi "Islanninhevosten askellajiratsastukseen varattu rata ulkona.",
+     :se
+     "En bana utomhus avsedd för gångartstävlingar med islandshästar.",
+     :en
+     "An outdoor track designated for gaited riding competitions with Icelandic horses."},
+    :tags
+    {:fi
+     ["islanninhevosrata"
+      "islanninhevosratsastus"
+      "ovaalibaana"
+      "askellajiratsastus"
+      "askellajirata"],
+     :se
+     ["islandshästbana"
+      "islandshästridning"
+      "ovalbana"
+      "gångartstävling"
+      "gångartsbana"],
+     :en
+     ["Icelandic horse track"
+      "Icelandic horse riding"
+      "oval track"
+      "gaited riding"
+      "gaited track"]},
+    :name          {:fi "Ovaalirata", :se "Ovalbana", :en "Oval Track"},
+    :type-code     6150,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6100,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :track-width-m                      {:priority 0},
+     :free-use                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 0},
+     :track-length-m                     {:priority 0}}},
+   4404
+   {:description
+    {:fi
+     "Erityisesti luontoharrastusta varten rakennettu ulkoilureitti. Reitin varrella opasteita tai infotauluja alueen luonnosta.",
+     :se
+     "I synnerhet för naturintresse, info- och orienteringstavlor längs leden.",
+     :en
+     "Intended particularly for nature activities; signposts or info boards along the route."},
+    :tags          {:fi ["retkeily"]},
+    :name          {:fi "Luontopolku", :se "Naturstig", :en "Nature trail"},
+    :type-code     4404,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   108
+   {:description
+    {:fi
+     "Metsähallituksen päätöksellä perustettu virkistysmetsä. Metsätaloudessa huomioidaan mm. maisemalliset arvot. Metsähallitus tietolähde.",
+     :se
+     "Grundad enligt Forststyrelsens beslut. I skogsbruket tas hänsyn till bl a landskapsvärden. Källa: Forststyrelsen.",
+     :en
+     "Recreational forest designated by Metsähallitus. E.g. scenic value is considered in forestry. Source of information  Metsähallitus."},
+    :tags          {:fi []},
+    :name
+    {:fi "Virkistysmetsä",
+     :se "Friluftsskog",
+     :en "Recreational forest"},
+    :type-code     108,
+    :main-category 0,
+    :status        "deprecated",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4401
+   {:description
+    {:fi
+     "Kuntoiluun tarkoitettu hoidettu liikuntareitti asutuksen läheisyydessä. Usein ainakin osittain valaistu.",
+     :se "Led avsedd för konditionssport i närheten av bebyggelse.",
+     :en "Route intended for jogging in or near a residential area."},
+    :tags          {:fi ["pururata"]},
+    :name          {:fi "Kuntorata", :se "Konditionsbana", :en "Jogging track"},
+    :type-code     4401,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :outdoor-exercise-machines?         {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :shooting-positions-count           {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   2350
+   {:description
+    {:fi
+     "Pysyvästi tanssi-, ilmaisu- tai ryhmäliikuntaan varustettu itsenäinen tila, joka ei ole osa esim. kuntokeskusta. Myös boutique-, fitness- ja mikrostudiot ovat tanssi- tai ryhmäliikuntatiloja.",
+     :se "Permanent utrustning för dans och kreativ motion.",
+     :en
+     "Space permanently equipped for dance or expressive movement exercise."},
+    :tags          {:fi ["peilisali" "baletti" "tanssisali"]},
+    :name
+    {:fi "Tanssi-/ryhmäliikuntatila",
+     :se "Utrymme för dans",
+     :en "Dance studio"},
+    :type-code     2350,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :active-space-width-m               {:priority 0},
+     :mirror-wall?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :area-m2                            {:priority 1},
+     :active-space-length-m              {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2340
+   {:description
+    {:fi "Pysyvästi miekkailuun varustettu tila.",
+     :se "Permanent utrustning för fäktning.",
+     :en "Space permanently equipped for fencing."},
+    :tags          {:fi []},
+    :name
+    {:fi "Miekkailutila",
+     :se "Utrymme för fäktning",
+     :en "Fencing venue"},
+    :type-code     2340,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :fencing-bases-count                {:priority 1},
+     :school-use?                        {:priority 0}}},
+   2120
+   {:description
+    {:fi
+     "Liikuntatila, jossa on useita kuntosalilaitteita pysyvästi sijoitettuna.",
+     :se "Gymredskap osv. Storleken anges i karakteristika.",
+     :en "Gym equipment, etc. Size specified in properties."},
+    :tags          {:fi ["kuntoilu" "voimailu"]},
+    :name          {:fi "Kuntosali", :se "Gym", :en "Gym"},
+    :type-code     2120,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-customer-use?                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :area-m2                            {:priority 1},
+     :weight-lifting-spots-count         {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :spinning-hall?                     {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 0}}},
+   109
+   {:description
+    {:fi
+     "Ulkoilulailla perustetut, retkeilyä ja luonnon virkistyskäyttöä varten. Metsähallitus tietolähteenä.",
+     :se
+     "Grundat enligt lagen om friluftsliv för att användas för friluftsliv och rekreation i naturen. Källa: Forststyrelsen.",
+     :en
+     "Established based on the Outdoor Recreation Act for hiking and recreational use of nature. Source of information  Metsähallitus."},
+    :tags          {:fi []},
+    :name
+    {:fi "Valtion retkeilyalue",
+     :se "Statens friluftsområde",
+     :en "National hiking area"},
+    :type-code     109,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   1650
+   {:description
+    {:fi
+     "Ensisijaisesti golfin pelaamiseen tarkoitettu alue kesäkaudella. Reikien määrä merkitään lisätietoihin.",
+     :se "Officiell golfbana. Antalet hål anges i karakteristika.",
+     :en
+     "Official golf course. Number of holes included in properties."},
+    :tags          {:fi ["greeni" "puttialue" "range"]},
+    :name          {:fi "Golfkenttä (alue)", :se "Golfbana", :en "Golf course"},
+    :type-code     1650,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1600,
+    :geometry-type "Polygon",
+    :props
+    {:holes-count                        {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :green?                             {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :range?                             {:priority 0}}},
+   4441
+   {:description
+    {:fi "Koiravaljakoille ylläpidetty reitti.",
+     :se "En rutt underhållen för hundspann.",
+     :en "A route maintained for dog sledding."},
+    :tags          {:fi ["valjakkoajo" "valjakkoreitti"], :se [], :en []},
+    :name
+    {:fi "Koiravaljakkoreitti",
+     :se "Hundspannsrutt",
+     :en "Dog Sledding Route"},
+    :type-code     4441,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material      {:priority 0},
+     :surface-material-info {:priority 0},
+     :route-length-km       {:priority 0},
+     :lit-route-length-km   {:priority 0},
+     :route-width-m         {:priority 0},
+     :free-use              {:priority 0},
+     :year-round-use?       {:priority 0}}},
+   5160
+   {:description
+    {:fi
+     "Soudun ja melonnan sisäharjoittelutila on erityisesti näihin lajeihin pysyvästi tarkoitettu liikuntapaikka.",
+     :se "Separat, ej normal bassäng.",
+     :en "Separate training facility, not a regular swimming pool."},
+    :tags          {:fi ["kajakki" "kanootti" "melonta"]},
+    :name
+    {:fi "Soudun ja melonnan sisäharjoittelutila",
+     :se "Inomhusträningsutrymme för rodd och paddling",
+     :en "Indoor training facility for rowing and canoeing"},
+    :type-code     5160,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:area-m2                            {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   1550
+   {:description
+    {:fi
+     "Luisteluun tarkoitettu luonnonjäälle tai maalle rakennettava huollettu luistelureitti. Rakennetaan talvisin samalle alueelle. ",
+     :se
+     "Byggs varje vinter på samma område t ex i en idrottspark eller på havsis.",
+     :en
+     "Built yearly in the same area, e.g., in a sports park or on frozen lake/sea."},
+    :tags          {:fi ["luistelu" "retkiluistelu" "retkiluistelurata"]},
+    :name
+    {:fi "Luistelureitti", :se "Skridskoled", :en "Ice-skating route"},
+    :type-code     1550,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :track-width-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   3230
+   {:description
+    {:fi
+     "Pieni yleinen uimaranta tai uimapaikka, jossa pelastusväline ja ilmoitustaulu. Veden laadun seuranta ja alueen hoito järjestetty.",
+     :se
+     "Liten allmän badstrand eller badplats. Räddningsutrustning och en anslagstavla finns. Kvaliteten på vattnet följs upp och området underhålls.",
+     :en
+     "Small public beach or swimming site. Rescue equipment and a notice board are available. The quality of the water is monitored and the area is maintained."},
+    :tags          {:fi ["uimaranta"]},
+    :name          {:fi "Uimapaikka", :se "Badplats", :en "Swimming site"},
+    :type-code     3230,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3200,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :beach-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :sauna?                             {:priority 0},
+     :other-platforms?                   {:priority 0},
+     :school-use?                        {:priority 0}}},
+   5130
+   {:description
+    {:fi "Pysyvä moottorivenekilpailujen rata-alue.",
+     :se "Permanent banområde för hastighetstävlingar.",
+     :en "Permanent track area for speed competitions."},
+    :tags          {:fi []},
+    :name
+    {:fi "Moottoriveneurheilualue",
+     :se "Område för motorbåtsport",
+     :en "Motor boat sports area"},
+    :type-code     5130,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:pier?                              {:priority 0},
+     :area-km2                           {:priority 0},
+     :boat-places-count                  {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   5110
+   {:description
+    {:fi
+     "Soutustadion sisältää pysyvästi soutuun käytettäviä rakenteita. Soutustadionissa on katsomo ja valmius ratamerkintöihin.",
+     :se
+     "Byggt för rodd, permanent. Läktare och förberett för banmärkning.",
+     :en
+     "Permanent construction for rowing. Bleachers, track markings possible."},
+    :tags          {:fi []},
+    :name          {:fi "Soutustadion", :se "Roddstadion", :en "Rowing stadium"},
+    :type-code     5110,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   3240
+   {:description
+    {:fi
+     "Talviuintipaikka voi sijaita avannossa, avovedessä tai maauimalassa talvikaudella. Talviuintipaikka merkitään omaksi liikuntapaikakseen.",
+     :se
+     "Vinterbadplats kan vara belägen i en vak, öppet vatten eller utomhuspool. Vinterbadplats är markerad som egen idrottsanläggning",
+     :en
+     "Winter swimming area may be located in an ice hole, open water or open air pool. Winter swimming area is marked as its own sports facility."},
+    :tags          {:fi ["avanto" "avantouinti" "talviuinti"]},
+    :name
+    {:fi "Talviuintipaikka",
+     :se "Vinterbadplats",
+     :en "Winter swimming area"},
+    :type-code     3240,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3200,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :ice-reduction?                     {:priority 0},
+     :sauna?                             {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4510
+   {:description
+    {:fi
+     "Suunnistukseen käytetty alue. Lisätietoihin merkitään, jos aluetta käytetään mobo-, pyörä- tai hiihtosuunnistukseen. Suunnistusalueesta on saatavilla kartta ja maankäyttöön on maanomistajan suostumus.",
+     :se
+     "Anmält till orienteringsförbundet. Karta över området tillgänglig.",
+     :en
+     "The Finnish Orienteering Federation has been informed. A map of the area available."},
+    :tags          {:fi []},
+    :name
+    {:fi "Suunnistusalue",
+     :se "Orienteringsområde",
+     :en "Orienteering area"},
+    :type-code     4510,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4500,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :mobile-orienteering?               {:priority 0},
+     :bike-orienteering?                 {:priority 0},
+     :ski-orienteering?                  {:priority 0}}},
+   4240
+   {:description
+    {:fi "Katettu laskettelurinne.",
+     :se "Slalombacke med tak. Höjdskillnad och längd i karakteristika.",
+     :en
+     "Covered ski slope. Height and length specified in attributes."},
+    :tags          {:fi []},
+    :name
+    {:fi "Lasketteluhalli",
+     :se "Slalomhall",
+     :en "Downhill skiing hall"},
+    :type-code     4240,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4200,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :altitude-difference                {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   2270
+   {:description
+    {:fi
+     "Ensisijaisesti squashin pelaamiseen tarkoitettu halli. Yksittäisen kentän mitat 9,75 m x 6,4 m. Vapaa korkeus ja pintamateriaali ilmoitetaan lisätiedoissa.",
+     :se "En eller flera squashplaner. Antalet planer i karakteristika.",
+     :en
+     "One or more squash courts. Number of courts specified in properties."},
+    :tags          {:fi ["squash" "squash-kenttä" "squashkenttä" "squashhalli"]},
+    :name          {:fi "Squash-halli", :se "Squashhall", :en "Squash hall"},
+    :type-code     2270,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :squash-courts-count                {:priority 1},
+     :customer-service-point?            {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4210
+   {:description
+    {:fi
+     "Pysyvästi lajiin varustettu tila, esim. curlingrata tai curlinghalli.",
+     :se "Curlingbana med tak och permanent utrustning för grenen.",
+     :en "Covered track permanently equipped for curling."},
+    :tags          {:fi ["curlinghalli" "curling-halli" "curling-rata"]},
+    :name
+    {:fi "Curlingrata/-halli", :se "Curlingbana", :en "Curling sheet"},
+    :type-code     4210,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4200,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :curling-lanes-count                {:priority 0},
+     :changing-rooms-m2                  {:priority 0}}},
+   301
+   {:description
+    {:fi
+     "Päiväsaikainen levähdyspaikka retkeilijöille. Esimerkiksi kodalla tarkoitetaan kotamallista sääsuojaa tai levähdyspaikkaa ja laavu on kaltevakattoinen sääsuoja, joka sisältää tulipaikan. Lisätietoihin merkitään tieto tulentekopaikasta.",
+     :se "Viloplats för vandrare under dagtid.",
+     :en "Daytime rest stop for hikers."},
+    :tags          {:fi ["taukopaikka"]},
+    :name
+    {:fi "Laavu, kota tai kammi",
+     :se "Vindskydd eller kåta",
+     :en "Lean-to, goahti (Lapp tent shelter) or 'kammi' earth lodge"},
+    :type-code     301,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :toilet?                            {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :water-point                        {:priority 0},
+     :free-use?                          {:priority 0}}},
+   111
+   {:description
+    {:fi
+     "Kansallispuistot ovat luonnonsuojelualueita, joiden perustamisesta ja tarkoituksesta on säädetty lailla. Kansallispuistoissa on merkittyjä reittejä, luontopolkuja ja tulentekopaikkoja. Kansallispuistoissa voi myös yöpyä, sillä niissä on telttailualueita tai yöpymiseen tarkoitettuja rakennuksia. LIPAS-aineisto perustuu Metsähallituksen tietoihin.",
+     :se
+     "Naturskyddsområden med lagstadgad status och uppgift. Areal minst 1000 ha. Källa: Forststyrelsen.",
+     :en
+     "Nature conservation areas whose establishment and purpose are based on legislation. Min. area 1,000 ha. Source of information  Metsähallitus."},
+    :tags          {:fi []},
+    :name
+    {:fi "Kansallispuisto", :se "Nationalpark", :en "National park"},
+    :type-code     111,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4630
+   {:description
+    {:fi
+     "Hiihtokilpailujen järjestämiseen soveltuva kisakeskus, jossa on esimerkiksi lähtö- ja maalialue, huoltotilat ja riittävä latuverkosto.",
+     :se "Start- och målområden, serviceutrymmen, spårsystem.",
+     :en "Start and finish area, service premises. Tracks."},
+    :tags          {:fi ["hiihtostadion"]},
+    :name
+    {:fi "Kilpahiihtokeskus",
+     :se "Maastohiihtokeskus",
+     :en "Ski competition centre"},
+    :type-code     4630,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4600,
+    :geometry-type "Point",
+    :props
+    {:stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :lit-route-length-km                {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :sauna?                             {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :ski-track-freestyle?               {:priority 0},
+     :route-length-km                    {:priority 0}}},
+   4810
+   {:description
+    {:fi "Ulkoampumarata yhdelle tai useammalle lajille.",
+     :se "Utomhusskjutbana för en eller flera grenar.",
+     :en "Outdoor shooting range for one or more sports. "},
+    :tags          {:fi ["ampumapaikka" "ammunta"]},
+    :name
+    {:fi "Ampumarata", :se "Skjutbana", :en "Open-air shooting range"},
+    :type-code     4810,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4800,
+    :geometry-type "Point",
+    :props
+    {:stand-capacity-person              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :air-gun-shooting?                  {:priority 0},
+     :toilet?                            {:priority 0},
+     :pistol-shooting?                   {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :rifle-shooting?                    {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :shotgun-shooting?                  {:priority 0},
+     :free-rifle-shooting?               {:priority 0},
+     :ligthing?                          {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   1540
+   {:description
+    {:fi
+     "Pikaluisteluun varusteltu luistelurata. Radan koko ja pituus lisätään ominaisuustietoihin. Käytössä talvikaudella.",
+     :se "Bana för hastighetsåkning. Används under vintersäsongen.",
+     :en "Track size and length specified in properties."},
+    :tags          {:fi ["luistelurata"]},
+    :name
+    {:fi "Pikaluistelurata",
+     :se "Bana för hastighetsåkning på skridsko",
+     :en "Speed-skating track"},
+    :type-code     1540,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   5320
+   {:description
+    {:fi
+     "Pääasiassa moottoripyöräilyä varten rakennettu, luonnonmukainen ei-asfalttipintainen alue (esim. enduroreitit ja trial-harjoittelualueet maastoliikennealueilla).",
+     :se "Huvudsakligen för motorcykelsport.",
+     :en "Mainly for motorcycling."},
+    :tags          {:fi ["motocross"]},
+    :name
+    {:fi "Moottoripyöräilyalue",
+     :se "Område för motorcykelsport",
+     :en "Motorcycling area"},
+    :type-code     5320,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :covered-stand-person-count         {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   3210
+   {:description
+    {:fi
+     "Maauimala tai vesipuisto on ulkona sijaitseva, vedenpuhdistusjärjestelmällä varustettu uintiin tarkoitettu ja hoidettu vesistö tai uima-altaita/allas. Lisäksi kohteessa voi olla vesiliukumäkiä.",
+     :se "Vattenreningssystem.",
+     :en "Water treatment system."},
+    :tags          {:fi ["uima-allas" "ulkoallas" "ulkouima-allas"]},
+    :name
+    {:fi "Maauimala/vesipuisto", :se "Utebassäng", :en "Open-air pool "},
+    :type-code     3210,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3200,
+    :geometry-type "Point",
+    :props
+    {:pool-tracks-count                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :pool-width-m                       {:priority 0},
+     :pool-min-depth-m                   {:priority 0},
+     :toilet?                            {:priority 0},
+     :swimming-pool-count                {:priority 1},
+     :pool-water-area-m2                 {:priority 1},
+     :pool-length-m                      {:priority 0},
+     :pool-max-depth-m                   {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :pool-temperature-c                 {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4640
+   {:description
+    {:fi
+     "Hiihdon opetteluun ja harjoitteluun tarkoitettu paikka erityisesti lapsille. Erilaisia harjoittelupaikkoja, kuten latuja, mäkiä ym.",
+     :se "Träningsplats för skidåkning, teknikhaster mm.",
+     :en
+     "Ski training venue, an area of parallel short ski tracks for ski instruction, etc."},
+    :tags          {:fi []},
+    :name
+    {:fi "Hiihtomaa", :se "Skidland", :en "Cross-country ski park"},
+    :type-code     4640,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4600,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :ski-track-freestyle?               {:priority 0},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 0}}},
+   1150
+   {:description
+    {:fi
+     "Rullaluistelua, skeittausta, potkulautailua varten varustettu paikka. Ominaisuustiedoissa tarkemmat tiedot kohteesta.",
+     :se
+     "Plats utrustad för rullskridskoåkning, skejtning och sparkcykelåkning.",
+     :en
+     "An area equipped  for roller-blading, skateboarding, kick scooting."},
+    :tags
+    {:fi ["ramppi" "skeittipaikka" "skeittipuisto" "skeittiparkki"]},
+    :name
+    {:fi "Skeitti-/rullaluistelupaikka",
+     :se "Plats för skejtning/rullskridskoåkning",
+     :en "Skateboarding/roller-blading rink "},
+    :type-code     1150,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:area-m2                            {:priority 1},
+     :surface-material-info              {:priority 0},
+     :surface-material                   {:priority 1},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :lighting-info                      {:priority 0}}},
+   2310
+   {:description
+    {:fi
+     "Yksittäinen yleisurheilun olosuhde sisätiloissa esim. liikunta- tai monitoimihallin yhteydessä. Suorituspaikat kuvataan lisätiedoissa.",
+     :se
+     "Fristående, ej i anslutning till en friidrottshall. I karakteristika anges övningsplatserna.",
+     :en
+     "Stand-alone, not in an athletics hall. Venues specified under properties."},
+    :tags          {:fi ["yleisurheilu" "juoksurata"]},
+    :name
+    {:fi "Yksittäinen yleisurheilun suorituspaikka",
+     :se "Enstaka övningsplats för friidrott",
+     :en "Stand-alone athletics venue"},
+    :type-code     2310,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :javelin-throw-places-count         {:priority 0},
+     :sprint-track-length-m              {:priority 0},
+     :inner-lane-length-m                {:priority 0},
+     :discus-throw-places                {:priority 0},
+     :hammer-throw-places-count          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :polevault-places-count             {:priority 0},
+     :area-m2                            {:priority 0},
+     :shotput-count                      {:priority 0},
+     :longjump-places-count              {:priority 0},
+     :school-use?                        {:priority 0},
+     :highjump-places-count              {:priority 0}}},
+   5210
+   {:description
+    {:fi
+     "Harraste- tai urheiluilmailuun tarkoitettu alue, esim. lentopaikka.",
+     :se "Flygsportarena, t ex en flygplats.",
+     :en "Area for air sports, e.g. an airfield."},
+    :tags
+    {:fi
+     ["lentäminen"
+      "lento"
+      "lentokone"
+      "ilmailu"
+      "ilmailualue"
+      "lentokenttä"]},
+    :name
+    {:fi "Urheiluilmailualue",
+     :se "Område för flygsport",
+     :en "Sport aviation area"},
+    :type-code     5210,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5200,
+    :geometry-type "Point",
+    :props
+    {:track-length-m                     {:priority 0},
+     :area-m2                            {:priority 0},
+     :surface-material-info              {:priority 0},
+     :surface-material                   {:priority 0},
+     :track-width-m                      {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2380
+   {:description
+    {:fi "Parkouria varten varustettu sisätila.",
+     :se "Inomhusutrymme utrustat för parkour.",
+     :en "Indoor space equipped for parkour. "},
+    :tags          {:fi ["parkour"]},
+    :name          {:fi "Parkour-sali", :se "Parkoursal", :en "Parkour hall"},
+    :type-code     2380,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                      {:priority 0},
+     :surface-material-info                 {:priority 0},
+     :free-use?                             {:priority 0},
+     :parkour-hall-equipment-and-structures {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi?    {:priority 0},
+     :area-m2                               {:priority 1},
+     :highest-obstacle-m                    {:priority 0},
+     :auxiliary-training-area?              {:priority 0},
+     :school-use?                           {:priority 0}}},
+   103
+   {:description
+    {:fi
+     "Voivat sijaita taajaman reunoilla, vyöhykkeittäin taajaman sisällä tai taajaman ulkopuolella. Kohteissa voi olla myös taajamasta lähteviä tai taajamaan palaavia reittejä tai polku- ja reittiverkosto. Kohteet sisältävät vaihtelevaa maastoa ja luonnonmukaisia tai puistomaisia alueita. Kohteet voivat myös sijaita vesialuiden lähellä kuten rannoilla tai saarissa. Kohteiden pääasiallinen käyttö on retkeilyä ja luonnossa virkistäytymistä, mutta niitä voidaan käyttää monipuolisesti erilaisen liikunnan kuten hiihdon, lenkkeilyn tai uinnin harrastamiseen.  Kaavamerkintä esim. VR. HUOM! Uusien liikunta- ja ulkoilupaikkojen lisäksi Ulkoilu-/virkistysalueluokka sisältää ennen vuotta 2024 Ulkoilualueet ja Retkeilyalueet tyyppiluokkiin lisätyt olosuhteet",
+     :se
+     "Området befinner sig i utkanten av tätorter eller i zoner inom tätorten. På 1-10 kilometers avstånd från bebyggelse. Friluftsområdet används för t.ex. promenader, skidning, joggning, simning. Serverar oftast friluftsaktiviteter för en kommun. Området erbjuder en stor variation av motions möjligheter. Området kan bestå av skog, kärr, åkrar, naturenliga områden och parkliknande delar. Planbeteckning VR.",
+     :en
+     "On the edge of population centres or zoned within population centres. 1-10 km from residential areas. Used for e.g. walks, skiing, jogging, swimming. Serves usually recreational needs within one municipality, offers versatile sports facilities. May include forest, swamp, fields, natural areas and park areas. Symbol VR."},
+    :tags          {:fi ["puisto" "virkistysalue"]},
+    :name
+    {:fi "Ulkoilu-/virkistysalue",
+     :se "Friluftsområde",
+     :en "Outdoor area"},
+    :type-code     103,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :water-point                        {:priority 0}}},
+   201
+   {:description
+    {:fi
+     "Vapaa-ajankalastukseen sopiva kohde. Kohteessa voi olla palvelurakenteita.",
+     :se
+     "Område eller en plats i ett naturligt vattendrag som ställts i ordning för fritidsfiske.",
+     :en
+     "Natural aquatic destination equipped and maintained for recreational fishing."},
+    :tags          {:fi ["kalastusalue" "kalastuspaikka"]},
+    :name
+    {:fi "Kalastuskohde (piste)",
+     :se "Område eller plats för fiske",
+     :en "Fishing area/spot "},
+    :type-code     201,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:toilet?                            {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :pier?                              {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :equipment-rental?                  {:priority 0}}},
+   1220
+   {:description
+    {:fi
+     "Hyvin varusteltu yleisurheilukenttä. Yleissurheilukentällä on ratoja ja yleisurheilun suorituspaikkoja. Myös kisakäyttö on mahdollista. Lyhytrataiset (juoksurata alle 400 m) yleisurheilukentät tallennettaan yleisurheilun harjoitusalueeksi. Yleisurheilukentällä sijaitseva jalkapallon tai muun lajin keskeinen suorituspaikka merkitään omaksi liikuntapaikakseen (esim. jalkapallostadion tai pallokenttä). ",
+     :se
+     "En plan, banor och träningsplatser för friidrott. Centrum, banor, ytbeläggningar samt träningsplatser med beskrivningar.",
+     :en
+     "Field, track and athletic venues/facilities. Centre, tracks, surfaces, venues specified in properties. "},
+    :tags
+    {:fi
+     ["keihäs"
+      "keihäänheitto"
+      "moukari"
+      "pituushyppy"
+      "juoksurata"
+      "kolmiloikka"
+      "seiväs"
+      "kuula"
+      "urheilukenttä"]},
+    :name
+    {:fi "Yleisurheilukenttä",
+     :se "Friidrottsplan",
+     :en "Athletics field"},
+    :type-code     1220,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1200,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :sprint-lanes-count                 {:priority 0},
+     :javelin-throw-places-count         {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :field-length-m                     {:priority 1},
+     :circular-lanes-count               {:priority 0},
+     :match-clock?                       {:priority 0},
+     :sprint-track-length-m              {:priority 0},
+     :inner-lane-length-m                {:priority 0},
+     :discus-throw-places                {:priority 0},
+     :hammer-throw-places-count          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :polevault-places-count             {:priority 0},
+     :toilet?                            {:priority 0},
+     :running-track-surface-material     {:priority 1},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :shotput-count                      {:priority 0},
+     :longjump-places-count              {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :covered-stand-person-count         {:priority 0},
+     :school-use?                        {:priority 0},
+     :highjump-places-count              {:priority 0},
+     :training-spot-surface-material     {:priority 0}}},
+   4411
+   {:description
+    {:fi
+     "Maastopyöräilyyn tarkoitettu reitti, joka kulkee vaihtelevassa maastossa ja on merkitty maastoon. Reitti voi hyödyntää muita olemassa olevia ulkoilureittipohjia.",
+     :se "Led avsedd framför allt för mountainbikar, märkt.",
+     :en "Marked route intended especially for cross-country biking."},
+    :tags          {:fi []},
+    :name
+    {:fi "Maastopyöräilyreitti",
+     :se "Mountainbikeled",
+     :en "Cross-country biking route"},
+    :type-code     4411,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   1140
+   {:description
+    {:fi "Parkouria varten varustettu alue.",
+     :se "Område utrustat för parkour.",
+     :en "An area equipped for parkour."},
+    :tags          {:fi []},
+    :name          {:fi "Parkour-alue", :se "Parkourområde", :en "Parkour area"},
+    :type-code     1140,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :highest-obstacle-m                 {:priority 0},
+     :ligthing?                          {:priority 1},
+     :climbing-wall?                     {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4520
+   {:description
+    {:fi
+     "Hiihtosuunnistukseen soveltuva alue, alueesta hiihtosuunnistuskartta saatavilla.",
+     :se "Skidorienteringskarta över området, ej för sommarorientering.",
+     :en
+     "A ski orienteering map of the area available; no summer orienteering."},
+    :tags          {:fi []},
+    :name
+    {:fi "Hiihtosuunnistusalue",
+     :se "Skidorienteringsområde",
+     :en "Ski orienteering area"},
+    :type-code     4520,
+    :main-category 4000,
+    :status        "deprecated",
+    :sub-category  4500,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   107
+   {:description
+    {:fi
+     "Matkailupalvelujen alueet ovat matkailua palveleville toiminnoille varattuja alueita, jotka sisältävät myös sisäiset liikenneväylät ja -alueet, alueen toimintoja varten tarpeelliset palvelut ja virkistysalueet sekä yhdyskuntateknisen huollon alueet. Kohteet voivat toimia myös retkeilyauto- ja pyörämatkailijoiden tauko- ja yöpymispaikkoina. Kaavamerkintä RM.",
+     :se
+     "Områden med turisttjänster har reserverats för turist- och semestercentra, semesterbyar, semesterhotell och motsvarande aktörer. De har egna trafikleder och -områden samt områden för egna serviceenheter och egen infrastruktur för aktiviteter.  Planbeteckning RM.",
+     :en
+     "Area reserved for tourism and holiday centres, holiday villages, hotels, etc., also including internal traffic routes and areas; services and recreational areas needed for operations, as well as technical maintenance areas. Symbol RM."},
+    :tags          {:fi ["ulkoilualue" "virkistysalue" "leirintäalue"]},
+    :name
+    {:fi "Matkailupalveluiden alue",
+     :se "Område med turisttjänster",
+     :en "Tourist services area"},
+    :type-code     107,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:area-km2                           {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0}}},
+   6110
+   {:description
+    {:fi "Ratsastukseen varustettu kenttä.",
+     :se "Bana avsedd för ridning. Storlek i karakteristika.",
+     :en
+     "Field reserved for horseback riding. Size specified in properties."},
+    :tags          {:fi []},
+    :name          {:fi "Ratsastuskenttä", :se "Ridbana", :en "Equestrian field"},
+    :type-code     6110,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :show-jumping?                      {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0}}},
+   1120
+   {:description
+    {:fi
+     "Lähiliikuntapaikka on tarkoitettu päivittäiseen ulkoiluun ja liikuntaan. Se sijaitsee asutuksen läheisyydessä, on pienimuotoinen ja alueelle on vapaa pääsy. Yleensä tarjolla on erilaisia suorituspaikkoja. Suorituspaikat tulee tallentaa omiksi liikuntapaikoikseen (esim. pallokenttä, ulkokuntosali tai parkour-alue). Lähiliikuntapaikka voi olla myös koulun tai päiväkodin piha, jos liikuntapaikan käyttö on mahdollista kouluajan ulkopuolella.",
+     :se
+     "Ett näridrottsområde är avsett för daglig utomhusaktivitet och motion. Det ligger nära bostadsområden, är småskaligt och har fri tillgång. Vanligtvis erbjuds olika aktivitetsplatser. Aktivitetsplatserna bör registreras som egna idrottsplatser (t.ex. bollplan, utomhusgym eller parkourområde). Ett näridrottsområde kan också vara en skolgård eller en daghemsgård om idrottsplatsen kan användas utanför skoltid.",
+     :en
+     "A local sports facility is intended for daily outdoor activities and exercise. It is located near residential areas, is small-scale, and has free access. Usually, various activity sites are available. Activity sites should be recorded as individual sports facilities (e.g., ball field, outdoor gym, or parkour area). A local sports facility can also be a school or daycare yard if the sports facility can be used outside school hours."},
+    :tags
+    {:fi
+     ["ässäkenttä" "monitoimikenttä" "monitoimikaukalo" "lähipuisto"]},
+    :name
+    {:fi "Lähiliikuntapaikka",
+     :se "Näridrottsplats",
+     :en "Neighbourhood sports area"},
+    :type-code     1120,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :fields-count                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :playground?                        {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 0}}},
+   1390
+   {:description
+    {:fi
+     "Padelin pelaamiseen tarkoitettu kenttä ulkona. Pintamateriaali hiekkatekonurmi. Lajivaatimusten mukaiset seinät. Voi olla myös katettu.",
+     :se
+     "En utomhusbana avsedd för padelspel. Underlagsmaterialet är sandkonstgräs. Väggar enligt sportens krav. Kan även vara täckt.",
+     :en
+     "An outdoor court intended for playing padel. The surface material is sand artificial grass. Walls meet the sport's requirements. It can also be covered."},
+    :tags          {:fi ["padel" "padel-kenttä"]},
+    :name
+    {:fi "Padelkenttä",
+     :se "Område med padelbanor",
+     :en "Padel court area"},
+    :type-code     1390,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   5340
+   {:description
+    {:fi "Pääasiallisesti kartingajoon tai supermotoon käytetty rata.",
+     :se "Huvudsakligen för karting.",
+     :en "Mainly for karting."},
+    :tags          {:fi []},
+    :name          {:fi "Karting-rata", :se "Kartingbana", :en "Kart circuit"},
+    :type-code     5340,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :free-use?                          {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :ligthing?                          {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   302
+   {:description
+    {:fi
+     "Autiotupa, varaustupa, taukotupa, päivätupa. Yöpymis- ja levähdyspaikka retkeilijöille. Autiotupa avoin, varaustupa lukittu ja maksullinen. Päivätupa päiväkäyttöön.",
+     :se
+     "Övernattningsstuga, reserveringsstuga, raststuga, dagstuga. Övernattnings- och rastplats för vandrare. Övernattningsstugan öppen, reserveringsstugan låst och avgiftsbelagd. Dagstuga för bruk under dagen.",
+     :en
+     "Open hut, reservable hut, rest hut, day hut. Overnight resting place for hikers. An open hut is freely available; a reservable hut locked and subject to a charge. A day hut is for daytime use."},
+    :tags          {:fi ["taukopaikka"]},
+    :name          {:fi "Tupa", :se "Stuga", :en "Hut"},
+    :type-code     302,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :toilet?                            {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :water-point                        {:priority 0},
+     :free-use?                          {:priority 0}}},
+   4405
+   {:description
+    {:fi
+     "Maastossa oleva retkeilyreitti, yleensä kauempana asutuksesta. Reitin varrella retkeilyn palveluita, esim. laavuja.",
+     :se
+     "Utflyktsled i terrängen, oftast längre borta från bebyggelse. Längs rutten friluftstjänster, t ex vindskydd.",
+     :en
+     "Natural hiking route, usually further away from residential areas. Provides hiking facilities, e.g. lean-to structures."},
+    :tags          {:fi ["retkeily" "vaellus" "vaelluspolku"]},
+    :name          {:fi "Retkeilyreitti", :se "Utflyktsled", :en "Hiking route"},
+    :type-code     4405,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   6120
+   {:description
+    {:fi "Kylmä tai lämmin katettu tila ratsastukseen.",
+     :se "Kallt eller varmt takförsett utrymme för ridning.",
+     :en "Cold or warm, covered space for horseback riding."},
+    :tags          {:fi ["ratsastushalli" "maneesi"]},
+    :name          {:fi "Ratsastusmaneesi", :se "Ridmanege", :en "Riding manège"},
+    :type-code     6120,
+    :main-category 6000,
+    :status        "active",
+    :sub-category  6100,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :show-jumping?                      {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :school-use?                        {:priority 0}}},
+   4407
+   {:description
+    {:fi
+     "Asfaltoitu rullahiihtoon lumettomana aikana tarkoitettu reitti. Reitti kulkee maastossa, ja sen käyttöä muilla kulkutavoilla on rajoitettu.",
+     :se
+     "En asfalterad bana avsedd för rullskidåkning under snöfria perioder. Banan går genom terrängen och användningen av andra färdsätt är begränsad.",
+     :en
+     "An asphalt track intended for roller skiing during snow-free periods. The track runs through terrain, and the use of other modes of travel is restricted."},
+    :tags
+    {:fi ["rullahiihto"], :se ["rullskidåkning"], :en ["roller skiing"]},
+    :name
+    {:fi "Rullahiihtorata", :se "Rullskidbana", :en "Roller Ski Track"},
+    :type-code     4407,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :outdoor-exercise-machines?         {:priority 0},
+     :free-use                           {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 0},
+     :route-length-km                    {:priority 0}}},
+   1310
+   {:description
+    {:fi
+     "Koripalloon varustettu kenttä, kiinteät tai siirrettävät koritelineet.  Minikenttä ja yhden korin kenttä lisätiedoissa.",
+     :se
+     "Plan utrustad för basket med fasta eller flyttbara ställningar. Miniplan och enkorgsplan i tilläggsupgifter.",
+     :en
+     "A field equipped for basketball, with fixed or movable apparatus. 'Mini-court' and 'one-basket court'  included in additional information. "},
+    :tags          {:fi []},
+    :name
+    {:fi "Koripallokenttä", :se "Basketplan", :en "Basketball court"},
+    :type-code     1310,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                    {:priority 1},
+     :surface-material-info               {:priority 0},
+     :height-of-basket-or-net-adjustable? {:priority 0},
+     :free-use?                           {:priority 0},
+     :field-length-m                      {:priority 1},
+     :match-clock?                        {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi?  {:priority 0},
+     :toilet?                             {:priority 0},
+     :area-m2                             {:priority 1},
+     :field-width-m                       {:priority 1},
+     :lighting-info                       {:priority 0},
+     :scoreboard?                         {:priority 0},
+     :water-point                         {:priority 0},
+     :ligthing?                           {:priority 1},
+     :basketball-field-type               {:priority 0},
+     :school-use?                         {:priority 0}}},
+   202
+   {:description
+    {:fi "Telttailualue tai muu leiriytymiseen osoitettu paikka.",
+     :se "Tältplats eller annat område ordnat för tältning.",
+     :en "Camping site for tents or other encampment. "},
+    :tags
+    {:fi ["yöpyminen" "taukopaikka" "telttapaikka" "leirintäalue"]},
+    :name
+    {:fi "Telttailu ja leiriytyminen",
+     :se "Tältning och läger",
+     :en "Camping"},
+    :type-code     202,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:toilet?                            {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :water-point                        {:priority 0},
+     :free-use?                          {:priority 0}}},
+   1190
+   {:description
+    {:fi
+     "Yleinen mäenlaskuun esimerkiksi pulkalla tai liukurilla tarkoitettu mäki. Kohde on ylläpidetty ja hoidettu, ja se voi muodostua luonnon mäestä tai rakennetuista kumpareista.",
+     :se
+     "En allmän backe avsedd för åkning med till exempel pulka eller stjärtlapp. Backen är underhållen och skött och kan bestå av en naturlig backe eller konstruerade högar.",
+     :en
+     "A common hill intended for sledding with, for example, a sled or a slider. The hill is maintained and taken care of, and it can consist of a natural hill or constructed mounds."},
+    :tags          {:fi ["pulkkailu" "pulkka" "mäenlasku"]},
+    :name          {:fi "Pulkkamäki", :se "Pulkabacke", :en "Sledding hill"},
+    :type-code     1190,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:ligthing?                          {:priority 0},
+     :school-use?                        {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0}}},
+   1620
+   {:description
+    {:fi
+     "Ensisijaisesti golfin pelaamiseen tarkoitettu alue kesäkaudella. Reikien määrä merkitään lisätietoihin.",
+     :se "Officiell golfbana. Antalet hål anges i karakteristika.",
+     :en
+     "Official golf course. Number of holes included in properties."},
+    :tags          {:fi ["greeni" "puttialue" "range"]},
+    :name          {:fi "Golfkenttä (piste)", :se "Golfbana", :en "Golf course"},
+    :type-code     1620,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1600,
+    :geometry-type "Point",
+    :props
+    {:holes-count                        {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :green?                             {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :range?                             {:priority 0}}},
+   2250
+   {:description
+    {:fi
+     "Ensisijaisesti skeittausta varten varustettu halli. Hallia voidaan käyttää bmx-pyöräilyn tai muiden soveltuvien lajien harrastamiseen.",
+     :se
+     "Hall utrustad för skejtning, rullskridskoåkning, bmx-åkning osv.",
+     :en "An area for skateboarding, roller-blading, BMX biking, etc."},
+    :tags          {:fi ["ramppi"]},
+    :name
+    {:fi "Skeittihalli", :se "Skateboardhall", :en "Indoor skatepark"},
+    :type-code     2250,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2530
+   {:description
+    {:fi "Pikaluisteluun tarkoitettu halli.",
+     :se
+     "Hall avsedd för hastighetsåkning på skridsko. Storlek > 333 1/3 m.",
+     :en "Hall intended for speed-skating. Size > 333.3 m."},
+    :tags          {:fi ["jäähalli"]},
+    :name
+    {:fi "Pikaluisteluhalli",
+     :se "Skridskohall",
+     :en "Speed-skating hall"},
+    :type-code     2530,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2500,
+    :geometry-type "Point",
+    :props
+    {:field-2-area-m2                    {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :field-3-length-m                   {:priority 0},
+     :field-2-length-m                   {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-1-length-m                   {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :match-clock?                       {:priority 0},
+     :field-1-width-m                    {:priority 0},
+     :field-3-width-m                    {:priority 0},
+     :field-2-width-m                    {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 1},
+     :field-1-area-m2                    {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :field-3-area-m2                    {:priority 0},
+     :school-use?                        {:priority 0}}},
+   112
+   {:description
+    {:fi
+     "Muut luonnonsuojelualueet kuin kansallispuistot. Tietoja kerätään vain sellaisilta luonnonsuojelualueilta ja luonnonpuistoilta, joiden virkistyskäyttö on mahdollista. Esim. kunta- tai yksityisomisteisille maille perustetut suojelualueet. Kaavamerkintä S, SL.",
+     :se
+     "Andra naturskyddsområden än nationalparker och naturparker. Endast de naturskyddsområden där friluftsanvändning är möjlig. T ex skyddsområden som grundats på kommunal eller privat mark. Planbeteckning S, SL.",
+     :en
+     "Nature conservation areas other than national parks and natural parks. Only nature conservation areas with opportunities for recreation. E.g. protection areas established on municipal and private land. Symbol S, SL."},
+    :tags          {:fi ["virkistysalue"]},
+    :name
+    {:fi "Muu luonnonsuojelualue, jolla on virkistyspalveluita",
+     :se "Annat naturskyddsområde med rekreationstjänster",
+     :en "Other nature conservation area with recreational services"},
+    :type-code     112,
+    :main-category 0,
+    :status        "active",
+    :sub-category  1,
+    :geometry-type "Polygon",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :area-km2                           {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2130
+   {:description
+    {:fi
+     "Painonnostoon tai toiminnalliseen voimaharjoitteluun varustettu kuntoilutila tai voimailusali. Esimerkiksi crossfit- ja painonnostosalit.",
+     :se
+     "Utrustad för tyngdlyftning och boxning. Storleken anges i karakteristika.",
+     :en
+     "Equipped for weightlifting and boxing. Size specified in properties."},
+    :tags          {:fi ["kuntosali" "kuntoilu" "painonnosto" "voimanosto"]},
+    :name
+    {:fi "Voimailusali",
+     :se "Styrketräningssal",
+     :en "Weight training hall "},
+    :type-code     2130,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-customer-use?                 {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :group-exercise-rooms-count         {:priority 0},
+     :tatamis-count                      {:priority 0},
+     :area-m2                            {:priority 1},
+     :wrestling-mats-count               {:priority 0},
+     :boxing-rings-count                 {:priority 0},
+     :weight-lifting-spots-count         {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 0}}},
+   4406
+   {:description
+    {:fi
+     "Talvisin tai ympärivuotisesti käytössä oleva maastoreitti, joka soveltuu usealle kulkutavalle (esim. jalan, lumikengille, läskipyörälle). Lisätietoihin merkitään, jos reitti on ympärivuotisessa käytössä ja mahdolliset kulkutavat.",
+     :se
+     "En terrängled som används på vintern eller året runt och som är lämplig för flera färdsätt (t.ex. till fots, med snöskor, fatbike). Ytterligare information anger om leden är i bruk året runt och möjliga färdsätt.",
+     :en
+     "A terrain trail used in winter or year-round, suitable for multiple modes of travel (e.g., on foot, with snowshoes, fat bike). Additional information indicates if the trail is in year-round use and possible modes of travel."},
+    :tags
+    {:fi ["yhteiskäyttöreitti" "talvipolku"],
+     :se ["gemensam led" "vinterstig"],
+     :en ["shared trail" "winter path"]},
+    :name
+    {:fi "Monikäyttöreitti",
+     :se "Multianvändningsled",
+     :en "Multi-use Trail"},
+    :type-code     4406,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material      {:priority 0},
+     :surface-material-info {:priority 0},
+     :travel-mode-info      {:priority 0},
+     :route-width-m         {:priority 0},
+     :toilet?               {:priority 0},
+     :rest-places-count     {:priority 0},
+     :lit-route-length-km   {:priority 0},
+     :travel-modes          {:priority 0},
+     :year-round-use?       {:priority 0},
+     :route-length-km       {:priority 0}}},
+   3220
+   {:description
+    {:fi
+     "Yleinen uimaranta, EU-uimaranta. Pelastusväline ja ilmoitustaulu, jäteastia ja käymälä. Veden laadun seuranta ja alueen hoito järjestetty.",
+     :se
+     "Allmän badstrand, EU badstrand. Räddningsutrustning, en anslagstavla samt ett sopkärl och en toalett finns. Kvaliteten på vattnet följs upp och området underhålls.",
+     :en
+     "Public beach, EU bathing beach. Rescue equipment, a notice board, a waste bin, and a toilet are available. The quality of the water is monitored and the area is maintained."},
+    :tags          {:fi ["uimapaikka"]},
+    :name          {:fi "Uimaranta", :se "Badstrand", :en "Public beach"},
+    :type-code     3220,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3200,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :beach-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :sauna?                             {:priority 0},
+     :other-platforms?                   {:priority 0},
+     :school-use?                        {:priority 0}}},
+   5330
+   {:description
+    {:fi
+     "Suuri rata-autoiluun tai moottoripyöräilyyn tarkoitettu asfaltoitu moottoriurheilupaikka.",
+     :se "Stor motorsportplats avsedd för bankörning.",
+     :en "Large motor sports venue for formula racing."},
+    :tags          {:fi ["autourheilu"]},
+    :name
+    {:fi "Moottorirata", :se "Motorbana", :en "Formula race track"},
+    :type-code     5330,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   4230
+   {:description
+    {:fi "Lumilautailua varten rakennettu halli.",
+     :se
+     "Tunnel avsedd för snowboardåkning. Olika användningsmöjligheter i tilläggsinformation.",
+     :en
+     "Tunnel intended for snowboarding. Different uses specified in additional information."},
+    :tags          {:fi ["laskettelu"]},
+    :name
+    {:fi "Lumilautatunneli",
+     :se "Snowboardtunnel",
+     :en "Snowboarding tunnel"},
+    :type-code     4230,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :altitude-difference                {:priority 1},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   4320
+   {:description
+    {:fi
+     "Mäkihyppyyn soveltuva mäki, vauhtimäessä on jää-, keramiikka- tai muovilatu. Mäen koko, materiaalit ja mahdollinen kesäkäyttö kuvataan lisätiedoissa.",
+     :se
+     "Is-, keramik- eller plastspår. K-punkt samt sommar- och vinteranvändning i karakteristika. Minimikrav: en liten backe med k-punkt på 75 m eller mera.",
+     :en
+     "Ice, ceramic or plastic track. Summer and winter use specified in attributes, along with K point, etc. Minimum normal hill, K point minimum 75 m."},
+    :tags          {:fi ["mäkihyppy" "hyppyri"]},
+    :name          {:fi "Hyppyrimäki", :se "Hoppbacke", :en "Ski jumping hill"},
+    :type-code     4320,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4300,
+    :geometry-type "Point",
+    :props
+    {:skijump-hill-type                  {:priority 1},
+     :lifts-count                        {:priority 0},
+     :plastic-outrun?                    {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :skijump-hill-material              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :hs-point                           {:priority 0},
+     :k-point                            {:priority 1},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :changing-rooms-m2                  {:priority 0},
+     :jumps-count                        {:priority 0},
+     :inruns-material                    {:priority 0}}},
+   3130
+   {:description
+    {:fi
+     "Monipuolinen uimala kuntoutus-, virkistys- tai hyvinvointipalveluilla. Vesipinta-ala ja allasmäärät/tyypit ominaisuuksiin.",
+     :se
+     "Mångsidig badinrättning med rehabiliterings- och rekreationstjänster. Vattenareal samt antal och typ av bassänger i karakteristika.",
+     :en
+     "Versatile spa with rehabilitation or wellness services. Water volume and number/types of pools specified in properties."},
+    :tags          {:fi []},
+    :name          {:fi "Kylpylä", :se "Badinrättning", :en "Spa"},
+    :type-code     3130,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3100,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :swimming-pool-count                {:priority 1},
+     :pool-water-area-m2                 {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :school-use?                        {:priority 0}}},
+   3110
+   {:description
+    {:fi
+     "Halli, jossa on yksi tai useampia uima-altaita. Altaiden määrä ja vesipinta-ala kysytään ominaisuustiedoissa.",
+     :se
+     "Hall med en eller flera simbassänger. Antalet bassänger och vattenareal anges i karakteristika.",
+     :en
+     "Hall with one or several swimming pools. Number of pools and water surface area is requested in properties."},
+    :tags          {:fi []},
+    :name
+    {:fi "Uimahalli", :se "Simhall", :en "Public indoor swimming pool"},
+    :type-code     3110,
+    :main-category 3000,
+    :status        "active",
+    :sub-category  3100,
+    :geometry-type "Point",
+    :props
+    {:automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :swimming-pool-count                {:priority 1},
+     :pool-water-area-m2                 {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :school-use?                        {:priority 0}}},
+   203
+   {:description
+    {:fi
+     "Kohteessa on veneilyyn liittyviä palveluita kuten säilytysmahdollisuus, vesillelaskupaikka tai veneen kiinnitysmahdollisuus. Kohteelle määritetään venesatamaluokka, jonka palveluvarustus kuvataan lisätiedoissa. Jos kyse on melontalaiturista, se kirjataan kyseisen laituriluokan alle. Kohde tulee merkitä tärkeimmän laiturin läheisyyteen, jos sellainen kohteessa on.",
+     :se "Tjänster för båtfarare. Precisering i karakteristika.",
+     :en "Facilities related to boating. Specififed in 'attributes'."},
+    :tags          {:fi ["satama" "laituri"]},
+    :name
+    {:fi "Veneilyn palvelupaikka",
+     :se "Serviceplats för båtfarare",
+     :en "Boating services"},
+    :type-code     203,
+    :main-category 0,
+    :status        "active",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :boat-launching-spot?               {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :boating-service-class              {:priority 1},
+     :customer-service-point?            {:priority 0},
+     :water-point                        {:priority 0},
+     :accessibility-info                 {:priority 0}}},
+   4620
+   {:description
+    {:fi
+     "Vähintään kansallisen tason kilpailujen järjestämiseen soveltuva ampumahiihtokeskus. Ampumahiihtokeskuksessa useita ampumapaikkoja ja latuverkosto.",
+     :se "Tillräckligt stort för åtminstone nationella tävlingar.",
+     :en "For minimum national level competitions."},
+    :tags          {:fi ["ampumapaikka"]},
+    :name
+    {:fi "Ampumahiihtokeskus",
+     :se "Skidskyttecentrum",
+     :en "Biathlon centre"},
+    :type-code     4620,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4600,
+    :geometry-type "Point",
+    :props
+    {:stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :shower?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :shooting-positions-count           {:priority 1},
+     :lit-route-length-km                {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :sauna?                             {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :ski-track-freestyle?               {:priority 0},
+     :route-length-km                    {:priority 0}}},
+   5360
+   {:description
+    {:fi
+     "Pääasiallisesti jokamiesajoa, rallicrossia tai moottoripyöräilyä varten.",
+     :se "Huvudsakligen för allemanskörning och/eller rallycross.",
+     :en "Mainly for everyman racing and/or rallycross."},
+    :tags          {:fi []},
+    :name
+    {:fi "Jokamies- ja rallicross-rata",
+     :se "Allemans- och rallycrossbana",
+     :en "Everyman racing and rallycross track "},
+    :type-code     5360,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :covered-stand-person-count         {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   2290
+   {:description
+    {:fi "Petanque-peliin tarkoitettu halli.",
+     :se
+     "Hall avsedd för petanque. Storlek, antalet planer och utrustning i karakteristika.",
+     :en "Hall intended for petanque."},
+    :tags          {:fi ["petankki"]},
+    :name
+    {:fi "Petanque-halli", :se "Petanquehall", :en "Petanque hall"},
+    :type-code     2290,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :fields-count                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2260
+   {:description
+    {:fi
+     "Ensisijaisesti sulkapallon pelaamiseen tarkoitettu halli. Vapaa korkeus ilmoitetaan lisätiedoissa.",
+     :se "Hall i första hand  avsedd för badminton.",
+     :en "Hall intended primarily for badminton."},
+    :tags          {:fi []},
+    :name
+    {:fi "Sulkapallohalli", :se "Badmintonhall", :en "Badminton hall"},
+    :type-code     2260,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 0},
+     :badminton-courts-count             {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :squash-courts-count                {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   1160
+   {:description
+    {:fi
+     "Pyöräilyä ja temppuilua varten varattu alue, esim. bmx-, pump track- tai dirt-pyöräilyalue.",
+     :se "Ett område avsett för cykling och trick, till exempel BMX-, pump track- eller dirtcyklingsområde.",
+     :en "An area designated for cycling and stunts, such as a BMX, pump track, or dirt biking area."},
+    :tags          {:fi ["pumptrack" "bmx" "pump" "track"]},
+    :name
+    {:fi "Pyöräilyalue", :se "Cykelåkningsområde", :en "Cycling area"},
+    :type-code     1160,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :ligthing?                          {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :covered-stand-person-count         {:priority 0},
+     :school-use?                        {:priority 0}}},
+   1210
+   {:description
+    {:fi
+     "Yleisurheilun harjoitusalueeksi merkitään kohde, jossa on yleisurheilun harjoitteluun soveltuvia suorituspaikkoja, esim. kenttä, ratoja tai eri lajien suorituspaikkoja, mutta ei virallisen yleisurheilukentän kaikkia suorituspaikkoja. Lyhytrataiset (juoksurata alle 400 m) yleisurheilukentät tallennetaan yleisurheilun harjoitusalueeksi.",
+     :se
+     "Ett område för friidrottsträning markeras där det finns anläggningar som är lämpliga för friidrottsträning, till exempel en plan, banor eller platser för olika grenar, men inte alla anläggningar för en officiell friidrottsarena. Kortbaniga friidrottsarenor (löparbana under 400 m) registreras som friidrottsträningsområden.",
+     :en
+     "An athletics training area is designated for locations with facilities suitable for athletics training, such as a field, tracks, or various event areas, but not all facilities of an official athletics stadium. Short track athletics fields (running track under 400 m) are recorded as athletics training areas."},
+    :tags
+    {:fi
+     ["keihäs"
+      "keihäänheitto"
+      "moukari"
+      "pituushyppy"
+      "juoksurata"
+      "kolmiloikka"
+      "seiväs"
+      "kuula"
+      "urheilukenttä"
+      "yleisurheilukenttä"]},
+    :name
+    {:fi "Yleisurheilun harjoitusalue",
+     :se "Träningsområde för friidrott",
+     :en "Athletics training area"},
+    :type-code     1210,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1200,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :sprint-lanes-count                 {:priority 0},
+     :javelin-throw-places-count         {:priority 0},
+     :field-length-m                     {:priority 0},
+     :circular-lanes-count               {:priority 0},
+     :sprint-track-length-m              {:priority 0},
+     :inner-lane-length-m                {:priority 0},
+     :discus-throw-places                {:priority 0},
+     :hammer-throw-places-count          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :polevault-places-count             {:priority 0},
+     :toilet?                            {:priority 0},
+     :running-track-surface-material     {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :lighting-info                      {:priority 0},
+     :shotput-count                      {:priority 0},
+     :longjump-places-count              {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :highjump-places-count              {:priority 0},
+     :training-spot-surface-material     {:priority 0}}},
+   5140
+   {:description
+    {:fi
+     "Rakennettu pysyvästi vesihiihdolle. Vesihiihtoalueella on laituri.",
+     :se "Byggt för vattenskidåkning, permanent. Minimikrav: brygga.",
+     :en
+     "Permanent construction for water skiing. Minimum equipment  pier."},
+    :tags          {:fi []},
+    :name
+    {:fi "Vesihiihtoalue",
+     :se "Område för vattenskidåkning",
+     :en "Water ski area"},
+    :type-code     5140,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:pier?                              {:priority 0},
+     :area-km2                           {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4310
+   {:description
+    {:fi
+     "Mäkihypyn harjoitteluun rakennettu mäki. K-piste ominaisuustietoihin, materiaalit, kesä- ja talvikäyttö ominaisuuksiin. ",
+     :se
+     "K-punkt, material samt sommar- och vinteranvändning i karakteristika.",
+     :en
+     "K point in properties; materials, summer and winter use specified in attributes. "},
+    :tags          {:fi ["mäkihyppy" "hyppyri" "hyppyrimäki"]},
+    :name
+    {:fi "Harjoitushyppyrimäki",
+     :se "Träningshoppbacke",
+     :en "Ski jumping hill for training"},
+    :type-code     4310,
+    :main-category 4000,
+    :status        "deprecated",
+    :sub-category  4300,
+    :geometry-type "Point",
+    :props
+    {:skijump-hill-type                  {:priority 1},
+     :lifts-count                        {:priority 0},
+     :plastic-outrun?                    {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :skijump-hill-material              {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :k-point                            {:priority 1},
+     :toilet?                            {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :p-point                            {:priority 0},
+     :inruns-material                    {:priority 0},
+     :school-use?                        {:priority 0}}},
+   207
+   {:description
+    {:fi
+     "Opastuspiste on ulkoilureitin, virkistysalueen tai muun liikuntapaikan yhteydessä oleva lisätieto. Paikassa voi olla esimerkiksi opastustaulu ja kartta tai laajempi palvelupiste. Opastuspiste-merkintää voidaan käyttää myös ilmoittamaan reitin lähtöpisteen.",
+     :se
+     "En informationspunkt är en extra information vid en friluftsled, ett rekreationsområde eller en annan idrottsplats. På platsen kan det till exempel finnas en informationstavla och karta eller en mer omfattande servicestation. Informationspunkt-markeringen kan också användas för att ange startpunkten för en rutt.",
+     :en
+     "An information point is additional information associated with an outdoor trail, recreational area, or other sports facility. The location may include, for example, an information board and map or a more extensive service point. The information point marking can also be used to indicate the starting point of a route."},
+    :tags          {:fi ["info" "opastaulu" "infopiste"]},
+    :name          {:fi "Opastuspiste", :se "Informationspunkt", :en "Info"},
+    :type-code     207,
+    :main-category 0,
+    :status        "deprecated",
+    :sub-category  2,
+    :geometry-type "Point",
+    :props
+    {:parking-place?                     {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :toilet?                            {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   1130
+   {:description
+    {:fi
+     "Ulkokuntoilupaikka on esimerkiksi kuntoilulaitteita, voimailulaitteita tai kuntoportaat sisältävä liikuntapaikka. Kohde voi olla osa liikuntapuistoa, liikuntareitin varrella oleva kuntoilupaikka tai ns. ulkokuntosali.",
+     :se
+     "En utomhusträningsplats är en idrottsplats som innehåller till exempel träningsutrustning, styrketräningsutrustning eller träningsstegar. Platsen kan vara en del av en idrottspark, en träningsplats längs en motionsslinga eller en så kallad utomhusgym.",
+     :en
+     "An outdoor fitness area is a sports facility that includes, for example, exercise equipment, strength training equipment, or fitness stairs. The location can be part of a sports park, a fitness spot along a trail, or a so-called outdoor gym"},
+    :tags
+    {:fi
+     ["kuntoilulaite"
+      "ulkokuntoilupiste"
+      "kuntoilupiste"
+      "kuntoilupaikka"
+      "kuntoportaat"]},
+    :name
+    {:fi "Ulkokuntoilupaikka",
+     :se "Konditionspark för utomhusaktiviteter",
+     :en "Street workout park"},
+    :type-code     1130,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1100,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :fitness-stairs-length-m            {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :lighting-info                      {:priority 0},
+     :ligthing?                          {:priority 1},
+     :playground?                        {:priority 0},
+     :school-use?                        {:priority 0},
+     :exercise-machines-count            {:priority 1}}},
+   5120
+   {:description
+    {:fi "Pysyvästi purjehdusta varten varustettu alue.",
+     :se "Byggt för segling, permanent.",
+     :en "Permanent construction for sailing."},
+    :tags          {:fi []},
+    :name
+    {:fi "Purjehdusalue", :se "Seglingsområde", :en "Sailing area"},
+    :type-code     5120,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:area-km2                           {:priority 0},
+     :pier?                              {:priority 0},
+     :boat-places-count                  {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4110
+   {:description
+    {:fi
+     "Laskettelun suorituspaikka on lasketteluun tai lumilautailuun tarkoitettu liikuntapaikka, esim. laskettelukeskus. Laskettelun suorituspaikassa voi olla laskettelurinteitä, parkkeja tai muita rinnerakenteita ja hiihtohissejä.",
+     :se
+     "Slalombacke, rodelbana, pipe, puckelpist, freestyle ramp, trickbana.",
+     :en "Ski slopes, half pipes and other slope structures."},
+    :tags          {:fi ["rinne" "laskettelu" "laskettelurinne"]},
+    :name
+    {:fi "Laskettelun suorituspaikka",
+     :se "Slalombackar och alpina skidcentra",
+     :en "Ski slopes and downhill ski resorts"},
+    :type-code     4110,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4100,
+    :geometry-type "Point",
+    :props
+    {:lifts-count                        {:priority 1},
+     :freestyle-slope?                   {:priority 0},
+     :free-use?                          {:priority 0},
+     :ski-service?                       {:priority 0},
+     :sledding-hill?                     {:priority 0},
+     :longest-slope-m                    {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :snowpark-or-street?                {:priority 0},
+     :max-vertical-difference            {:priority 1},
+     :toilet?                            {:priority 0},
+     :halfpipe-count                     {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :slopes-count                       {:priority 1},
+     :shortest-slope-m                   {:priority 0},
+     :jumps-count                        {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :lit-slopes-count                   {:priority 1},
+     :accessibility-info                 {:priority 0}}},
+   4452
+   {:description
+    {:fi
+     "Merkitty vesireitti, ei kuitenkaan veneväylä. Vesireitti on reittiehdotus-tyyppinen suositeltu vesiretkeilyyn soveltuva reitti. Esim. kirkkovenesoutureitti.",
+     :se
+     "Märkt vattenled, endast ruttförslag t ex för kyrkbåtsrodd, inte som farled för småbåtar.",
+     :en
+     "Marked water route, not a navigation channel. Route suggestions included. E.g., route for \"church rowing boats\"."},
+    :tags          {:fi ["kanootti" "kajakki" "melonta"]},
+    :name
+    {:fi "Vesiretkeilyreitti",
+     :se "Utflyktsled i vattendrag",
+     :en "Water route"},
+    :type-code     4452,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-length-km                    {:priority 1},
+     :rest-places-count                  {:priority 0},
+     :school-use?                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :jumps-count                        {:priority 0}}},
+   5370
+   {:description
+    {:fi "Pääasiallisesti jääspeedwayta varten.",
+     :se "Huvudsakligen för isracing.",
+     :en "Speedway mainly for ice racing."},
+    :tags          {:fi ["speedway"]},
+    :name
+    {:fi "Speedway-/jääspeedwayrata",
+     :se "Isracingbana",
+     :en "Ice speedway track"},
+    :type-code     5370,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :track-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :ligthing?                          {:priority 0},
+     :track-length-m                     {:priority 1}}},
+   2240
+   {:description
+    {:fi
+     "Ensisijaisesti salibandyyn tarkoitettu halli. Kenttien määrä ja pintamateriaali kirjataan lisätietoihin.",
+     :se
+     "Hall i första hand avsedd för innebandy. Antalet planer samt ytmaterial i karakteristika.",
+     :en
+     "Hall primarily intended for floorball. Number of courts and surface material specified in properties."},
+    :tags          {:fi ["sähly"]},
+    :name
+    {:fi "Salibandyhalli", :se "Innebandyhall", :en "Floorball hall"},
+    :type-code     2240,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 0, :derived? true},
+     :surface-material                   {:priority 1, :derived? true},
+     :surface-material-info              {:priority 0, :derived? true},
+     :stand-capacity-person              {:priority 0, :derived? true},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1, :derived? true},
+     :badminton-courts-count             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1, :derived? true},
+     :field-width-m                      {:priority 1, :derived? true},
+     :scoreboard?                        {:priority 0},
+     :floorball-fields-count             {:priority 1, :derived? true},
+     :auxiliary-training-area?           {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2510
+   {:description
+    {:fi
+     "Harjoitusjäähalli on pääasiassa jääurheilun harjoitteluun ja jääliikuntaan käytettävä jäähalli.",
+     :se
+     "Antalet planer och omklädningshytter, uppvärmning osv anges i karakteristika.",
+     :en
+     "Number of fields, heating, changing rooms, etc., specified in properties."},
+    :tags          {:fi ["jäähalli"]},
+    :name
+    {:fi "Harjoitusjäähalli",
+     :se "Övningsishall",
+     :en "Training ice arena"},
+    :type-code     2510,
+    :keywords      {:fi ["Jäähalli"], :en [], :se []},
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2500,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :finish-line-camera?                {:priority 0},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :ice-rinks-count                    {:priority 1},
+     :field-2-flexible-rink?             {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :curling-lanes-count                {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :ringette-boundary-markings?        {:priority 0},
+     :field-1-flexible-rink?             {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :school-use?                        {:priority 0},
+     :field-3-flexible-rink?             {:priority 0}}},
+   1640
+   {:description
+    {:fi "Ratagolfliiton hyväksymät ratagolf-/minigolfradat.",
+     :se "Bangolf / minigolf, enligt Finlands Bangolfförbundets regler.",
+     :en
+     "A course built for miniature golf, accepted by the Ratagolf Union."},
+    :tags          {:fi ["minigolf"]},
+    :name          {:fi "Ratagolf", :se "Bangolf", :en "Minigolf course"},
+    :type-code     1640,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1600,
+    :geometry-type "Point",
+    :props
+    {:holes-count                        {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :green?                             {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :range?                             {:priority 0}}},
+   1380
+   {:description
+    {:fi "Rullakiekon pelaamiseen varustettu kenttä.",
+     :se "Plan utrustad för inlinehockey.",
+     :en "Field equipped for roller hockey."},
+    :tags          {:fi ["rullakiekko"]},
+    :name
+    {:fi "Rullakiekkokenttä",
+     :se "Inlinehockeyplan",
+     :en "Roller hockey field"},
+    :type-code     1380,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :match-clock?                       {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0}}},
+   4451
+   {:description
+    {:fi
+     "Erityisesti melontaan tarkoitettu vesistöreitti. Reitistä on laadittu reittikuvaus ja maastossa löytyy opasteita (esim. rantautumispaikoista). Reittiehdotus-tyyppinen, ei navigointiin.",
+     :se
+     "Särskilt för paddling, märkt med ruttförslag, ej för navigering.",
+     :en
+     "Marked route particularly for canoeing. Route suggestions are not intended for navigation."},
+    :tags          {:fi ["kanootti" "kajakki"]},
+    :name          {:fi "Melontareitti", :se "Paddlingsled", :en "Canoe route"},
+    :type-code     4451,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:route-length-km                    {:priority 1},
+     :rest-places-count                  {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   4403
+   {:description
+    {:fi
+     "Jalkaisin tapahtuvaan ulkoiluun tarkoitettu reitti. Suhteellisen leveä ja helppokulkuinen reitti, yleensä valaistu ja pinnoitettu.",
+     :se
+     "Promenadled. Relativt bred och lättilgänglig, eventuellt belyst och asfalterad.",
+     :en
+     "Route intended for outdoor pedestrian activities. Relatively broad and passable. Potentially lit and surfaced."},
+    :tags          {:fi ["ulkoilu" "kävely" "ulkoilureitti" "kävelyreitti"]},
+    :name
+    {:fi "Kävelyreitti/ulkoilureitti",
+     :se "Promenadled/friluftsled",
+     :en "Walking route/outdoor route"},
+    :type-code     4403,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :outdoor-exercise-machines?         {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :accessibility-info                 {:priority 0},
+     :route-length-km                    {:priority 1}}},
+   5150
+   {:description
+    {:fi
+     "Melontaan tarkoitettu palvelupaikka, jossa voi olla esim. vuokrauspalveluita. Melontakeskuksesta voi lähteä melontareitti tai sen yhteydessä voi olla melontaratoja.",
+     :se "",
+     :en ""},
+    :tags          {:fi ["melonta" "kajakki" "kanootti" "melontakeskus"]},
+    :name
+    {:fi "Melontakeskus",
+     :se "Centrum för paddling",
+     :en "Canoeing centre"},
+    :type-code     5150,
+    :main-category 5000,
+    :status        "active",
+    :sub-category  5100,
+    :geometry-type "Point",
+    :props
+    {:free-use?                          {:priority 0},
+     :pier?                              {:priority 0},
+     :canoeing-club?                     {:priority 0},
+     :altitude-difference                {:priority 0},
+     :rapid-canoeing-centre?             {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :equipment-rental?                  {:priority 0},
+     :activity-service-company?          {:priority 0}}},
+   1630
+   {:description
+    {:fi
+     "Golfia varten varustettu sisäharjoittelutila. Voi olla useita erilaisia suorituspaikkoja.",
+     :se "Övningsutrymme byggt för golf. Storlek i karakteristika.",
+     :en "Training space built for golf. Size specified in properties."},
+    :tags          {:fi ["greeni" "puttialue"]},
+    :name
+    {:fi "Golfin harjoitushalli",
+     :se "Övningshall för golf",
+     :en "Golf training hall"},
+    :type-code     1630,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :holes-count                        {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :customer-service-point?            {:priority 0},
+     :green?                             {:priority 0},
+     :school-use?                        {:priority 0},
+     :range?                             {:priority 0}}},
+   2295
+   {:description
+    {:fi
+     "Yksi tai useampi padelkenttä sisällä. Pintamateriaali tekonurmi (hiekkatekonurmi). Lajivaatimusten mukaiset seinät. Vapaa korkeus ilmoitetaan lisätiedoissa.",
+     :se
+     "En eller flera padelbanor inomhus. Ytmaterial konstgräs (med sand), 20 x 10 m. Väggar måste uppfylla spelets krav. Höjd anges i karakteristika.",
+     :en
+     "One or more indoor padel courts. The court has an artificial grass surface and its measurements are 20 x 10 metres. The walls must meet the requirements for the sport. Height given in 'properties'."},
+    :tags          {:fi ["padel" "padel-halli"]},
+    :name          {:fi "Padelhalli", :se "Padelhall", :en "Padel hall"},
+    :type-code     2295,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 1},
+     :toilet?                            {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 0},
+     :scoreboard?                        {:priority 0},
+     :school-use?                        {:priority 0}}},
+   2370
+   {:description
+    {:fi "Kiipeilyyn varustettu sisätila. Myös boulderointipaikat.",
+     :se
+     "Inomhusutrymme utrustat för klättring, även platser för bouldering.",
+     :en "Indoor space equipped for climbing. Also bouldering venues."},
+    :tags          {:fi ["kiipeilyseinä"]},
+    :name
+    {:fi "Sisäkiipeilyseinä",
+     :se "Klättervägg inomhus",
+     :en "Indoor climbing wall"},
+    :type-code     2370,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                   {:priority 0},
+     :surface-material-info              {:priority 0},
+     :climbing-routes-count              {:priority 0},
+     :climbing-wall-height-m             {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :area-m2                            {:priority 1},
+     :climbing-wall-width-m              {:priority 1},
+     :school-use?                        {:priority 0}}},
+   1340
+   {:description
+    {:fi
+     "Palloiluun tarkoitettu kenttä, jonka pintamateriaali on esim. hiekka, nurmi tai hiekkatekonurmi. Kentällä on mahdollista pelata yhtä tai useampaa palloilulajia. Kentän koko merkitään lisätietoihin.  Kevyt poistettava kate on mahdollinen.",
+     :se
+     "Plan avsedd för bollspel. Sand, konstgräs med sand el dyl, storleken varierar. En eller flera bollspelsgrenar möjliga.",
+     :en
+     "A field intended for ball games. Sand, grass, artificial turf, etc., size varies. One or more types of ball games possible."},
+    :tags          {:fi []},
+    :name          {:fi "Pallokenttä", :se "Bollplan", :en "Ball field"},
+    :type-code     1340,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:heating?                           {:priority 0},
+     :surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :field-length-m                     {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :changing-rooms?                    {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :lighting-info                      {:priority 0},
+     :year-round-use?                    {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :water-point                        {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :light-roof?                        {:priority 0}}},
+   1610
+   {:description
+    {:fi
+     "Golfin harjoittelua varten varustettu alue. Harjoitusalue voi sisältää useampia suorituspaikkoja, kuten rangen ja puttausviheriön. Harjoitusalue sijaitsee ulkona.",
+     :se
+     "Ett område utrustat för golfträning. Träningsområdet kan innehålla flera träningsplatser, såsom en range och en puttningsgreen. Träningsområdet ligger utomhus.",
+     :en "An area equipped for golf practice. The practice area may include multiple facilities, such as a driving range and a putting green. The practice area is located outdoors."},
+    :tags          {:fi ["greeni" "puttialue" "range"]},
+    :name
+    {:fi "Golfin harjoitusalue",
+     :se "Träningsområde för golf",
+     :en "Golf training area"},
+    :type-code     1610,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1600,
+    :geometry-type "Point",
+    :props
+    {:holes-count                        {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :lighting-info                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :green?                             {:priority 0},
+     :ligthing?                          {:priority 1},
+     :school-use?                        {:priority 0},
+     :range?                             {:priority 0}}},
+   4421
+   {:description
+    {:fi
+     "Reittitoimituksella hyväksytty, virallinen moottorikelkkailureitti.",
+     :se "En officiell rutt som godkänts genom en ruttexpedition.",
+     :en "Officially approved route (in compliance with Act 670/1991)."},
+    :tags          {:fi []},
+    :name
+    {:fi "Moottorikelkkareitti",
+     :se "Snöskoterled",
+     :en "Official snowmobile route"},
+    :type-code     4421,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:rest-places-count                  {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :route-length-km                    {:priority 1},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0}}},
+   2220
+   {:description
+    {:fi
+     "Monitoimihalli on suuri liikuntatila, joka on merkittävä monien lajien kilpailu- ja tapahtumapaikka. Liikuntapinta-ala on suurempi kuin 5 000 m2.",
+     :se "Större tävlingsplats för ett flertal grenar, >= 5 000 m2.",
+     :en "Significant competition venue for various sports, >=5000 m2."},
+    :tags          {:fi ["liikuntahalli" "urheilutalo" "urheiluhalli"]},
+    :name
+    {:fi "Monitoimihalli/areena",
+     :se "Allaktivitetshall/multiarena",
+     :en "Multipurpose hall/arena"},
+    :type-code     2220,
+    :main-category 2000,
+    :status        "active",
+    :sub-category  2200,
+    :geometry-type "Point",
+    :props
+    {:height-m                           {:priority 1},
+     :surface-material                   {:priority 1},
+     :basketball-fields-count            {:priority 0},
+     :surface-material-info              {:priority 0},
+     :automated-timing?                  {:priority 0},
+     :stand-capacity-person              {:priority 0},
+     :free-use?                          {:priority 0},
+     :sprint-lanes-count                 {:priority 0},
+     :javelin-throw-places-count         {:priority 0},
+     :tennis-courts-count                {:priority 0},
+     :field-length-m                     {:priority 1},
+     :circular-lanes-count               {:priority 0},
+     :match-clock?                       {:priority 0},
+     :sprint-track-length-m              {:priority 0},
+     :inner-lane-length-m                {:priority 0},
+     :discus-throw-places                {:priority 0},
+     :badminton-courts-count             {:priority 0},
+     :hammer-throw-places-count          {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :padel-courts-count                 {:priority 0},
+     :polevault-places-count             {:priority 0},
+     :space-divisible                    {:priority 0},
+     :toilet?                            {:priority 0},
+     :gymnastics-space?                  {:priority 0},
+     :running-track-surface-material     {:priority 0},
+     :area-m2                            {:priority 1},
+     :field-width-m                      {:priority 1},
+     :scoreboard?                        {:priority 0},
+     :shotput-count                      {:priority 0},
+     :longjump-places-count              {:priority 0},
+     :football-fields-count              {:priority 0},
+     :floorball-fields-count             {:priority 0},
+     :auxiliary-training-area?           {:priority 0},
+     :squash-courts-count                {:priority 0},
+     :loudspeakers?                      {:priority 0},
+     :customer-service-point?            {:priority 0},
+     :accessibility-info                 {:priority 0},
+     :handball-fields-count              {:priority 0},
+     :volleyball-fields-count            {:priority 0},
+     :climbing-wall?                     {:priority 0},
+     :school-use?                        {:priority 0},
+     :highjump-places-count              {:priority 0}}},
+   1320
+   {:description
+    {:fi
+     "Lentopalloon varustettu kenttä, jossa on kiinteät lentopallotolpat.",
+     :se "Plan utrustad för volleyboll. Fasta volleybollställningar.",
+     :en "A field equipped for volleyball. Fixed volleyball apparatus."},
+    :tags          {:fi []},
+    :name
+    {:fi "Lentopallokenttä",
+     :se "Volleybollplan",
+     :en "Volleyball court"},
+    :type-code     1320,
+    :main-category 1000,
+    :status        "active",
+    :sub-category  1300,
+    :geometry-type "Point",
+    :props
+    {:surface-material                    {:priority 1},
+     :surface-material-info               {:priority 0},
+     :height-of-basket-or-net-adjustable? {:priority 0},
+     :free-use?                           {:priority 0},
+     :field-length-m                      {:priority 1},
+     :may-be-shown-in-harrastuspassi-fi?  {:priority 0},
+     :toilet?                             {:priority 0},
+     :area-m2                             {:priority 1},
+     :field-width-m                       {:priority 1},
+     :lighting-info                       {:priority 0},
+     :water-point                         {:priority 0},
+     :ligthing?                           {:priority 1},
+     :school-use?                         {:priority 0}}},
+   4402
+   {:description
+    {:fi
+     "Talvikaudella hiihtoa varten ylläpidetty reitti. Hiihtotyylit kerrotaan ominaisuustiedoissa.",
+     :se
+     "Led avsedd för skidåkning. Ej sommaranvändning och -underhåll. Åkstilar anges i karakteristika.",
+     :en
+     "Route intended for skiing. Not in use and unmaintained in summer. Ski styles provided in properties."},
+    :tags          {:fi ["hiihto" "hiihtolatu"]},
+    :name          {:fi "Hiihtolatu", :se "Skidspår", :en "Ski track"},
+    :type-code     4402,
+    :main-category 4000,
+    :status        "active",
+    :sub-category  4400,
+    :geometry-type "LineString",
+    :props
+    {:surface-material                   {:priority 1},
+     :surface-material-info              {:priority 0},
+     :free-use?                          {:priority 0},
+     :may-be-shown-in-excursion-map-fi?  {:priority 0},
+     :outdoor-exercise-machines?         {:priority 0},
+     :ski-track-traditional?             {:priority 0},
+     :route-width-m                      {:priority 0},
+     :may-be-shown-in-harrastuspassi-fi? {:priority 0},
+     :toilet?                            {:priority 0},
+     :rest-places-count                  {:priority 0},
+     :shooting-positions-count           {:priority 0},
+     :lit-route-length-km                {:priority 1},
+     :ski-track-freestyle?               {:priority 0},
+     :school-use?                        {:priority 0},
+     :route-length-km                    {:priority 1}}}})
 
 (def active
   (reduce-kv (fn [m k v] (if (not= "active" (:status v)) (dissoc m k) m)) all all))
 
 (def unknown
-  new/unknown)
+  {:name          {:fi "Ei tietoa" :se "Unknown" :en "Unknown"}
+   :type-code     -1
+   :main-category -1
+   :sub-category  -1})
 
 (def by-main-category (group-by :main-category (vals active)))
 (def by-sub-category (group-by :sub-category (vals active)))

--- a/webapp/src/cljc/lipas/data/types.cljc
+++ b/webapp/src/cljc/lipas/data/types.cljc
@@ -3,22 +3,22 @@
   namespace hosts a controlled place to roll-out the changes."
   (:require
    [lipas.data.types-old :as old]
-   #_[lipas.data.types-new :as new]
+   [lipas.data.types-new :as new]
    [lipas.utils :as utils]))
 
 (def main-categories
-  old/main-categories)
+  new/main-categories)
 
 (def sub-categories
-  old/sub-categories)
+  new/sub-categories)
 
-(def all old/all)
+(def all new/all)
 
 (def active
   (reduce-kv (fn [m k v] (if (not= "active" (:status v)) (dissoc m k) m)) all all))
 
 (def unknown
-  old/unknown)
+  new/unknown)
 
 (def by-main-category (group-by :main-category (vals active)))
 (def by-sub-category (group-by :sub-category (vals active)))

--- a/webapp/src/cljc/lipas/data/types.cljc
+++ b/webapp/src/cljc/lipas/data/types.cljc
@@ -1766,9 +1766,10 @@
      "Includes bleachers, whose size is specified in properties. Number of fields, heating, changing rooms, etc., specified in properties."},
     :tags          {:fi ["jäähalli"]},
     :additional-type
-    {:small       {:fi "Pieni kilpahalli > 500 hlö", :en nil, :se nil},
-     :competition {:fi "Kilpahalli < 3000 hlö", :en nil, :se nil},
-     :large       {:fi "Suurhalli > 3000 hlö", :en nil, :se nil}},
+    {:small       {:fi "Pieni kilpahalli > 500 hlö", :en "Small competition hall > 500 people", :se "Liten tävlingshall > 500 personer"},
+     :competition {:fi "Kilpahalli < 3000 hlö", :en "Competition hall < 3000 people", :se "Tävlingshall < 3000 personer"},
+     :large       {:fi "Suurhalli > 3000 hlö", :en "Large hall > 3000 people", :se "Större hall > 3000 personer"}}
+,
     :name
     {:fi "Kilpajäähalli",
      :se "Tävlingsishall",
@@ -4309,8 +4310,8 @@
    {:description
     {:fi
      "Melontaan tarkoitettu palvelupaikka, jossa voi olla esim. vuokrauspalveluita. Melontakeskuksesta voi lähteä melontareitti tai sen yhteydessä voi olla melontaratoja.",
-     :se "",
-     :en ""},
+     :se "En paddlingsanläggning med uthyrningstjänster. Från paddlingscentret kan det finnas paddelleder eller paddelbanor i närheten.",
+     :en "A canoeing facility with rental services. From the canoeing center, there may be canoeing routes or paddling tracks nearby."},
     :tags          {:fi ["melonta" "kajakki" "kanootti" "melontakeskus"]},
     :name
     {:fi "Melontakeskus",

--- a/webapp/src/cljc/lipas/data/types_new.cljc
+++ b/webapp/src/cljc/lipas/data/types_new.cljc
@@ -825,7 +825,26 @@
 
       ))
 
-(def all all7)
+(def all8
+  (-> all7
+      (update-in [4810 :props] dissoc :free-use?)
+      (update-in [4820 :props] dissoc :free-use?)
+      (assoc-in [5120 :description :fi] "Pysyvästi purjehdusta varten varustettu alue.")
+      (assoc-in [202 :props :free-use?] {:priority 0})
+      (assoc-in [203 :props :free-use?] {:priority 0})
+      (assoc-in [204 :props :free-use?] {:priority 0})
+      (assoc-in [206 :props :free-use?] {:priority 0})
+      (assoc-in [301 :props :free-use?] {:priority 0})
+      (assoc-in [302 :props :free-use?] {:priority 0})
+      (assoc-in [304 :props :free-use?] {:priority 0})
+      (assoc-in [4412 :description :fi] "Pyöräilyreitti, joka kulkee enimmäkseen päällystetyillä teillä tai sorateillä. Reitti voi olla merkitty maastoon tai se on digitaalisesti opastettu.")
+      (assoc-in [5370 :name :fi] "Speedway-/jääspeedwayrata")
+      (assoc-in [6130 :name :fi] "Esteratsastuskenttä/-alue")
+      (assoc-in [3210 :name :fi] "Maauimala/vesipuisto")
+
+      ))
+
+(def all all8)
 
 (def active
   (reduce-kv (fn [m k v] (if (not= "active" (:status v)) (dissoc m k) m)) all all))
@@ -843,5 +862,9 @@
   (utils/index-by (comp :fi :name) (vals sub-categories)))
 
 (comment
-  (all 2620)
+  (require '[clojure.pprint :as pprint])
+  #?(:clj (spit "/tmp/types.edn" (with-out-str (pprint/pprint all))))
+  #?(:clj (spit "/tmp/sub-cats.edn" (with-out-str (pprint/pprint sub-categories))))
+  #?(:clj (spit "/tmp/main-cats.edn" (with-out-str (pprint/pprint main-categories))))
+
   )

--- a/webapp/src/cljc/lipas/data/types_new.cljc
+++ b/webapp/src/cljc/lipas/data/types_new.cljc
@@ -9,7 +9,11 @@
   old/main-categories)
 
 (def sub-categories
-  old/sub-categories)
+  (-> old/sub-categories
+      ;; alaluokka "Keilahallit" tulee uudelleennimetä "Keilahallit ja biljardisalit"
+      (assoc-in [2600 :name] {:fi "Keilahallit ja biljardisalit"
+                              :se "Bowlinghallar och biljardsalonger"
+                              :en "Bowling alleys and billiard halls"})))
 
 (def all1
   (-> old/all
@@ -336,8 +340,10 @@
                                  true
                                  (update :props dissoc :kiosk?)
 
+                                 ;; There's unfortunate typo in the
+                                 ;; old lighting? prop
                                  (contains? (:props v) :ligthing?)
-                                 (assoc-in [:props :ligthing-info] {:priority 0}))))
+                                 (assoc-in [:props :lighting-info] {:priority 0}))))
                       {}))))
 
 (def all4

--- a/webapp/src/cljc/lipas/data/types_new.cljc
+++ b/webapp/src/cljc/lipas/data/types_new.cljc
@@ -150,8 +150,9 @@
       (assoc-in [1130 :props :fitness-stairs-length-m] {:priority 0})
 
       ;; 1140 Parkour-alue
-      (assoc-in [1140 :props :highest-drop-m] {:priority 0})
+      (assoc-in [1140 :props :highest-obstacle-m] {:priority 0})
       (assoc-in [1140 :props :climbing-wall?] {:priority 0})
+      (assoc-in [1140 :props :lighting-info] {:priority 0})
 
       ;; 1150 skeitti/rullaluistelupaikka
       (assoc-in [1150 :description :fi] "Rullaluistelua, skeittausta, potkulautailua varten varustettu paikka. Ominaisuustiedoissa tarkemmat tiedot kohteesta.")

--- a/webapp/src/cljc/lipas/data/types_new.cljc
+++ b/webapp/src/cljc/lipas/data/types_new.cljc
@@ -493,7 +493,7 @@
       ;;  Devissä tietokentän nimenä on vielä "Vapaa käyttö" -> Pitäisi olla "Kohde on vapaasti käytettävissä"
       (assoc-in [2510 :props :free-use?] {:priority 0})
       (assoc-in [2520 :description :fi] "Kilpajäähalli on jääurheilun kilpailu- ja ottelutapahtumiin soveltuva jäähalli. Katsomon koko, kenttien lukumäärä ja muut tarkemmat tiedot kuvataan lisätiedoissa.")
-      (assoc-in [2520 :props :ringette-boundary-markings] {:priority 0})
+      (assoc-in [2520 :props :ringette-boundary-markings?] {:priority 0})
       ;;  Olisiko kenttien/kaukaloiden tiedonhallintaa mahdollista helpottaa Lipaksessa (mallia esim. uimahallien altaista tai salibandyn ominaisuustiedoista?)
       (assoc-in [2520 :props :field-1-flexible-rink?] {:priority 0})
       ;;  Olisiko kenttien/kaukaloiden tiedonhallintaa mahdollista helpottaa Lipaksessa (mallia esim. uimahallien altaista tai salibandyn ominaisuustiedoista?)

--- a/webapp/src/cljc/lipas/data/types_new.cljc
+++ b/webapp/src/cljc/lipas/data/types_new.cljc
@@ -548,7 +548,284 @@
       (assoc-in [3250 :props :free-use?] {:priority 0})
       (update-in [3220 :props] dissoc :eu-beach?)))
 
-(def all all4)
+(def all5
+  (-> all4
+
+      ;; Add new rullahiihto type. Props added via script
+      (assoc 4407
+             {:name
+              {:fi "Rullahiihtorata"
+               :se "Rullskidbana"
+               :en "Roller Ski Track"}
+              :description
+              {:fi "Asfaltoitu rullahiihtoon lumettomana aikana tarkoitettu reitti. Reitti kulkee maastossa, ja sen käyttöä muilla kulkutavoilla on rajoitettu."
+               :se "En asfalterad bana avsedd för rullskidåkning under snöfria perioder. Banan går genom terrängen och användningen av andra färdsätt är begränsad."
+               :en "An asphalt track intended for roller skiing during snow-free periods. The track runs through terrain, and the use of other modes of travel is restricted."}
+              :geometry-type "LineString"
+              :tags          {:fi ["rullahiihto"] :se ["rullskidåkning"] :en ["roller skiing"]}
+              :main-category 4000
+              :sub-category  4400
+              :status        "active"
+              :type-code     4407
+              :props
+              {}})
+
+      ;; Add new monikäyttöreitti type. Props added via script
+      (assoc 4406
+             {:name
+              {:fi "Monikäyttöreitti"
+               :se "Multianvändningsled"
+               :en "Multi-use Trail"}
+              :description
+              {:fi "Talvisin tai ympärivuotisesti käytössä oleva maastoreitti, joka soveltuu usealle kulkutavalle (esim. jalan, lumikengille, läskipyörälle). Lisätietoihin merkitään, jos reitti on ympärivuotisessa käytössä ja mahdolliset kulkutavat."
+               :se "En terrängled som används på vintern eller året runt och som är lämplig för flera färdsätt (t.ex. till fots, med snöskor, fatbike). Ytterligare information anger om leden är i bruk året runt och möjliga färdsätt."
+               :en "A terrain trail used in winter or year-round, suitable for multiple modes of travel (e.g., on foot, with snowshoes, fat bike). Additional information indicates if the trail is in year-round use and possible modes of travel."}
+              :geometry-type "LineString"
+              :tags          {:fi ["yhteiskäyttöreitti" "talvipolku"] :se ["gemensam led" "vinterstig"] :en ["shared trail" "winter path"]}
+              :main-category 4000
+              :sub-category  4400
+              :status        "active"
+              :type-code     4406
+              :props
+              {}})
+
+      ;; Add new koiravaljakkoreitti type
+      (assoc 4441
+             {:name
+              {:fi "Koiravaljakkoreitti"
+               :se "Hundspannsrutt"
+               :en "Dog Sledding Route"}
+              :description
+              {:fi "Koiravaljakoille ylläpidetty reitti."
+               :se "En rutt underhållen för hundspann."
+               :en "A route maintained for dog sledding."}
+              :geometry-type "LineString"
+              :tags          {:fi ["valjakkoajo" "valjakkoreitti"] :se [] :en []}
+              :main-category 4000
+              :sub-category  4400
+              :status        "active"
+              :type-code     4441
+              :props
+              {}})
+
+      (assoc 6150
+             {:name
+              {:fi "Ovaalirata"
+               :se "Ovalbana"
+               :en "Oval Track"}
+              :description
+              {:fi "Islanninhevosten askellajiratsastukseen varattu rata ulkona."
+               :se "En bana utomhus avsedd för gångartstävlingar med islandshästar."
+               :en "An outdoor track designated for gaited riding competitions with Icelandic horses."}
+              :geometry-type "LineString"
+              :tags          {:fi ["islanninhevosrata" "islanninhevosratsastus" "ovaalibaana" "askellajiratsastus" "askellajirata"]
+                              :se ["islandshästbana" "islandshästridning" "ovalbana" "gångartstävling" "gångartsbana"]
+                              :en ["Icelandic horse track" "Icelandic horse riding" "oval track" "gaited riding" "gaited track"]}
+              :main-category 6000
+              :sub-category  6100
+              :status        "active"
+              :type-code     6150
+              :props
+              {}})))
+
+(def all6
+  (-> all5
+
+      (assoc-in [4110 :description :fi] "Laskettelun suorituspaikka on lasketteluun tai lumilautailuun tarkoitettu liikuntapaikka, esim. laskettelukeskus. Laskettelun suorituspaikassa voi olla laskettelurinteitä, parkkeja tai muita rinnerakenteita ja hiihtohissejä.")
+      (assoc-in [4110 :props :customer-service-point?] {:priority 0})
+      (update-in [4110 :props] clojure.core/dissoc :toboggan-run?)
+      (update-in [4110 :props] clojure.core/dissoc :school-use?)
+      (update-in [4110 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4110 :props :sledding-hill?] {:priority 0})
+      (assoc-in [4210 :name :fi] "Curlingrata/-halli")
+      (assoc-in [4210 :description :fi] "Pysyvästi lajiin varustettu tila, esim. curlingrata tai curlinghalli.")
+      (update-in [4210 :props] clojure.core/dissoc :fields-count)
+      (assoc-in [4210 :props :curling-lanes-count] {:priority 0})
+      (assoc-in [4210 :props :stand-capacity-person] {:priority 0})
+      (assoc-in [4210 :props :changing-rooms?] {:priority 0})
+      (assoc-in [4210 :props :changing-rooms-m2] {:priority 0})
+      (update-in [4210 :props] clojure.core/dissoc :school-use?)
+      (update-in [4210 :props] clojure.core/dissoc :free-use)
+      (update-in [4220 :props] clojure.core/dissoc :school-use?)
+      (update-in [4220 :props] clojure.core/dissoc :free-use)
+      (update-in [4230 :props] clojure.core/dissoc :school-use?)
+      (update-in [4230 :props] clojure.core/dissoc :free-use)
+      (update-in [4240 :props] clojure.core/dissoc :school-use?)
+      (update-in [4240 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4320 :description :fi] "Mäkihyppyyn soveltuva mäki, vauhtimäessä on jää-, keramiikka- tai muovilatu. Mäen koko, materiaalit ja mahdollinen kesäkäyttö kuvataan lisätiedoissa.")
+      (assoc-in [4320 :props :changing-rooms?] {:priority 0})
+      (assoc-in [4320 :props :changing-rooms-m2] {:priority 0})
+      (assoc-in [4320 :props :jumps-count] {:priority 0})
+      (assoc-in [4402 :name :fi] "Hiihtolatu")
+      (assoc-in [4402 :description :fi] "Talvikaudella hiihtoa varten ylläpidetty reitti. Hiihtotyylit kerrotaan ominaisuustiedoissa.")
+      (assoc-in [4407 :description :fi] "Asfaltoitu rullahiihtoon lumettomana aikana tarkoitettu reitti. Reitti kulkee maastossa, ja sen käyttöä muilla kulkutavoilla on rajoitettu.")
+      (assoc-in [4407 :props :surface-material] {:priority 0})
+      (assoc-in [4407 :props :surface-material-info] {:priority 0})
+      (assoc-in [4407 :props :route-length-km] {:priority 0})
+      (assoc-in [4407 :props :lit-route-length-km] {:priority 0})
+      (assoc-in [4407 :props :route-width-m] {:priority 0})
+      (assoc-in [4407 :props :free-use] {:priority 0})
+      (assoc-in [4407 :props :outdoor-exercise-machines?] {:priority 0})
+      (assoc-in [4407 :props :rest-places-count] {:priority 0})
+      (assoc-in [4407 :props :toilet?] {:priority 0})
+      (assoc-in [4407 :props :may-be-shown-in-harrastuspassi-fi?] {:priority 0})
+      (update-in [4403 :props] clojure.core/dissoc :free-use)
+      (update-in [4403 :props] clojure.core/dissoc :school-use?)
+      (update-in [4404 :props] clojure.core/dissoc :free-use)
+      (update-in [4405 :props] clojure.core/dissoc :free-use)
+      (update-in [4405 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [4412 :description :fi] "Pyöräilyreitti, joka kulkee enimmäkseen päällystetyillä teillä tai sorateillä. Reitti voi olla merkitty maastoon tai se on digitaalisesti opastettu")
+      (update-in [4412 :props] clojure.core/dissoc :free-use)
+      (update-in [4412 :props] clojure.core/dissoc :school-use?)
+      (update-in [4421 :props] clojure.core/dissoc :school-use?)
+      (update-in [4422 :props] clojure.core/dissoc :school-use?)
+      (update-in [4451 :props] clojure.core/dissoc :school-use?)
+      (update-in [4451 :props] clojure.core/dissoc :free-use)
+      (update-in [4452 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4452 :props :jumps-count] {:priority 0})
+      (assoc-in [4320 :description :fi] "Mäkihyppyyn soveltuva mäki, vauhtimäessä on jää-, keramiikka- tai muovilatu. Mäen koko, materiaalit ja mahdollinen kesäkäyttö kuvataan lisätiedoissa.")
+      (assoc-in [4320 :props :changing-rooms?] {:priority 0})
+      (update-in [4320 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [4406 :description :fi] "Talvisin tai ympärivuotisesti käytössä oleva maastoreitti, joka soveltuu usealle kulkutavalle (esim. jalan, lumikengille, läskipyörälle). Lisätietoihin merkitään, jos reitti on ympärivuotisessa käytössä ja mahdolliset kulkutavat.")
+      (assoc-in [4406 :props :surface-material] {:priority 0})
+      (assoc-in [4406 :props :surface-material-info] {:priority 0})
+      (assoc-in [4406 :props :route-length-km] {:priority 0})
+      (assoc-in [4406 :props :lit-route-length-km] {:priority 0})
+      (assoc-in [4406 :props :rest-places-count] {:priority 0})
+      (assoc-in [4406 :props :toilet?] {:priority 0})
+      (assoc-in [4406 :props :route-width-m] {:priority 0})
+      (assoc-in [4406 :props :travel-modes] {:priority 0})
+      (assoc-in [4406 :props :travel-mode-info] {:priority 0})
+      (assoc-in [4406 :props :summer-usage?] {:priority 0})
+      (assoc-in [4441 :description :fi] "Koiravaljakoille ylläpidetty reitti.")
+      (assoc-in [4441 :props :surface-material] {:priority 0})
+      (assoc-in [4441 :props :surface-material-info] {:priority 0})
+      (assoc-in [4441 :props :route-length-km] {:priority 0})
+      (assoc-in [4441 :props :lit-route-length-km] {:priority 0})
+      (assoc-in [4441 :props :route-width-m] {:priority 0})
+      (assoc-in [4441 :props :free-use] {:priority 0})
+      (assoc-in [4441 :props :summer-usage?] {:priority 0})
+      (assoc-in [4510 :description :fi] "Suunnistukseen käytetty alue. Lisätietoihin merkitään, jos aluetta käytetään mobo-, pyörä- tai hiihtosuunnistukseen. Suunnistusalueesta on saatavilla kartta ja maankäyttöön on maanomistajan suostumus.")
+      (update-in [4510 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4510 :props :mobile-orienteering?] {:priority 0})
+      (assoc-in [4510 :props :bike-orienteering?] {:priority 0})
+      (assoc-in [4510 :props :ski-orienteering?] {:priority 0})
+      (update-in [4610 :props] clojure.core/dissoc :automated-timing?)
+      (assoc-in [4610 :props :changing-rooms?] {:priority 0})
+      (assoc-in [4610 :props :changing-rooms-m2] {:priority 0})
+      (update-in [4610 :props] clojure.core/dissoc :surface-material)
+      (update-in [4610 :props] clojure.core/dissoc :surface-material-info)
+      (update-in [4610 :props] clojure.core/dissoc :school-use?)
+      (update-in [4620 :props] clojure.core/dissoc :automated-timing?)
+      (update-in [4620 :props] clojure.core/dissoc :surface-material)
+      (update-in [4620 :props] clojure.core/dissoc :surface-material-info)
+      (assoc-in [4620 :props :summer-usage?] {:priority 0})
+      (update-in [4620 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [4630 :name :se] "Maastohiihtokeskus")
+      (update-in [4630 :props] clojure.core/dissoc :automated-timing?)
+      (update-in [4630 :props] clojure.core/dissoc :school-use?)
+      (update-in [4640 :props] clojure.core/dissoc :automated-timing?)
+      (update-in [4720 :props] clojure.core/dissoc :school-use?)
+      (update-in [4720 :props] clojure.core/dissoc :free-use)
+      (update-in [4810 :props] clojure.core/dissoc :track-width-m)
+      (update-in [4810 :props] clojure.core/dissoc :school-use?)
+      (update-in [4810 :props] clojure.core/dissoc :free-use)
+      (update-in [4820 :props] clojure.core/dissoc :track-width-m)
+      (update-in [4820 :props] clojure.core/dissoc :school-use?)
+      (update-in [4820 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4830 :description :fi] "Ulkona tai sisällä sijaitseva jousiammuntarata. Radan käyttö edellyttää erillistä lupaa, seuran jäsenyyttä tai harjoitusvuoroa.  Radan varustus ja soveltuvat lajit kuvataan lisätiedoissa.")
+      (update-in [4830 :props] clojure.core/dissoc :school-use?)
+      (update-in [4830 :props] clojure.core/dissoc :free-use)
+      (assoc-in [4830 :props :free-customer-use?] {:priority 0})
+      (assoc-in [4840 :description :fi] "Maastoon rakennettu jousiammuntarata. Radan käyttö edellyttää erillistä lupaa, seuran jäsenyyttä tai harjoitusvuoroa.  ")
+      (assoc-in [4840 :props :free-customer-use?] {:priority 0})
+      (update-in [4840 :props] clojure.core/dissoc :school-use?)
+      (update-in [4840 :props] clojure.core/dissoc :free-use)
+      (assoc-in [5110 :description :fi] "Soutustadion sisältää pysyvästi soutuun käytettäviä rakenteita. Soutustadionissa on katsomo ja valmius ratamerkintöihin.")
+      (update-in [5110 :props] clojure.core/dissoc :school-use?)
+      (update-in [5120 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5130 :description :fi] "Pysyvä moottorivenekilpailujen rata-alue.")
+      (update-in [5130 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5140 :description :fi] "Rakennettu pysyvästi vesihiihdolle. Vesihiihtoalueella on laituri.")
+      (update-in [5140 :props] clojure.core/dissoc :school-use?)
+      (update-in [5150 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5160 :description :fi] "Soudun ja melonnan sisäharjoittelutila on erityisesti näihin lajeihin pysyvästi tarkoitettu liikuntapaikka.")
+      (update-in [5160 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5210 :description :fi] "Harraste- tai urheiluilmailuun tarkoitettu alue, esim. lentopaikka.")
+      (update-in [5210 :props] clojure.core/dissoc :school-use?)
+      (update-in [5310 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5310 :props :summer-usage?] {:priority 0})
+      (assoc-in [5320 :description :fi] "Pääasiassa moottoripyöräilyä varten rakennettu, luonnonmukainen ei-asfalttipintainen alue (esim. enduroreitit ja trial-harjoittelualueet maastoliikennealueilla).")
+      (update-in [5320 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5320 :props :summer-usage?] {:priority 0})
+      (assoc-in [5330 :description :fi] "Suuri rata-autoiluun tai moottoripyöräilyyn tarkoitettu asfaltoitu moottoriurheilupaikka.")
+      (update-in [5330 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5330 :props :summer-usage?] {:priority 0})
+      (assoc-in [5340 :description :fi] "Pääasiallisesti kartingajoon tai supermotoon käytetty rata.")
+      (update-in [5340 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5340 :props :summer-usage?] {:priority 0})
+      (assoc-in [5350 :description :fi] "Pääasiallisesti kiihdytysautoiluun tai kiihdytysmoottoripyöräilyyn käytetty rata.")
+      (update-in [5350 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5350 :props :summer-usage?] {:priority 0})
+      (assoc-in [5360 :description :fi] "Pääasiallisesti jokamiesajoa, rallicrossia tai moottoripyöräilyä varten.")
+      (update-in [5360 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5360 :props :summer-usage?] {:priority 0})
+      (assoc-in [5370 :name :fi] "Speedway- ja jääspeedwayrata")
+      (update-in [5370 :props] clojure.core/dissoc :school-use?)
+      (assoc-in [5370 :props :summer-usage?] {:priority 0})
+      (update-in [6120 :props] clojure.core/dissoc :ligthing?)
+      (assoc-in [6130 :name :fi] "Esteratsastuskenttä tai -alue")
+      (assoc-in [6130 :description :fi] "Pysyvästi esteratsastukseen varusteltu kenttä tai alue ulkona.")
+      (assoc-in [6150 :description :fi] "Islanninhevosten askellajiratsastukseen varattu rata ulkona.")
+      (assoc-in [6150 :props :customer-service-point?] {:priority 0})
+      (assoc-in [6150 :props :surface-material] {:priority 0})
+      (assoc-in [6150 :props :surface-material-info] {:priority 0})
+      (assoc-in [6150 :props :ligthing?] {:priority 0})
+      (assoc-in [6150 :props :toilet?] {:priority 0})
+      (assoc-in [6150 :props :track-width-m] {:priority 0})
+      (assoc-in [6150 :props :track-length-m] {:priority 0})
+      (assoc-in [6150 :props :may-be-shown-in-harrastuspassi-fi?] {:priority 0})
+      (assoc-in [6150 :props :free-use] {:priority 0})
+      (assoc-in [5360 :props :summer-usage?] {:priority 0})
+      (update-in [6140 :props] clojure.core/dissoc :school-use?)
+      (update-in [6210 :props] clojure.core/dissoc :school-use?)
+      (update-in [6220 :props] clojure.core/dissoc :school-use?)
+
+      )
+  )
+
+(def all7
+  (-> all6
+
+      ;; Remove :winter-use?, summer-use? and add :year-round-use? to
+      ;; replace them
+      (->> (reduce-kv (fn [m k v]
+                        (assoc m k
+                               (cond-> v
+                                 (contains? (:props v) :summer-usage?)
+                                 (assoc-in [:props :year-round-use?] {:priority 0})
+
+                                 (contains? (:props v) :winter-usage?)
+                                 (assoc-in [:props :year-round-use?] {:priority 0})
+
+                                 true (update :props dissoc :winter-usage? :summer-usage?)
+
+                                 )))
+                      {}))
+
+      ;; Deprecate pyörä- and hiihtosuunnistusallue
+      ;; They were merged to "suunnistusalue" 4510
+      (assoc-in [4530 :status] "deprecated")
+      (assoc-in [4520 :status] "deprecated")
+
+      ;; Migrate harjoityshyppyrimäki to hyppyrimäki
+      (assoc-in [4310 :status] "deprecated")
+      (update-in [4320 :props] assoc :hs-point {:priority 0})
+      (update-in [4320 :props] dissoc :p-point)
+
+      ))
+
+(def all all7)
 
 (def active
   (reduce-kv (fn [m k v] (if (not= "active" (:status v)) (dissoc m k) m)) all all))

--- a/webapp/src/cljc/lipas/i18n/core.cljc
+++ b/webapp/src/cljc/lipas/i18n/core.cljc
@@ -122,6 +122,41 @@
     :translations materials/surface-materials
     :many?        true}
 
+   ;; Proerties->travel-modes
+   {:path         [:properties :travel-modes]
+    :translations (-> prop-types/all
+                      (get-in [:travel-modes :opts])
+                      (update-vals :label))
+    :many?        true}
+
+   ;; Proerties->parkour-hall-equipment-and-structures
+   {:path         [:properties :parkour-hall-equipment-and-structures]
+    :translations (-> prop-types/all
+                      (get-in [:parkour-hall-equipment-and-structures :opts])
+                      (update-vals :label))
+    :many?        true}
+
+   ;; Proerties->boating-service-class
+   {:path         [:properties :boating-service-class]
+    :translations (-> prop-types/all
+                      (get-in [:boating-service-class :opts])
+                      (update-vals :label))
+    :many?        false}
+
+   ;; Properties->water-point
+   {:path         [:properties :water-point]
+    :translations (-> prop-types/all
+                      (get-in [:water-point :opts])
+                      (update-vals :label))
+    :many?        false}
+
+   ;; Properties->sport-specification
+   {:path         [:properties :sport-specification]
+    :translations (-> prop-types/all
+                      (get-in [:sport-specification :opts])
+                      (update-vals :label))
+    :many?        false}
+
    ;; Ice stadiums
    {:path         [:type :size-category]
     :translations ice/size-categories}
@@ -221,7 +256,57 @@
     {:path         [:properties :surface-material]
      :target-path  [:properties :surface-material-localized]
      :translate-fn (fn [locales vs]
-                     (map (fn [v] (-> v materials/surface-materials (select-keys locales))) vs))}]
+                     (map (fn [v] (-> v materials/surface-materials (select-keys locales))) vs))}
+
+    ;; Proerties->travel-modes
+    {:path         [:properties :travel-modes]
+     :translate-fn (fn [locales vs]
+                     (-> prop-types/all
+                         (get-in [:travel-modes :opts])
+                         (select-keys vs)
+                         (->> (map :label)
+                              (map #(select-keys % locales)))))}
+
+    ;; Proerties->parkour-hall-equipment-and-structures
+    {:path         [:properties :parkour-hall-equipment-and-structures]
+     :target-path  [:properties :parkour-hall-equipment-and-structures-localized]
+     :translate-fn (fn [locales vs]
+                     (-> prop-types/all
+                         (get-in [:parkour-hall-equipment-and-structures :opts])
+                         (select-keys vs)
+                         (->> (map :label)
+                              (map #(select-keys % locales)))))}
+
+    ;; Proerties->boating-service-class
+    {:path         [:properties :boating-service-class]
+     :target-path  [:properties :boating-service-class-localized]
+     :translate-fn (fn [locales vs]
+                     (-> prop-types/all
+                         (get-in [:boating-service-class :opts])
+                         (select-keys vs)
+                         (->> (map :label)
+                              (map #(select-keys % locales)))))}
+
+    ;; Properties->water-point
+    {:path         [:properties :water-point]
+     :target-path  [:properties :water-point-localized]
+     :translate-fn (fn [locales vs]
+                     (-> prop-types/all
+                         (get-in [:water-point :opts])
+                         (select-keys vs)
+                         (->> (map :label)
+                              (map #(select-keys % locales)))))}
+
+    ;; Properties->sport-specification
+    {:path         [:properties :sport-specification]
+     :target-path  [:properties :sport-specification-localized]
+     :translate-fn (fn [locales vs]
+                     (-> prop-types/all
+                         (get-in [:sport-specification :opts])
+                         (select-keys vs)
+                         (->> (map :label)
+                              (map #(select-keys % locales)))))}]
+
    (map #(update % :translate-fn memoize))))
 
 (defn localize2

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -733,7 +733,7 @@
 (s/def :lipas.sports-site.properties/fitness-stairs-length-m ::real)
 (s/def :lipas.sports-site.properties/fitness-stairs-length-m ::real)
 (s/def :lipas.sports-site.properties/free-customer-use? boolean?)
-(s/def :lipas.sports-site.properties/space-divisible string?)
+(s/def :lipas.sports-site.properties/space-divisible ::real)
 (s/def :lipas.sports-site.properties/auxiliary-training-area? boolean?)
 (s/def :lipas.sports-site.properties/sport-specification string?)
 (s/def :lipas.sports-site.properties/width-of-active-space-m ::real)

--- a/webapp/src/cljc/lipas/schema/core.cljc
+++ b/webapp/src/cljc/lipas/schema/core.cljc
@@ -13,6 +13,7 @@
    [lipas.data.loi :as loi]
    [lipas.data.materials :as materials]
    [lipas.data.owners :as owners]
+   [lipas.data.prop-types :as prop-types]
    [lipas.data.reminders :as reminders]
    [lipas.data.sports-sites :as sports-sites]
    [lipas.data.swimming-pools :as swimming-pools]
@@ -724,7 +725,8 @@
 (s/def :lipas.sports-site.properties/canoeing-club? boolean?)
 (s/def :lipas.sports-site.properties/activity-service-company? boolean?)
 (s/def :lipas.sports-site.properties/boating-service-class string?)
-(s/def :lipas.sports-site.properties/water-point string?)
+(s/def :lipas.sports-site.properties/water-point
+  (into #{} (keys (get-in prop-types/all [:water-point :opts]))))
 (s/def :lipas.sports-site.properties/customer-service-point? boolean?)
 (s/def :lipas.sports-site.properties/height-of-basket-or-net-adjustable? boolean?)
 (s/def :lipas.sports-site.properties/changing-rooms-m2 ::real)
@@ -739,7 +741,9 @@
 (s/def :lipas.sports-site.properties/width-of-active-space-m ::real)
 (s/def :lipas.sports-site.properties/length-of-active-space-m ::real)
 (s/def :lipas.sports-site.properties/mirror-wall? boolean?)
-(s/def :lipas.sports-site.properties/parkour-hall-equipment-and-structures string?)
+(s/def :lipas.sports-site.properties/parkour-hall-equipment-and-structures
+  (s/coll-of
+   (into #{} (keys (get-in prop-types/all [:parkour-hall-equipment-and-structures :opts])))))
 (s/def :lipas.sports-site.properties/ringette-boundary-markings? boolean?)
 (s/def :lipas.sports-site.properties/field-1-flexible-rink? boolean?)
 (s/def :lipas.sports-site.properties/field-2-flexible-rink? boolean?)
@@ -750,6 +754,9 @@
 (s/def :lipas.sports-site.properties/pyramid-tables-count ::real)
 (s/def :lipas.sports-site.properties/carom-tables-count ::real)
 (s/def :lipas.sports-site.properties/total-billiard-tables-count ::real)
+(s/def :lipas.sports-site.properties/boating-service-class
+  (s/coll-of
+   (into #{} (keys (get-in prop-types/all [:boating-service-class :opts])))))
 
 (s/def :lipas.sports-site/properties
   (s/keys :opt-un [:lipas.sports-site.properties/height-m
@@ -934,7 +941,7 @@
                    :lipas.sports-site.properties/pyramid-tables-count
                    :lipas.sports-site.properties/carom-tables-count
                    :lipas.sports-site.properties/total-billiard-tables-count
-                   ]))
+                   :lipas.sports-site.properties/boating-service-class]))
 
 (s/def :lipas.sports-site/properties-old
   (s/map-of keyword? (s/or :string? (str-in 1 100)

--- a/webapp/src/cljs/lipas/ui/map/styles.cljs
+++ b/webapp/src/cljs/lipas/ui/map/styles.cljs
@@ -107,21 +107,23 @@
         stroke-black       (Stroke. #js {:color "#00000"
                                          :width 1})
 
-        stroke-planned (Stroke. #js {:color    "#3b3b3b"
-                                     :lineDash #js [2 20]
-                                     ; :lineDashOffset 1
-                                     :width    (case (:shape m)
-                                                 ("polygon" "linestring") 10
-                                                 ("circle")               5
-                                                 ("square")               4)})
+        stroke-planned (Stroke.
+                        #js{:color    "#b1b7c4"
+                            :lineDash #js[2 20]
+                                        ; :lineDashOffset 1
+                            :width    (case (:shape m)
+                                        ("polygon" "linestring") 7
+                                        ("circle")               5
+                                        ("square")               4)})
 
-        stroke-planning (Stroke. #js {:color    "#ee00ee"
-                                      :lineDash #js [2 20]
-                                      ; :lineDashOffset 1
-                                      :width    (case (:shape m)
-                                                  ("polygon" "linestring") 10
-                                                  ("circle")               5
-                                                  ("square")               4)})
+        stroke-planning (Stroke.
+                         #js{:color    "#ee00ee"
+                             :lineDash #js[2 20]
+                                        ; :lineDashOffset 1
+                             :width    (case (:shape m)
+                                         ("polygon" "linestring") 7
+                                         ("circle")               5
+                                         ("square")               4)})
 
         stroke         (Stroke. #js {:color    stroke-color
                                      :lineDash (when (or selected? hover?)

--- a/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/subs.cljs
@@ -282,8 +282,7 @@
                                   :distance-m  (* 1000 distance-km)})))))))))))
 
 
-(rf/reg-sub
- ::elevation-stats
+(rf/reg-sub ::elevation-stats
  (fn [[_ lipas-id]]
    (rf/subscribe [:lipas.ui.sports-sites.subs/elevation lipas-id]))
  (fn [elevation _]

--- a/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
@@ -495,17 +495,18 @@
     [:<>
      [lui/checkbox
       {:label     label
+       :tooltip   tooltip
        :value     @checkbox-state
        :on-change #(reset! checkbox-state %)}]
      (when @checkbox-state
        [lui/text-field
-        {:value     value
-         :label     helper-text
-         :disabled  disabled?
-         :tooltip   tooltip
-         :spec      spec
-         :type      "number"
-         :on-change on-change}])])
+        {:value       value
+         :label       helper-text
+         :disabled    disabled?
+         #_#_:tooltip tooltip
+         :spec        spec
+         :type        "number"
+         :on-change   on-change}])])
   )
 
 (defn make-prop-field

--- a/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
@@ -589,7 +589,19 @@
                                :label       label
                                :disabled    disabled?
                                :value-fn    first
+                               :on-change   on-change
                                :label-fn    (comp locale :name second)}]
+
+      (= "enum-coll" data-type k) [lui/multi-select
+                                  {:items       (:opts prop-type)
+                                   :deselect?   true
+                                   :value       value
+                                   :helper-text tooltip
+                                   :on-change   on-change
+                                   :label       label
+                                   :disabled    disabled?
+                                   :value-fn    first
+                                   :label-fn    (comp locale :name second)}]
 
       :else [lui/text-field
              {:value     value
@@ -731,24 +743,38 @@
                                       :tooltip   tooltip
                                       :disabled  disabled?
                                       :on-change on-change}]
-            (= "enum" data-type)    [lui/select
-                                     {:items       (:opts v)
-                                      :deselect?   true
-                                      :value       value
-                                      :helper-text tooltip
-                                      :label       label
-                                      :on-change   on-change
-                                      :disabled    disabled?
-                                      :value-fn    first
-                                      :label-fn    (comp locale :label second)}]
-            :else                   [lui/text-field
-                                     {:value     value
-                                      :disabled  disabled?
-                                      :tooltip   tooltip
-                                      :spec      spec
-                                      :type      (when (#{"numeric" "integer"} data-type)
-                                                   "number")
-                                      :on-change on-change}])})
+
+            (= "enum" data-type) [lui/select
+                                  {:items       (:opts v)
+                                   :deselect?   true
+                                   :value       value
+                                   :helper-text tooltip
+                                   :label       label
+                                   :on-change   on-change
+                                   :disabled    disabled?
+                                   :value-fn    first
+                                   :label-fn    (comp locale :label second)}]
+
+            (= "enum-coll" data-type) [lui/autocomplete
+                                       {:multi?      true
+                                        :items       (:opts v)
+                                        :deselect?   true
+                                        :value       value
+                                        :helper-text tooltip
+                                        :on-change   on-change
+                                        :label       label
+                                        :disabled    disabled?
+                                        :value-fn    first
+                                        :label-fn    (comp locale :label second)}]
+
+            :else [lui/text-field
+                   {:value     value
+                    :disabled  disabled?
+                    :tooltip   tooltip
+                    :spec      spec
+                    :type      (when (#{"numeric" "integer"} data-type)
+                                 "number")
+                    :on-change on-change}])})
 
           (concat
         ;; Ice stadium special props


### PR DESCRIPTION
Larger changes to sports site categorization. The changes have been prepared since 2022 and approved by the LIPAS steering committee.
- a few new type-codes
- a few old types merged
- a few new property types
- property overhaul for many types

All the changes are "implemented" in `types_new.cljc` and the resulting categorization is inlined in `types.cljc`.  The starting point was left untouched and renamed as `types_old.cljc`.

Similarly property type changes: `prop_types_new.cljc`, `prop_types_old.cljc` and `prop_types.cljc`.

`*_old` and `*_new` namespaces can be removed later, once we're sure we don't miss anything from them.

TODO:

- [ ]  Verify all new props have specs
- [ ]  Fix formatting to accommodate cljfmt
- [ ]  Prepare winter/summer use data migration to the new `year-round-use` prop
- [ ]  Verify legacy integration doesn't blow up with new types & props
- [ ]  Wait for approval to release in prod (can be merged silently, but then "old types" and "old prop types" need to be "enabled" to hide the changes)