### PR TITLE
Fix save-sports-site when user doesn't have site/create-edit permission

### DIFF
--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -267,7 +267,7 @@
 (defn- check-permissions! [user sports-site draft?]
   (when-not (or draft?
                 (new? sports-site)
-                (roles/check-privilege user (roles/site-roles-context sports-site) :site/create-edit))
+                (roles/check-privilege user (roles/site-roles-context sports-site) :site/save-api))
     (throw (ex-info "User doesn't have enough permissions!"
                     {:type :no-permission}))))
 

--- a/webapp/src/cljs/lipas/ui/sports_sites/activities/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/activities/subs.cljs
@@ -42,13 +42,13 @@
   :<- [:lipas.ui.user.subs/user-data]
   (fn [user [_ activity-value role-context]]
     (and activity-value
-         (roles/check-privilege user (assoc role-context :activity activity-value) :activity/view))))
+         (roles/check-privilege user (assoc role-context :activity #{activity-value}) :activity/view))))
 
 (rf/reg-sub ::edit-activities?
   :<- [:lipas.ui.user.subs/user-data]
   (fn [user [_ activity-value role-context]]
     (and activity-value
-         (roles/check-privilege user (assoc role-context :activity activity-value) :activity/edit))))
+         (roles/check-privilege user (assoc role-context :activity #{activity-value}) :activity/edit))))
 
 (rf/reg-sub ::selected-features
   :<- [:lipas.ui.map.subs/selected-features]


### PR DESCRIPTION
Roles that provides e.g. activity/edit should also give :site/save-api so BE can check for this privilege.