### PR TITLE
Refactor register views from reagent to uix

### DIFF
--- a/webapp/src/cljc/lipas/schema/users.cljc
+++ b/webapp/src/cljc/lipas/schema/users.cljc
@@ -1,0 +1,51 @@
+(ns lipas.schema.users
+  (:require [lipas.schema.common :as common]))
+
+;; Email validation
+(def email-regex #"^[a-zA-Z0-9åÅäÄöÖ._%+-]+@[a-zA-Z0-9åÅäÄöÖ.-]+\.[a-zA-Z]{2,63}$")
+(def two-consecutive-dots-regex #"\.{2,}")
+
+(def email-schema
+  [:and
+   [:string]
+   [:fn {:error/message "Not a valid email address"}
+    #(re-matches email-regex %)]
+   [:fn {:error/message "Email contains consecutive dots"}
+    #(not (re-find two-consecutive-dots-regex %))]])
+
+;; Common string validations
+(defn string-length
+  [min max]
+  [:string {:min min :max max}])
+
+;; User property schemas
+(def username-schema (string-length 1 128))
+(def password-schema (string-length 6 128))
+(def firstname-schema (string-length 1 128))
+(def lastname-schema (string-length 1 128))
+(def permissions-request-schema (string-length 1 200))
+
+;; User data schemas
+(def user-data-schema
+  [:map
+   [:firstname firstname-schema]
+   [:lastname lastname-schema]
+   [:permissions-request {:optional true} permissions-request-schema]])
+
+;; Main user schema for registration/validation
+(def new-user-schema
+  [:map
+   [:email email-schema]
+   [:username username-schema]
+   [:password password-schema]
+   [:user-data user-data-schema]])
+
+;; Complete user schema with system fields
+(def user-schema
+  [:map
+   [:id common/uuid]
+   [:status [:enum "active" "archived"]]
+   [:email email-schema]
+   [:username username-schema]
+   [:user-data user-data-schema]
+   [:password {:optional true} password-schema]])

--- a/webapp/src/cljs/lipas/ui/register/views.cljs
+++ b/webapp/src/cljs/lipas/ui/register/views.cljs
@@ -1,131 +1,152 @@
 (ns lipas.ui.register.views
-  (:require [clojure.spec.alpha :as s]
+  (:require ["@mui/material/Button$default" :as Button]
+            ["@mui/material/Card$default" :as Card]
+            ["@mui/material/CardContent$default" :as CardContent]
+            ["@mui/material/CardHeader$default" :as CardHeader]
+            ["@mui/material/FormGroup$default" :as FormGroup]
+            ["@mui/material/Grid$default" :as Grid]
+            ["@mui/material/Link$default" :as Link]
+            ["@mui/material/Paper$default" :as Paper]
+            ["@mui/material/Typography$default" :as Typography]
+            [clojure.spec.alpha :as s]
             [lipas.ui.components :as lui]
             [lipas.ui.mui :as mui]
             [lipas.ui.register.events :as events]
             [lipas.ui.register.subs :as subs]
-            [lipas.ui.utils :refer [<== ==> navigate!]]))
+            [lipas.ui.uix.hooks :refer [use-subscribe]]
+            [lipas.ui.utils :refer [==> navigate!]]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [uix.core :as uix :refer [$ defui]]))
 
 (defn set-field [& args]
   (==> [::events/set-registration-form-field (butlast args) (last args)]))
 
-(defn registration-form [{:keys [tr]}]
-  (let [form-data (<== [::subs/registration-form])
-        error     (<== [::subs/registration-error])]
+(defui registration-form [{:keys [tr]}]
+  (let [form-data (use-subscribe [::subs/registration-form])
+        error     (use-subscribe [::subs/registration-error])]
 
-    [mui/form-group
+    ($ FormGroup
+       {}
 
-     ;; Email
-     [lui/text-field
-      {:required    true
-       :label       (tr :lipas.user/email)
-       :type        "email"
-       :spec        :lipas.user/email
-       :value       (:email form-data)
-       :on-change   #(==> [::events/set-registration-form-email %])
-       :placeholder (tr :lipas.user/email-example)}]
+       ;; Email
+       (r/as-element
+        [lui/text-field
+         {:required    true
+          :label       (tr :lipas.user/email)
+          :type        "email"
+          :spec        :lipas.user/email
+          :value       (:email form-data)
+          :on-change   #(==> [::events/set-registration-form-email %])
+          :placeholder (tr :lipas.user/email-example)}])
 
-     ;; Username
-     [lui/text-field
-      {:required          true
-       :Input-label-props (when-not (-> form-data :username empty?)
-                            {:shrink true})
-       :label             (tr :lipas.user/username)
-       :type              "text"
-       :spec              :lipas.user/username
-       :value             (:username form-data)
-       :on-change         #(set-field :username %)
-       :placeholder       (tr :lipas.user/username-example)}]
+       ;; Username
+       (r/as-element
+        [lui/text-field
+         {:required          true
+          :Input-label-props (when-not (-> form-data :username empty?)
+                               {:shrink true})
+          :label             (tr :lipas.user/username)
+          :type              "text"
+          :spec              :lipas.user/username
+          :value             (:username form-data)
+          :on-change         #(set-field :username %)
+          :placeholder       (tr :lipas.user/username-example)}])
 
-     ;; Password
-     [lui/text-field
-      {:required  true
-       :label     (tr :lipas.user/password)
-       :type      "password"
-       :spec      :lipas.user/password
-       :value     (:password form-data)
-       :on-change #(set-field :password %)}]
+       ;; Password
+       (r/as-element
+        [lui/text-field
+         {:required  true
+          :label     (tr :lipas.user/password)
+          :type      "password"
+          :spec      :lipas.user/password
+          :value     (:password form-data)
+          :on-change #(set-field :password %)}])
 
-     ;; Firstname
-     [lui/text-field
-      {:required  true
-       :label     (tr :lipas.user/firstname)
-       :spec      :lipas.user/firstname
-       :value     (-> form-data :user-data :firstname)
-       :on-change #(set-field :user-data :firstname %)}]
+       ;; Firstname
+       (r/as-element
+        [lui/text-field
+         {:required  true
+          :label     (tr :lipas.user/firstname)
+          :spec      :lipas.user/firstname
+          :value     (-> form-data :user-data :firstname)
+          :on-change #(set-field :user-data :firstname %)}])
 
-     ;; Lastname
-     [lui/text-field
-      {:required  true
-       :label     (tr :lipas.user/lastname)
-       :spec      :lipas.user/lastname
-       :value     (-> form-data :user-data :lastname)
-       :on-change #(set-field :user-data :lastname %)}]
+       ;; Lastname
+       (r/as-element
+        [lui/text-field
+         {:required  true
+          :label     (tr :lipas.user/lastname)
+          :spec      :lipas.user/lastname
+          :value     (-> form-data :user-data :lastname)
+          :on-change #(set-field :user-data :lastname %)}])
 
-     ;; Permissions request
-     [lui/text-field
-      {:label       (tr :lipas.user/permissions)
-       :multiline   true
-       :spec        :lipas.user/permissions-request
-       :value       (-> form-data :user-data :permissions-request)
-       :on-change   #(set-field :user-data :permissions-request %)
-       :min-rows    3
-       :placeholder (tr :lipas.user/permissions-example)
-       :helper-text (tr :lipas.user/permissions-help)}]
+       ;; Permissions request
+       (r/as-element
+        [lui/text-field
+         {:label       (tr :lipas.user/permissions)
+          :multiline   true
+          :spec        :lipas.user/permissions-request
+          :value       (-> form-data :user-data :permissions-request)
+          :on-change   #(set-field :user-data :permissions-request %)
+          :min-rows    3
+          :placeholder (tr :lipas.user/permissions-example)
+          :helper-text (tr :lipas.user/permissions-help)}])
 
-     ;; Register button
-     [mui/button
-      {:style    {:margin-top "1em"}
-       :color    "secondary"
-       :variant  "contained"
-       :disabled (not (s/valid? :lipas/new-user form-data))
-       :size     "large"
-       :on-click #(==> [::events/submit-registration-form form-data])}
-      (tr :register/headline)]
+       ;; Register button
+       ($ Button
+          {:style    {:margin-top "1em"}
+           :color    "secondary"
+           :variant  "contained"
+           :disabled (not (s/valid? :lipas/new-user form-data))
+           :size     "large"
+           :on-click #(==> [::events/submit-registration-form form-data])}
+          (tr :register/headline))
 
-     ;; Privacy policy
-     [mui/link
-      {:style  {:margin-top "0.5em"}
-       :href   "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"
-       :target "_blank"}
-      (tr :help/privacy-policy)]
+       ;; Privacy policy
+       ($ Link
+          {:style  {:margin-top "0.5em"}
+           :href   "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"
+           :target "_blank"}
+          (tr :help/privacy-policy))
 
-     ;; Terms
-     [mui/typography {:variant "body1" :sx {:mt 1 :mb 1}}
-      (tr :user/data-ownership)]
+       ;; Terms
+       ($ Typography {:variant "body1" :sx {:mt 1 :mb 1}}
+          (tr :user/data-ownership))
 
-     [mui/typography {:variant "body1" :style {:font-size "0.9em"}}
-      (tr :disclaimer/data-ownership)]
+       ($ Typography {:variant "body1" :style {:font-size "0.9em"}}
+          (tr :disclaimer/data-ownership))
 
-     ;; Error messages
-     (when error
-       [mui/typography {:color "error"}
-        (case (-> error :response :type)
-          "email-conflict"    (tr :error/email-conflict)
-          "username-conflict" (tr :error/username-conflict)
-          (tr :error/unknown))])]))
+       ;; Error messages
+       (when error
+         ($ Typography {:color "error"}
+            (case (-> error :response :type)
+              "email-conflict"    (tr :error/email-conflict)
+              "username-conflict" (tr :error/username-conflict)
+              (tr :error/unknown)))))))
 
-(defn thank-you-for-registering-box [{:keys [tr]}]
-  [mui/grid
-   {:item true :xs 12 :style {:padding-top "1em" :padding-bottom "1em"}}
-   [mui/paper {:style {:background-color mui/gray3 :padding "1em"}}
-    [mui/typography {:variant "body2"}
-     (tr :register/thank-you-for-registering)]]])
+(defui thank-you-for-registering-box [{:keys [tr]}]
+  ($ Grid
+     {:item true :xs 12 :style {:padding-top "1em" :padding-bottom "1em"}}
+     ($ Paper {:style {:background-color mui/gray3 :padding "1em"}}
+        ($ Typography {:variant "body2"}
+           (tr :register/thank-you-for-registering)))))
 
-(defn create-panel [tr]
-  (let [registered? (<== [::subs/registration-success?])]
-    [mui/grid {:container true :justify-content "center" :style {:padding "1em"}}
-     [mui/grid {:item true :xs 12 :md 8 :lg 6}
-      [mui/card {:square true :style {:height "100%"}}
-       [mui/card-header {:title (tr :register/headline)}]
-       [mui/card-content
-        (if registered?
-          [thank-you-for-registering-box {:tr tr}]
-          [registration-form {:tr tr}])]]]]))
+(defui create-panel [{:keys [tr]}]
+  (let [registered? (use-subscribe [::subs/registration-success?])]
+    ($ Grid {:container true :justify-content "center" :style {:padding "1em"}}
+       ($ Grid {:item true :xs 12 :md 8 :lg 6}
+          ($ Card {:square true :style {:height "100%"}}
+             ($ CardHeader {:title (tr :register/headline)})
+             ($ CardContent
+                {}
+                (if registered?
+                  ($ thank-you-for-registering-box {:tr tr})
+                  ($ registration-form {:tr tr}))))))))
 
-(defn main []
-  (let [tr         (<== [:lipas.ui.subs/translator])
-        logged-in? (<== [::subs/logged-in?])]
+(defui main []
+  (let [tr         (use-subscribe [:lipas.ui.subs/translator])
+        logged-in? (use-subscribe [::subs/logged-in?])]
     (if logged-in?
-      (navigate! "/profiili")
-      [create-panel tr])))
+      (do (navigate! "/profiili") nil)
+      ($ create-panel {:tr tr}))))

--- a/webapp/src/cljs/lipas/ui/register/views.cljs
+++ b/webapp/src/cljs/lipas/ui/register/views.cljs
@@ -8,7 +8,8 @@
             ["@mui/material/Link$default" :as Link]
             ["@mui/material/Paper$default" :as Paper]
             ["@mui/material/Typography$default" :as Typography]
-            [clojure.spec.alpha :as s]
+            [malli.core :as m]
+            [lipas.schema.users :as users]
             [lipas.ui.components :as lui]
             [lipas.ui.mui :as mui]
             [lipas.ui.register.events :as events]
@@ -35,7 +36,7 @@
          {:required    true
           :label       (tr :lipas.user/email)
           :type        "email"
-          :spec        :lipas.user/email
+          :spec        users/email-schema
           :value       (:email form-data)
           :on-change   #(==> [::events/set-registration-form-email %])
           :placeholder (tr :lipas.user/email-example)}])
@@ -48,7 +49,7 @@
                                {:shrink true})
           :label             (tr :lipas.user/username)
           :type              "text"
-          :spec              :lipas.user/username
+          :spec              users/username-schema
           :value             (:username form-data)
           :on-change         #(set-field :username %)
           :placeholder       (tr :lipas.user/username-example)}])
@@ -59,7 +60,7 @@
          {:required  true
           :label     (tr :lipas.user/password)
           :type      "password"
-          :spec      :lipas.user/password
+          :spec      users/password-schema
           :value     (:password form-data)
           :on-change #(set-field :password %)}])
 
@@ -68,7 +69,7 @@
         [lui/text-field
          {:required  true
           :label     (tr :lipas.user/firstname)
-          :spec      :lipas.user/firstname
+          :spec      users/firstname-schema
           :value     (-> form-data :user-data :firstname)
           :on-change #(set-field :user-data :firstname %)}])
 
@@ -77,7 +78,7 @@
         [lui/text-field
          {:required  true
           :label     (tr :lipas.user/lastname)
-          :spec      :lipas.user/lastname
+          :spec      users/lastname-schema
           :value     (-> form-data :user-data :lastname)
           :on-change #(set-field :user-data :lastname %)}])
 
@@ -86,7 +87,7 @@
         [lui/text-field
          {:label       (tr :lipas.user/permissions)
           :multiline   true
-          :spec        :lipas.user/permissions-request
+          :spec        users/permissions-request-schema
           :value       (-> form-data :user-data :permissions-request)
           :on-change   #(set-field :user-data :permissions-request %)
           :min-rows    3
@@ -98,7 +99,7 @@
           {:style    {:margin-top "1em"}
            :color    "secondary"
            :variant  "contained"
-           :disabled (not (s/valid? :lipas/new-user form-data))
+           :disabled (not (m/validate users/new-user-schema form-data))
            :size     "large"
            :on-click #(==> [::events/submit-registration-form form-data])}
           (tr :register/headline))

--- a/webapp/src/cljs/lipas/ui/register/views.cljs
+++ b/webapp/src/cljs/lipas/ui/register/views.cljs
@@ -7,8 +7,8 @@
             ["@mui/material/Grid$default" :as Grid]
             ["@mui/material/Link$default" :as Link]
             ["@mui/material/Paper$default" :as Paper]
+            ["@mui/material/Stack$default" :as Stack]
             ["@mui/material/Typography$default" :as Typography]
-            [malli.core :as m]
             [lipas.schema.users :as users]
             [lipas.ui.components :as lui]
             [lipas.ui.mui :as mui]
@@ -16,6 +16,7 @@
             [lipas.ui.register.subs :as subs]
             [lipas.ui.uix.hooks :refer [use-subscribe]]
             [lipas.ui.utils :refer [==> navigate!]]
+            [malli.core :as m]
             [re-frame.core :as rf]
             [reagent.core :as r]
             [uix.core :as uix :refer [$ defui]]))
@@ -104,19 +105,21 @@
            :on-click #(==> [::events/submit-registration-form form-data])}
           (tr :register/headline))
 
-       ;; Privacy policy
-       ($ Link
-          {:style  {:margin-top "0.5em"}
-           :href   "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"
-           :target "_blank"}
-          (tr :help/privacy-policy))
+       ($ Stack {:spacing 1}
 
-       ;; Terms
-       ($ Typography {:variant "body1" :sx {:mt 1 :mb 1}}
-          (tr :user/data-ownership))
+          ;; Privacy policy
+          ($ Link
+             {:style  {:margin-top "0.5em"}
+              :href   "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"
+              :target "_blank"}
+             (tr :help/privacy-policy))
 
-       ($ Typography {:variant "body1" :style {:font-size "0.9em"}}
-          (tr :disclaimer/data-ownership))
+          ;; Terms
+          ($ Typography {:variant "body1" :sx {:mt 1 :mb 1}}
+             (tr :user/data-ownership))
+
+          ($ Typography {:variant "body1" :style {:font-size "0.9em"}}
+             (tr :disclaimer/data-ownership)))
 
        ;; Error messages
        (when error


### PR DESCRIPTION
- Convert all components from defn to defui
- Replace reagent vector notation with JSX-style $ syntax
- Use uix hooks (use-subscribe) instead of re-frame subscriptions
- Keep lui/text-field components wrapped in r/as-element since they're still reagent components
- Maintain all existing functionality
- Switch from spec to malli validation

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>