### PR TITLE
Add label-driven deploy-to-dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,172 @@
+name: Deploy to lipas-dev
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or SHA to deploy (default: master)'
+        required: false
+        default: 'master'
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+env:
+  DEPLOY_LABEL: on-lipas-dev
+  ALLOWED_USERS: "vharmain"
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.decide.outputs.should_deploy }}
+      ref:           ${{ steps.decide.outputs.ref }}
+    steps:
+      - name: Decide what to deploy
+        id: decide
+        env:
+          EVENT:         ${{ github.event_name }}
+          ACTION:        ${{ github.event.action }}
+          LABEL_NAME:    ${{ github.event.label.name }}
+          SENDER:        ${{ github.event.sender.login }}
+          PR_HEAD_REF:   ${{ github.event.pull_request.head.ref }}
+          PR_HAD_LABEL:  ${{ contains(github.event.pull_request.labels.*.name, 'on-lipas-dev') }}
+          INPUT_REF:     ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+
+          authorize() {
+            if ! grep -qw "$SENDER" <<<"$ALLOWED_USERS"; then
+              echo "::error::User '$SENDER' is not allowed to deploy to lipas-dev"
+              exit 1
+            fi
+          }
+
+          emit() {
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "ref=$1" >> "$GITHUB_OUTPUT"
+            echo "Will deploy ref: $1"
+          }
+
+          case "$EVENT" in
+            workflow_dispatch)
+              authorize
+              emit "$INPUT_REF"
+              ;;
+            pull_request)
+              case "$ACTION" in
+                labeled)
+                  if [[ "$LABEL_NAME" == "$DEPLOY_LABEL" ]]; then
+                    authorize
+                    emit "$PR_HEAD_REF"
+                  else
+                    echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+                  fi
+                  ;;
+                unlabeled)
+                  if [[ "$LABEL_NAME" == "$DEPLOY_LABEL" ]]; then
+                    authorize
+                    emit "master"
+                  else
+                    echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+                  fi
+                  ;;
+                closed)
+                  if [[ "$PR_HAD_LABEL" == "true" ]]; then
+                    emit "master"
+                  else
+                    echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+                  fi
+                  ;;
+                *)
+                  echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+                  ;;
+              esac
+              ;;
+            *)
+              echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  # Strip the deploy label from any other PRs so it stays exclusive to one PR.
+  exclusive-label:
+    needs: plan
+    if: |
+      needs.plan.outputs.should_deploy == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'on-lipas-dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label from any other open PRs
+        env:
+          GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "$DEPLOY_LABEL" \
+            --state open \
+            --json number --jq '.[].number' \
+          | while read -r n; do
+              if [[ "$n" != "$PR_NUMBER" ]]; then
+                echo "Removing $DEPLOY_LABEL from PR #$n"
+                gh pr edit "$n" --repo "$GITHUB_REPOSITORY" --remove-label "$DEPLOY_LABEL"
+              fi
+            done
+
+  deploy:
+    needs: [plan, exclusive-label]
+    if: |
+      always() &&
+      needs.plan.outputs.should_deploy == 'true' &&
+      (needs.exclusive-label.result == 'success' || needs.exclusive-label.result == 'skipped')
+    runs-on: [self-hosted, lipas-dev]
+    environment:
+      name: lipas-dev
+      url: https://lipas-dev.cc.jyu.fi
+    steps:
+      - name: Sync /var/lipas to ${{ needs.plan.outputs.ref }}
+        working-directory: /var/lipas
+        env:
+          REF: ${{ needs.plan.outputs.ref }}
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet HEAD; then
+            echo "::error::/var/lipas has uncommitted changes to tracked files; refusing to switch refs"
+            git status --short
+            exit 1
+          fi
+          git fetch origin --prune --tags
+          if git rev-parse --verify "origin/${REF}" >/dev/null 2>&1; then
+            TARGET="origin/${REF}"
+          else
+            TARGET="${REF}"
+          fi
+          git -c advice.detachedHead=false checkout "$TARGET"
+          echo "Now at $(git rev-parse --short HEAD) — $(git log -1 --pretty='%s')"
+
+      - name: Build backend and frontend (dockerized)
+        working-directory: /var/lipas
+        run: |
+          set -euo pipefail
+          source /var/lipas/.env.sh
+          docker compose run --rm backend-build
+          docker compose run --rm frontend-npm-deps
+          docker compose run --rm frontend-build
+
+      - name: Install artifacts and restart services
+        working-directory: /var/lipas
+        run: |
+          set -euo pipefail
+          cp webapp/target/backend.jar webapp/backend.jar
+          # frontend bundle + rendered index.html landed in webapp/resources/public/ during build
+          source /var/lipas/.env.sh
+          docker compose rm -sf backend worker
+          docker compose up -d backend worker
+          docker compose restart proxy
+          echo "Deployed $(git -C /var/lipas rev-parse --short HEAD)"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEPLOY_LABEL: on-lipas-dev
+  DEPLOY_LABEL: lipas-dev
   ALLOWED_USERS: "vharmain"
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
           LABEL_NAME:    ${{ github.event.label.name }}
           SENDER:        ${{ github.event.sender.login }}
           PR_HEAD_REF:   ${{ github.event.pull_request.head.ref }}
-          PR_HAD_LABEL:  ${{ contains(github.event.pull_request.labels.*.name, 'on-lipas-dev') }}
+          PR_HAD_LABEL:  ${{ contains(github.event.pull_request.labels.*.name, 'lipas-dev') }}
           INPUT_REF:     ${{ inputs.ref }}
         run: |
           set -euo pipefail
@@ -98,7 +98,7 @@ jobs:
       needs.plan.outputs.should_deploy == 'true' &&
       github.event_name == 'pull_request' &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'on-lipas-dev'
+      github.event.label.name == 'lipas-dev'
     runs-on: ubuntu-latest
     steps:
       - name: Remove label from any other open PRs


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/deploy-dev.yml`: deploys a PR's head to lipas-dev when an authorized user adds the `lipas-dev` label; reverts dev to master when the label is removed or the PR closed/merged
- Exclusive labeling: adding the label strips it from any other open PR
- Runs on a self-hosted runner on lipas-dev (already deployed as a Docker container `gha-runner-lipas-ci`)
- Allowlist: currently `vharmain` only

## How it works
1. Plan job decides what to deploy based on event (label add → PR head; label remove / PR close → master; dispatch → user-supplied ref) and authorizes the sender
2. Exclusive-label job strips `lipas-dev` from any other open PR
3. Deploy job (on self-hosted runner): syncs `/var/lipas` to the target ref, builds via the existing dockerized `backend-build` / `frontend-build` services, copies the jar + bundle into place, restarts backend/worker/proxy

## Test plan
- [ ] Smoke test via `workflow_dispatch` with `ref=master` — exercises the whole pipeline
- [ ] Label this PR with `lipas-dev` to verify the label trigger and watch the runner pick up the job
- [ ] Remove the label and confirm dev reverts to master

## Notes
- Ditches the long-lived `deploy/lipas-dev` branch convention. Master becomes the default; per-PR testing happens via the label.
- Requires the `lipas-dev` label to exist (will create after merge).