### PR TITLE
Allow runner container to operate on /var/lipas

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -136,6 +136,9 @@ jobs:
           REF: ${{ needs.plan.outputs.ref }}
         run: |
           set -euo pipefail
+          # Runner container runs as root; /var/lipas is owned by lipas-ci on the host.
+          # Tell git to trust the directory regardless of ownership mismatch.
+          git config --global --add safe.directory /var/lipas
           if ! git diff --quiet HEAD; then
             echo "::error::/var/lipas has uncommitted changes to tracked files; refusing to switch refs"
             git status --short


### PR DESCRIPTION
## Summary
First smoke-test of the new deploy-dev workflow failed with:
\`\`\`
fatal: detected dubious ownership in repository at '/var/lipas'
\`\`\`

The dockerized runner runs as root inside its container; \`/var/lipas\` is owned by \`lipas-ci\` (uid 999068) on the host. Git refuses to operate on a working tree with mismatched ownership.

This adds \`git config --global --add safe.directory /var/lipas\` at the start of the sync step so git trusts the directory regardless. Each workflow run starts a fresh runner-job context, so the config is set per-run (no persistent state).

## Test plan
- [ ] Re-run \`workflow_dispatch\` with \`ref=master\` after merge — should now sync, build, deploy