### PR TITLE
PTV improvements

### DIFF
--- a/webapp/resources/sql/sports_site.sql
+++ b/webapp/resources/sql/sports_site.sql
@@ -107,6 +107,18 @@ SELECT *
 FROM sports_site_current
 WHERE lipas_id IN (:v*:lipas_ids)
 
+-- :name get-lipas-ids-by-ptv-service-channel-id
+-- :command :query
+-- :result :many
+-- :doc Lipas-ids (and names) of current revisions whose PTV service-channel-ids
+-- :doc array contains :service_channel_id. Used to detect double-linking (more
+-- :doc than one sports-site bound to the same PTV service-location). The :ptv
+-- :doc subtree is not indexed in Elasticsearch ({:enabled false}), so this JSONB
+-- :doc query against the source of truth is the authoritative lookup.
+SELECT lipas_id, document ->> 'name' AS name
+FROM sports_site_current
+WHERE document #> '{ptv,service-channel-ids}' @> to_jsonb(:service_channel_id ::text)
+
 -- :name invalidate-since!
 -- :command :execute
 -- :result :affected

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -149,6 +149,16 @@
          (sports-site/get-latest-by-city-code db-spec)
          (map sports-site/unmarshall))))
 
+(defn get-sports-sites-by-ptv-service-channel-id
+  "Returns [{:lipas-id _ :name _} ...] for current sports-site revisions whose
+  PTV :service-channel-ids contain `service-channel-id`. Used to detect
+  double-linking (more than one site bound to the same PTV service-location)."
+  [db-spec service-channel-id]
+  (->> (sports-site/get-lipas-ids-by-ptv-service-channel-id
+        db-spec {:service_channel_id service-channel-id})
+       (map (fn [{:keys [lipas_id name]}]
+              {:lipas-id lipas_id :name name}))))
+
 (defn get-users-drafts [db user]
   (let [params {:author-id (:id user) :status "draft"}]
     (->> params

--- a/webapp/src/clj/lipas/backend/ptv/core.clj
+++ b/webapp/src/clj/lipas/backend/ptv/core.clj
@@ -444,6 +444,36 @@
 
     [ptv-resp new-ptv-data]))
 
+(defn assert-no-double-link!
+  "Guards the PTV invariant of one service-location per sports-site: throws an
+  ex-info {:type :double-link ...} when `service-channel-id` is already bound to
+  a sports-site other than `lipas-id`. Two LIPAS sites sharing one PTV
+  service-location corrupt each other — their one-way syncs overwrite the
+  channel and archiving one archives the shared channel. A blank/nil channel-id
+  (a fresh create or a deliberate unlink) is always allowed. Re-syncing a site's
+  own channel is allowed because the current `lipas-id` is excluded."
+  [db lipas-id service-channel-id]
+  (when-not (str/blank? service-channel-id)
+    (let [others (->> (db/get-sports-sites-by-ptv-service-channel-id db service-channel-id)
+                      (remove #(= lipas-id (:lipas-id %))))]
+      (when (seq others)
+        (throw (ex-info "PTV service-location already linked to another sports-site"
+                        {:type :double-link
+                         :service-channel-id service-channel-id
+                         :lipas-id lipas-id
+                         :other-sites (vec others)}))))))
+
+(defn check-service-channel-link
+  "Returns the OTHER sports-sites currently linked to `service-channel-id`,
+  excluding `lipas-id`. The single-site PTV view uses this to warn about a
+  pre-existing double-link, which it can't detect locally (it loads neither the
+  org's channels nor its sibling sites)."
+  [db {:keys [lipas-id service-channel-id]}]
+  {:service-channel-id service-channel-id
+   :other-sites (->> (db/get-sports-sites-by-ptv-service-channel-id db service-channel-id)
+                     (remove #(= lipas-id (:lipas-id %)))
+                     vec)})
+
 (defn upsert-ptv-service-location!
   [db ptv-component search user {:keys [lipas-id org-id ptv archive?]}]
   ;; FIXME: This is called from inside tx in save-sports-site! is that a problem?
@@ -452,6 +482,9 @@
   (jdbc/with-db-transaction [tx db]
     (let [site (db/get-sports-site db lipas-id)
           _ (assert (some? site) (str "Sports site " lipas-id " not found in DB"))
+          ;; Reject linking to a service-location another site already owns
+          ;; before we touch PTV (a fresh create / unlink has no id and passes).
+          _ (assert-no-double-link! tx lipas-id (-> ptv :service-channel-ids first))
 
           [ptv-resp new-ptv-data] (upsert-ptv-service-location!* ptv-component
                                                                  {:org-id org-id
@@ -601,6 +634,9 @@
   [db search user lipas-id->ptv-meta]
   (jdbc/with-db-transaction [tx db]
     (doseq [[lipas-id ptv] lipas-id->ptv-meta]
+      ;; Meta-save can persist :service-channel-ids without a sync, so guard the
+      ;; one-service-location-per-site invariant here too.
+      (assert-no-double-link! tx lipas-id (-> ptv :service-channel-ids first))
       ;; TODO take when-let -> let and add assert
       (when-let [site (-> (core/get-sports-site tx lipas-id)
                           (assoc :event-date (utils/timestamp))

--- a/webapp/src/clj/lipas/backend/ptv/core.clj
+++ b/webapp/src/clj/lipas/backend/ptv/core.clj
@@ -366,8 +366,16 @@
         ;; Fetch the stored channel for service-connection diffing below.
         ;; Drift detection in `sports-site->ptv-input` uses a separately
         ;; cached channel snapshot, not this fetch.
+        ;; A previously-archived channel (publishing-status "Deleted") 404s on
+        ;; every PTV read endpoint but is still addressable for a PUT — so a
+        ;; resurrect (re-publish) must tolerate the 404 here and proceed.
         old-service-location (when id
-                               (ptv/get-org-service-channel ptv-component org-id id))
+                               (try
+                                 (ptv/get-org-service-channel ptv-component org-id id)
+                                 (catch clojure.lang.ExceptionInfo e
+                                   (if (= 404 (-> e ex-data :resp :status))
+                                     nil
+                                     (throw e)))))
 
         ptv-resp (if id
                    (ptv/update-service-location ptv-component id data)
@@ -420,10 +428,16 @@
                                 ;; Take the created ID from ptv response and store to Lipas DB right away.
                                 ;; TODO: Is there a case where this could be multiple ids?
                                 :service-channel-ids [(:id ptv-resp)])
+                         ;; Keep :source-id and :service-channel-ids on archive so
+                         ;; the LIPAS↔PTV link survives. :publishing-status is
+                         ;; stored as "Deleted" (from ptv-resp) above, so
+                         ;; is-sent-to-ptv? stays false and nothing re-archives;
+                         ;; but a later re-activation re-publishes the SAME PTV
+                         ;; channel (PUT Published) instead of creating a
+                         ;; duplicate that collides with PTV's unique-name rule.
+                         ;; Clear only the one-shot :delete-existing flag.
                          (cond->
-                           archive? (dissoc :source-id
-                                            :service-channel-ids
-                                            :delete-existing)))]
+                           archive? (dissoc :delete-existing)))]
 
     (log/infof "Upserted service-location %s (status: %s, update: %s, channel: %s)"
                (:lipas-id site) (:status site) (boolean id) (:id ptv-resp))
@@ -471,79 +485,95 @@
          (utils/index-by :sourceId)
          keys)))
 
+(def ^:private removal-statuses
+  "Statuses that mean the facility is genuinely gone — the only status
+  transition that auto-archives a previously-published PTV service-location."
+  #{"incorrect-data" "out-of-service-permanently"})
+
+(defn to-archive?
+  "Should saving `sports-site` archive its PTV service-location
+  (publishingStatus \"Deleted\")? Only for a genuine removal of a
+  previously-published site: its status set to permanently-out / incorrect-data,
+  or an explicit `:delete-existing` request in `ptv`. Owner/type changes and
+  incomplete (not ptv-ready?) texts never archive."
+  [sports-site ptv]
+  (boolean
+    (and (ptv-data/is-sent-to-ptv? sports-site)
+         (or (contains? removal-statuses (:status sports-site))
+             (:delete-existing ptv)))))
+
 ;; Used through resolve due to circular dep
 ;; TODO: Check if code can be moved around to avoid this
 ^{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn sync-ptv! [tx search ptv-component user {:keys [sports-site ptv org-id lipas-id]}]
   (try
-    (let [type-code (-> sports-site :type :type-code)
+    (let [ready? (ptv-data/ptv-ready? sports-site)
+          archive? (to-archive? sports-site ptv)]
+      (if (and (not archive?) (not ready?))
+        ;; Safety guard. Reached only for integration-enabled sites (others
+        ;; never get here). The PTV data is incomplete/invalid, so pushing it
+        ;; would fail PTV validation — don't create or update, leave any
+        ;; existing PTV record frozen. No new revision is written here; the
+        ;; site itself was already saved by the caller.
+        (do
+          (log/infof "Skipping PTV sync for %d: PTV data not ready and not archiving" lipas-id)
+          {:ptv ptv :event-date (:event-date sports-site)})
+        (let [type-code (-> sports-site :type :type-code)
+              type-code-changed? (not= type-code (:previous-type-code ptv))
+              ptv (if type-code-changed?
+                    (let [types types/all
+                           ;; Figure out what services are available in PTV for the site organization
+                          services (:itemList (ptv/get-org-services ptv-component org-id))
+                          source-id->service (->> services
+                                                  (utils/index-by :sourceId))
 
-          previous-sent? (ptv-data/is-sent-to-ptv? sports-site)
-          candidate-now? (and (ptv-data/ptv-candidate? sports-site)
-                              (ptv-data/ptv-ready? sports-site))
+                           ;; Check if services for the current/new site type-code exist
+                          missing-services-input [{:service-ids #{}
+                                                   :sub-category-id (-> sports-site :type :type-code types :sub-category)
+                                                   :sub-cateogry (-> sports-site :search-meta :type :sub-category :name :fi)}]
+                          missing-services (ptv-data/resolve-missing-services org-id source-id->service missing-services-input)
 
-          ;; If it looks like site that was previously sent to PTV is no longer
-          ;; a candidate, mark for it archival.
-          ;; The other function will mark the document Deleted when archive flag is true
-          to-archive? (and previous-sent?
-                           (or (not candidate-now?)
-                               (:delete-existing ptv)))
+                           ;; FE doesn't update the :ptv :service-ids, that is still handled here.
+                           ;; This code just presumes the user has created the possibly missing Sercices
+                           ;; in the FE first.
 
-          type-code-changed? (not= type-code (:previous-type-code ptv))
-          ptv (if type-code-changed?
-                (let [types types/all
-                       ;; Figure out what services are available in PTV for the site organization
-                      services (:itemList (ptv/get-org-services ptv-component org-id))
-                      source-id->service (->> services
-                                              (utils/index-by :sourceId))
+                          _ (when (seq missing-services)
+                              (throw (ex-info "Site needs a PTV Service that doesn't exists"
+                                              {:missing-services missing-services})))
 
-                       ;; Check if services for the current/new site type-code exist
-                      missing-services-input [{:service-ids #{}
-                                               :sub-category-id (-> sports-site :type :type-code types :sub-category)
-                                               :sub-cateogry (-> sports-site :search-meta :type :sub-category :name :fi)}]
-                      missing-services (ptv-data/resolve-missing-services org-id source-id->service missing-services-input)
+                           ;; Remove old service-ids from :ptv data and add the new.
+                           ;; Don't touch other service-ids in the data, those could have be added manually in UI or in PTV.
+                           ;; NOTE: OK, PTV updates are likely lost, because our :ptv :service-ids is what the create/update from
+                           ;; Lipas previously returned, so if PTV ServiceLocation was modified after that in PTV, we lose those changes.
+                          old-sports-site (assoc-in sports-site [:type :type-code] (:previous-type-code ptv))
+                          old-service-ids (ptv-data/sports-site->service-ids types source-id->service old-sports-site)
+                          new-service-ids (ptv-data/sports-site->service-ids types source-id->service sports-site)]
+                      (log/infof "Site %d type changed %s => %s, service-ids %s => %s"
+                                 lipas-id (:previous-type-code ptv) type-code
+                                 old-service-ids new-service-ids)
+                      (update ptv :service-ids (fn [ids]
+                                                 (let [x (set ids)
+                                                       x (apply disj x old-service-ids)
+                                                       x (into x new-service-ids)]
+                                                   (vec x)))))
+                    ptv)
 
-                       ;; FE doesn't update the :ptv :service-ids, that is still handled here.
-                       ;; This code just presumes the user has created the possibly missing Sercices
-                       ;; in the FE first.
+              [_ptv-resp new-ptv-data] (upsert-ptv-service-location!* ptv-component
+                                                                      {:org-id org-id
+                                                                       :ptv ptv
+                                                                       :site sports-site
+                                                                       :archive? archive?})]
 
-                      _ (when (seq missing-services)
-                          (throw (ex-info "Site needs a PTV Service that doesn't exists"
-                                          {:missing-services missing-services})))
-
-                       ;; Remove old service-ids from :ptv data and add the new.
-                       ;; Don't touch other service-ids in the data, those could have be added manually in UI or in PTV.
-                       ;; NOTE: OK, PTV updates are likely lost, because our :ptv :service-ids is what the create/update from
-                       ;; Lipas previously returned, so if PTV ServiceLocation was modified after that in PTV, we lose those changes.
-                      old-sports-site (assoc-in sports-site [:type :type-code] (:previous-type-code ptv))
-                      old-service-ids (ptv-data/sports-site->service-ids types source-id->service old-sports-site)
-                      new-service-ids (ptv-data/sports-site->service-ids types source-id->service sports-site)]
-                  (log/infof "Site %d type changed %s => %s, service-ids %s => %s"
-                             lipas-id (:previous-type-code ptv) type-code
-                             old-service-ids new-service-ids)
-                  (update ptv :service-ids (fn [ids]
-                                             (let [x (set ids)
-                                                   x (apply disj x old-service-ids)
-                                                   x (into x new-service-ids)]
-                                               (vec x)))))
-                ptv)
-
-          [_ptv-resp new-ptv-data] (upsert-ptv-service-location!* ptv-component
-                                                                  {:org-id org-id
-                                                                   :ptv ptv
-                                                                   :site sports-site
-                                                                   :archive? to-archive?})]
-
-      (let [resp (core/upsert-sports-site! tx
-                                           user
-                                           (assoc sports-site
-                                                  :event-date (:last-sync new-ptv-data)
-                                                  :ptv new-ptv-data)
-                                           false)]
-        (core/index! search resp :sync)
-        ;; Return both :ptv and :event-date so the caller's outer index!
-        ;; reindexes the same revision we just wrote.
-        {:ptv new-ptv-data :event-date (:event-date resp)}))
+          (let [resp (core/upsert-sports-site! tx
+                                               user
+                                               (assoc sports-site
+                                                      :event-date (:last-sync new-ptv-data)
+                                                      :ptv new-ptv-data)
+                                               false)]
+            (core/index! search resp :sync)
+            ;; Return both :ptv and :event-date so the caller's outer index!
+            ;; reindexes the same revision we just wrote.
+            {:ptv new-ptv-data :event-date (:event-date resp)}))))
     (catch Exception e
       ;; Don't store (ex-data e) directly — clj-http's response includes a
       ;; live `HttpClient` Java object that Cheshire can't serialize to the

--- a/webapp/src/clj/lipas/backend/ptv/core.clj
+++ b/webapp/src/clj/lipas/backend/ptv/core.clj
@@ -331,18 +331,9 @@
   [ptv org-id service-channel-id]
   (ptv/get-org-service-channel ptv org-id service-channel-id))
 
-(def persisted-ptv-keys [:languages
-                         :summary
-                         :description
-                         :user-instruction
-                         :last-sync
-                         :org-id
-                         :sync-enabled
-                         :service-integration
-                         :descriptions-integration
-                         :service-channel-integration
-                         :service-ids
-                         :service-channel-ids])
+;; Single source of truth lives in lipas.data.ptv so the sync path and the
+;; no-sync meta path persist exactly the same editable keys.
+(def persisted-ptv-keys ptv-data/persisted-ptv-keys)
 
 (defn upsert-ptv-service-location!*
   [ptv-component {:keys [org-id site ptv archive?] :as _m}]
@@ -637,12 +628,22 @@
       ;; Meta-save can persist :service-channel-ids without a sync, so guard the
       ;; one-service-location-per-site invariant here too.
       (assert-no-double-link! tx lipas-id (-> ptv :service-channel-ids first))
-      ;; TODO take when-let -> let and add assert
-      (when-let [site (-> (core/get-sports-site tx lipas-id)
-                          (assoc :event-date (utils/timestamp))
-                          (assoc :ptv ptv))]
-        (core/upsert-sports-site! tx user site)
-        (core/index! search site :sync))))
+      (when-let [existing (core/get-sports-site tx lipas-id)]
+        ;; Persist the same editable keys the sync path does (persisted-ptv-keys
+        ;; from the payload), and explicitly preserve the server-owned lifecycle
+        ;; keys from the existing record — there's no PTV response here to
+        ;; re-derive them, and a blanket (assoc :ptv ptv) would wipe them and
+        ;; break the reversible-archive bookkeeping (is-sent-to-ptv?).
+        (let [old-ptv (:ptv existing)
+              new-ptv (-> (select-keys ptv persisted-ptv-keys)
+                          (assoc :source-id          (:source-id old-ptv)
+                                 :publishing-status  (:publishing-status old-ptv)
+                                 :previous-type-code (:previous-type-code old-ptv)))
+              site (assoc existing
+                          :event-date (utils/timestamp)
+                          :ptv new-ptv)]
+          (core/upsert-sports-site! tx user site)
+          (core/index! search site :sync)))))
   {:status "OK"})
 
 (defn save-ptv-audit

--- a/webapp/src/clj/lipas/backend/ptv/handler.clj
+++ b/webapp/src/clj/lipas/backend/ptv/handler.clj
@@ -203,6 +203,19 @@
                                                    (-> req :parameters :body :org-id)
                                                    (-> req :parameters :body :service-channel-id))})}}]
 
+   ["/actions/check-ptv-service-channel-link"
+    {:post
+     {:require-privilege ptv-read-access?
+      :parameters {:body [:map
+                          [:lipas-id #'sports-sites-schema/lipas-id]
+                          [:service-channel-id :string]]}
+      :handler
+      (fn [req]
+        {:status 200
+         :body (ptv-core/check-service-channel-link
+                db
+                (select-keys (-> req :parameters :body) [:lipas-id :service-channel-id]))})}}]
+
    ["/actions/save-ptv-service-location"
     {:post
      {:require-privilege [{:city-code ::roles/any} :ptv/manage]
@@ -213,14 +226,26 @@
           {:status 200
            :body (ptv-core/upsert-ptv-service-location! db ptv search (:identity req) (-> req :parameters :body))}
           (catch clojure.lang.ExceptionInfo e
-            (if-let [ptv-err (ptv-core/parse-ptv-error e)]
+            (cond
+              ;; A different sports-site already owns this service-location.
+              (= :double-link (:type (ex-data e)))
               (do
+                (log/warnf "save-ptv-service-location rejected (double-link, lipas-id: %s): %s"
+                           (-> req :parameters :body :lipas-id)
+                           (pr-str (ex-data e)))
+                {:status 409
+                 :body (ex-data e)})
+
+              (ptv-core/parse-ptv-error e)
+              (let [ptv-err (ptv-core/parse-ptv-error e)]
                 (log/warnf "save-ptv-service-location failed (lipas-id: %s, org: %s): %s"
                            (-> req :parameters :body :lipas-id)
                            (-> req :parameters :body :org-id)
                            (pr-str ptv-err))
                 {:status 409
                  :body ptv-err})
+
+              :else
               (throw e)))))}}]
 
    ["/actions/save-ptv-meta"
@@ -229,8 +254,16 @@
       :parameters {:body [:map-of :int #'ptv-schema/ptv-meta]}
       :handler
       (fn [req]
-        {:status 200
-         :body (ptv-core/save-ptv-integration-definitions db search (:identity req) (-> req :parameters :body))})}}]
+        (try
+          {:status 200
+           :body (ptv-core/save-ptv-integration-definitions db search (:identity req) (-> req :parameters :body))}
+          (catch clojure.lang.ExceptionInfo e
+            (if (= :double-link (:type (ex-data e)))
+              (do
+                (log/warnf "save-ptv-meta rejected (double-link): %s" (pr-str (ex-data e)))
+                {:status 409
+                 :body (ex-data e)})
+              (throw e)))))}}]
 
    ["/actions/save-ptv-audit"
     {:post

--- a/webapp/src/cljc/lipas/data/ptv.cljc
+++ b/webapp/src/cljc/lipas/data/ptv.cljc
@@ -807,15 +807,33 @@
    concept — so leave it out of the comparison."
   [:summary :description])
 
+(defn normalize-ws
+  "Normalize whitespace for *comparing* PTV/LIPAS free-text values — never for
+   storing or pushing them. PTV collapses runs of horizontal whitespace in
+   fields on save (e.g. a double space in a Name becomes a single space), which
+   would otherwise read as drift immediately after a sync. Collapses runs of
+   spaces/tabs to a single space, normalizes line endings and trims, but keeps
+   newlines: paragraph structure is meaningful and PTV preserves it. Returns nil
+   for nil/blank input (so a missing value and an all-whitespace value compare
+   equal)."
+  [s]
+  (some-> s
+          (str/replace #"\r\n?" "\n")    ; CRLF / CR -> LF
+          (str/replace #"[^\S\n]+" " ")  ; collapse horizontal whitespace runs, keep \n
+          (str/replace #" *\n *" "\n")   ; drop spaces hugging newlines (line-edge ws)
+          str/trim
+          not-empty))
+
 (defn texts-match?
   "Compare LIPAS-side texts with PTV-side texts. Returns true if all
-   non-nil fields match. Trims whitespace for comparison. `fields`
-   defaults to all three lipas text fields; callers comparing against
-   a PTV ServiceChannel should pass `service-channel-compare-fields`."
+   non-nil fields match. Whitespace is normalized for comparison
+   (see `normalize-ws`). `fields` defaults to all three lipas text fields;
+   callers comparing against a PTV ServiceChannel should pass
+   `service-channel-compare-fields`."
   ([lipas-texts ptv-texts]
    (texts-match? lipas-texts ptv-texts [:summary :description :user-instruction]))
   ([lipas-texts ptv-texts fields]
-   (let [trim #(some-> % str/trim not-empty)]
+   (let [trim normalize-ws]
      (every? (fn [field]
                (let [lipas-vals (get lipas-texts field)
                      ptv-vals (get ptv-texts field)]
@@ -882,7 +900,9 @@
           ptv-descs (into {} (map (juxt (juxt :type :language) :value))
                           (:serviceChannelDescriptions ptv-channel))
           lang-pairs (resolve-lang-pairs lipas-languages)
-          trim #(some-> % str/trim not-empty)
+          ;; Normalize whitespace so PTV's server-side collapsing (e.g. a
+          ;; double space in a name) isn't reported as drift right after a sync.
+          trim normalize-ws
           mk-text-comparison (fn [field type-v]
                                (for [[ptv-lang locale] lang-pairs]
                                  {:field field

--- a/webapp/src/cljc/lipas/data/ptv.cljc
+++ b/webapp/src/cljc/lipas/data/ptv.cljc
@@ -801,6 +801,27 @@
           {}
           descriptions))
 
+(def persisted-ptv-keys
+  "The editable :ptv meta keys persisted on a sync. Both the sync path
+   (upsert-ptv-service-location!*) and the no-sync meta path
+   (save-ptv-integration-definitions / ::save-ptv-meta) select exactly these
+   from the incoming payload, so the two stay in lock-step. Lifecycle keys the
+   server owns (:source-id, :publishing-status, :previous-type-code) are NOT
+   here — the sync path derives them from the PTV response, the meta path
+   preserves them from the existing record."
+  [:languages
+   :summary
+   :description
+   :user-instruction
+   :last-sync
+   :org-id
+   :sync-enabled
+   :service-integration
+   :descriptions-integration
+   :service-channel-integration
+   :service-ids
+   :service-channel-ids])
+
 (def service-channel-compare-fields
   "Fields to compare when checking drift against a PTV ServiceChannel.
    PTV ServiceChannels don't carry :user-instruction — that's a Service-level
@@ -982,7 +1003,15 @@
         ;; channel left to diff) and event-date still equals last-sync, so
         ;; sync-status would wrongly read :ok and the button would stay
         ;; disabled ("up to date").
-        link-removed? (and last-sync (str/blank? service-channel-id))]
+        link-removed? (and last-sync (str/blank? service-channel-id))
+
+        ;; A channel archived in PTV ("Deleted") that the user has re-enabled
+        ;; needs a sync to resurrect it (the upsert PUTs publishingStatus
+        ;; "Published" on the same channel). Without this, event-date still
+        ;; equals last-sync (from the archive) and the archived channel can't be
+        ;; diffed, so status reads :ok and "Synkronoi nyt" stays disabled.
+        archived-resync? (and (= "Deleted" (-> site :ptv :publishing-status))
+                              (get-in site [:ptv :sync-enabled] false))]
 
     {:valid (boolean (and (some-> description :fi count (> 5))
                           (some-> summary :fi count (> 5))))
@@ -1009,6 +1038,7 @@
      :sync-status (cond
                     (not last-sync) :not-synced
                     link-removed? :out-of-date
+                    archived-resync? :out-of-date
                     has-drift? :content-drift
                     (= (:event-date site) last-sync) :ok
                     :else :out-of-date)
@@ -1026,7 +1056,13 @@
      :service-channel-ids (-> site :ptv :service-channel-ids)
      :service-channel-name (-> (get service-channels service-channel-id)
                                (resolve-service-channel-name))
+     ;; Live status from the cached PTV channel (nil once archived — PTV drops
+     ;; Deleted channels from /list/organization).
      :service-channel-publishing-status (:publishingStatus ptv-channel)
+     ;; LIPAS-persisted status from the last sync/archive. Stays "Deleted" for
+     ;; an archived channel, so the UI can label it instead of showing a bare
+     ;; UUID it can no longer resolve to a name.
+     :publishing-status (-> site :ptv :publishing-status)
 
      :audit-status (determine-audit-status site)}))
 

--- a/webapp/src/cljc/lipas/data/ptv.cljc
+++ b/webapp/src/cljc/lipas/data/ptv.cljc
@@ -972,15 +972,17 @@
         has-drift? (boolean (seq drift-fields))
 
         ;; A site that was synced before (last-sync present) but now has no
-        ;; service-channel-ids was deliberately unlinked by the user — a
+        ;; service-channel-id was deliberately unlinked by the user — a
         ;; successful sync always writes service-channel-ids back, so this
-        ;; combination can't arise any other way. Treat it as out-of-date so
-        ;; the sync button re-activates and the backend create-path (channel
-        ;; id nil) builds a fresh PTV service-location. Without this,
-        ;; has-drift? is false (no channel left to diff) and event-date still
-        ;; equals last-sync, so sync-status would wrongly read :ok and the
-        ;; button would stay disabled ("up to date").
-        link-removed? (and last-sync (empty? (-> site :ptv :service-channel-ids)))]
+        ;; combination can't arise any other way. (Use str/blank? rather than
+        ;; empty?: clearing the autocomplete can leave service-channel-ids as
+        ;; [nil]/[""], not [].) Treat it as out-of-date so the sync button
+        ;; re-activates and the backend create-path (channel id nil) builds a
+        ;; fresh PTV service-location. Without this, has-drift? is false (no
+        ;; channel left to diff) and event-date still equals last-sync, so
+        ;; sync-status would wrongly read :ok and the button would stay
+        ;; disabled ("up to date").
+        link-removed? (and last-sync (str/blank? service-channel-id))]
 
     {:valid (boolean (and (some-> description :fi count (> 5))
                           (some-> summary :fi count (> 5))))

--- a/webapp/src/cljc/lipas/data/ptv.cljc
+++ b/webapp/src/cljc/lipas/data/ptv.cljc
@@ -949,7 +949,18 @@
         drift-langs (or (-> site :ptv :languages) org-langs)
         drift-fields (when (and last-sync ptv-channel)
                        (compute-service-channel-drift site ptv-channel services drift-langs))
-        has-drift? (boolean (seq drift-fields))]
+        has-drift? (boolean (seq drift-fields))
+
+        ;; A site that was synced before (last-sync present) but now has no
+        ;; service-channel-ids was deliberately unlinked by the user — a
+        ;; successful sync always writes service-channel-ids back, so this
+        ;; combination can't arise any other way. Treat it as out-of-date so
+        ;; the sync button re-activates and the backend create-path (channel
+        ;; id nil) builds a fresh PTV service-location. Without this,
+        ;; has-drift? is false (no channel left to diff) and event-date still
+        ;; equals last-sync, so sync-status would wrongly read :ok and the
+        ;; button would stay disabled ("up to date").
+        link-removed? (and last-sync (empty? (-> site :ptv :service-channel-ids)))]
 
     {:valid (boolean (and (some-> description :fi count (> 5))
                           (some-> summary :fi count (> 5))))
@@ -975,6 +986,7 @@
 
      :sync-status (cond
                     (not last-sync) :not-synced
+                    link-removed? :out-of-date
                     has-drift? :content-drift
                     (= (:event-date site) last-sync) :ok
                     :else :out-of-date)

--- a/webapp/src/cljc/lipas/i18n/en/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv.edn
@@ -77,4 +77,9 @@
  :open-in-ptv "Open in PTV"
  :open-in-suomi-fi "Open in suomi.fi"
  :service-missing-for-type "The sports site type has changed and no matching service exists in PTV."
- :type-changed-may-rebind "The sports site type has changed. The site may be linked to a different service in PTV."}
+ :type-changed-may-rebind "The sports site type has changed. The site may be linked to a different service in PTV."
+ :error-summary-too-long "Summary is too long (maximum 150 characters)."
+ :error-description-too-long "Description is too long (maximum 5000 characters)."
+ :error-user-instruction-too-long "User instruction is too long (maximum 5000 characters)."
+ :sync-failed-body-name-conflict "The name '{1}' is already used by another service location in the organization in PTV. PTV requires service location names to be unique. Attach the sports site to the existing service location or change the name, then try again."
+ :saved-but-sync-failed-body-name-conflict "The name '{1}' is already used by another service location in the organization in PTV. PTV requires service location names to be unique. Attach the sports site to the existing service location or change the name, then save again."}

--- a/webapp/src/cljc/lipas/i18n/en/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv.edn
@@ -78,6 +78,7 @@
  :open-in-suomi-fi "Open in suomi.fi"
  :service-missing-for-type "The sports site type has changed and no matching service exists in PTV."
  :type-changed-may-rebind "The sports site type has changed. The site may be linked to a different service in PTV."
+ :delete-will-archive "This sports facility has been exported to PTV. Deleting it also archives the PTV service location."
  :error-summary-too-long "Summary is too long (maximum 150 characters)."
  :error-description-too-long "Description is too long (maximum 5000 characters)."
  :error-user-instruction-too-long "User instruction is too long (maximum 5000 characters)."

--- a/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
@@ -10,6 +10,7 @@
  :attach-existing-service-channel "Link to existing service location...",
  :new-service-channel-will-be-created "A new service location will be created in PTV on export.",
  :change-service-channel "Change service location",
+ :service-channel-archived "Service location archived in PTV",
  :select-service-channel "Select service location",
  :sync-now "Sync now",
  :load-texts-from-ptv "Load texts from PTV",

--- a/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
@@ -17,4 +17,7 @@
  "Replace the summary and description with the texts currently in PTV. Unsaved changes will be lost.",
  :refresh-data "Re-fetch all data from PTV",
  :archive-in-ptv "Archive in PTV",
+ :archive "Archive",
+ :archive-confirm "Archive this sports facility in PTV? You can restore it later by re-enabling synchronization.",
+ :archived-in-ptv "Sports facility archived in PTV",
  :integration-enabled "PTV integration enabled"}

--- a/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv_actions.edn
@@ -20,4 +20,5 @@
  :archive "Archive",
  :archive-confirm "Archive this sports facility in PTV? You can restore it later by re-enabling synchronization.",
  :archived-in-ptv "Sports facility archived in PTV",
+ :archive-on-sync-off-confirm "Synchronization will be turned off. Archive the service location in PTV? You can restore it later by re-enabling synchronization.",
  :integration-enabled "PTV integration enabled"}

--- a/webapp/src/cljc/lipas/i18n/en/ptv_double-link.edn
+++ b/webapp/src/cljc/lipas/i18n/en/ptv_double-link.edn
@@ -1,0 +1,8 @@
+{:warning-title "Service location shared by several sports facilities",
+ :linked-also-to "This PTV service location is also linked to: {1}.",
+ :explanation
+ "A service location can belong to only one sports facility. Linking two facilities to the same service location causes conflicts: their syncs overwrite each other and archiving affects the shared location.",
+ :remediation
+ "Unlink and sync to create a separate PTV service location for this facility.",
+ :blocked
+ "The service location is already linked to {1}, so it can't be linked to this facility."}

--- a/webapp/src/cljc/lipas/i18n/fi/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv.edn
@@ -54,4 +54,9 @@
  :open-in-ptv "Avaa PTV:ssä"
  :open-in-suomi-fi "Avaa suomi.fi:ssä"
  :service-missing-for-type "Liikuntapaikan tyyppi on muuttunut ja uutta tyyppiä vastaava Palvelu puuttuu PTV:stä."
- :type-changed-may-rebind "Liikuntapaikan tyyppi on vaihdettu. Liikuntapaikka liitetään PTV:ssä mahdollisesti toiseen Palveluun vaihdon seurauksena."}
+ :type-changed-may-rebind "Liikuntapaikan tyyppi on vaihdettu. Liikuntapaikka liitetään PTV:ssä mahdollisesti toiseen Palveluun vaihdon seurauksena."
+ :error-summary-too-long "Tiivistelmä on liian pitkä (enintään 150 merkkiä)."
+ :error-description-too-long "Kuvaus on liian pitkä (enintään 5000 merkkiä)."
+ :error-user-instruction-too-long "Toimintaohje on liian pitkä (enintään 5000 merkkiä)."
+ :sync-failed-body-name-conflict "Nimi '{1}' on jo käytössä organisaation toisella palvelupaikalla PTV:ssä. PTV vaatii palvelupaikoille uniikit nimet. Liitä liikuntapaikka olemassa olevaan palvelupaikkaan tai muuta nimeä, ja yritä uudelleen."
+ :saved-but-sync-failed-body-name-conflict "Nimi '{1}' on jo käytössä organisaation toisella palvelupaikalla PTV:ssä. PTV vaatii palvelupaikoille uniikit nimet. Liitä liikuntapaikka olemassa olevaan palvelupaikkaan tai muuta nimeä, ja tallenna uudelleen."}

--- a/webapp/src/cljc/lipas/i18n/fi/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv.edn
@@ -55,6 +55,7 @@
  :open-in-suomi-fi "Avaa suomi.fi:ssä"
  :service-missing-for-type "Liikuntapaikan tyyppi on muuttunut ja uutta tyyppiä vastaava Palvelu puuttuu PTV:stä."
  :type-changed-may-rebind "Liikuntapaikan tyyppi on vaihdettu. Liikuntapaikka liitetään PTV:ssä mahdollisesti toiseen Palveluun vaihdon seurauksena."
+ :delete-will-archive "Tämä liikuntapaikka on viety PTV:hen. Poistaminen arkistoi myös PTV-palvelupaikan."
  :error-summary-too-long "Tiivistelmä on liian pitkä (enintään 150 merkkiä)."
  :error-description-too-long "Kuvaus on liian pitkä (enintään 5000 merkkiä)."
  :error-user-instruction-too-long "Toimintaohje on liian pitkä (enintään 5000 merkkiä)."

--- a/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
@@ -17,4 +17,7 @@
  "Korvaa tiivistelmä ja kuvaus PTV:ssä tällä hetkellä olevilla teksteillä. Tallentamattomat muutokset menetetään.",
  :refresh-data "Hae kaikki tiedot uudelleen PTV:stä",
  :archive-in-ptv "Arkistoi paikka PTV:ssä",
+ :archive "Arkistoi",
+ :archive-confirm "Arkistoidaanko liikuntapaikka PTV:stä? Voit palauttaa sen myöhemmin ottamalla synkronoinnin uudelleen käyttöön.",
+ :archived-in-ptv "Liikuntapaikka arkistoitu PTV:ssä",
  :integration-enabled "PTV-integraatio käytössä"}

--- a/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
@@ -10,6 +10,7 @@
  :attach-existing-service-channel "Liitä olemassa olevaan palvelupaikkaan...",
  :new-service-channel-will-be-created "Uusi palvelupaikka luodaan PTV:hen viennin yhteydessä.",
  :change-service-channel "Muuta palvelupaikkaa",
+ :service-channel-archived "Palvelupaikka arkistoitu PTV:ssä",
  :select-service-channel "Valitse palvelupaikka",
  :sync-now "Synkronoi nyt",
  :load-texts-from-ptv "Lataa tekstit PTV:stä",

--- a/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv_actions.edn
@@ -20,4 +20,5 @@
  :archive "Arkistoi",
  :archive-confirm "Arkistoidaanko liikuntapaikka PTV:stä? Voit palauttaa sen myöhemmin ottamalla synkronoinnin uudelleen käyttöön.",
  :archived-in-ptv "Liikuntapaikka arkistoitu PTV:ssä",
+ :archive-on-sync-off-confirm "Synkronointi otetaan pois päältä. Arkistoidaanko palvelupaikka PTV:ssä? Voit palauttaa sen myöhemmin ottamalla synkronoinnin uudelleen käyttöön.",
  :integration-enabled "PTV-integraatio käytössä"}

--- a/webapp/src/cljc/lipas/i18n/fi/ptv_double-link.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/ptv_double-link.edn
@@ -1,0 +1,8 @@
+{:warning-title "Palvelupaikka on jaettu usean liikuntapaikan kesken",
+ :linked-also-to "Tämä PTV-palvelupaikka on liitetty myös: {1}.",
+ :explanation
+ "Yksi palvelupaikka voi kuulua vain yhdelle liikuntapaikalle. Kahden liikuntapaikan liittäminen samaan palvelupaikkaan aiheuttaa ristiriitoja: synkronoinnit ylikirjoittavat toistensa tiedot ja arkistointi koskee yhteistä palvelupaikkaa.",
+ :remediation
+ "Poista liitos ja synkronoi, jolloin PTV:hen luodaan tälle kohteelle oma palvelupaikka.",
+ :blocked
+ "Palvelupaikka on jo liitetty kohteeseen {1}, joten sitä ei voi liittää tähän liikuntapaikkaan."}

--- a/webapp/src/cljc/lipas/i18n/se/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv.edn
@@ -55,6 +55,7 @@
  :open-in-suomi-fi "Öppna i suomi.fi"
  :service-missing-for-type "Typen av idrottsanläggning har ändrats och motsvarande tjänst saknas i PTV."
  :type-changed-may-rebind "Typen av idrottsanläggning har ändrats. Idrottsanläggningen kan komma att kopplas till en annan tjänst i PTV."
+ :delete-will-archive "Denna idrottsanläggning har förts till PTV. Borttagning arkiverar även PTV-servicestället."
  :error-summary-too-long "Sammandraget är för långt (högst 150 tecken)."
  :error-description-too-long "Beskrivningen är för lång (högst 5000 tecken)."
  :error-user-instruction-too-long "Användarinstruktionen är för lång (högst 5000 tecken)."

--- a/webapp/src/cljc/lipas/i18n/se/ptv.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv.edn
@@ -54,4 +54,9 @@
  :open-in-ptv "Öppna i PTV"
  :open-in-suomi-fi "Öppna i suomi.fi"
  :service-missing-for-type "Typen av idrottsanläggning har ändrats och motsvarande tjänst saknas i PTV."
- :type-changed-may-rebind "Typen av idrottsanläggning har ändrats. Idrottsanläggningen kan komma att kopplas till en annan tjänst i PTV."}
+ :type-changed-may-rebind "Typen av idrottsanläggning har ändrats. Idrottsanläggningen kan komma att kopplas till en annan tjänst i PTV."
+ :error-summary-too-long "Sammandraget är för långt (högst 150 tecken)."
+ :error-description-too-long "Beskrivningen är för lång (högst 5000 tecken)."
+ :error-user-instruction-too-long "Användarinstruktionen är för lång (högst 5000 tecken)."
+ :sync-failed-body-name-conflict "Namnet '{1}' används redan av ett annat serviceställe i organisationen i PTV. PTV kräver unika namn för serviceställen. Koppla idrottsanläggningen till det befintliga servicestället eller ändra namnet och försök igen."
+ :saved-but-sync-failed-body-name-conflict "Namnet '{1}' används redan av ett annat serviceställe i organisationen i PTV. PTV kräver unika namn för serviceställen. Koppla idrottsanläggningen till det befintliga servicestället eller ändra namnet och spara igen."}

--- a/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
@@ -11,6 +11,7 @@
  :attach-existing-service-channel "Koppla till befintlig servicepunkt...",
  :new-service-channel-will-be-created "En ny servicepunkt skapas i PTV vid export.",
  :change-service-channel "Ändra servicepunkt",
+ :service-channel-archived "Servicestället arkiverat i PTV",
  :select-service-channel "Välj servicepunkt",
  :sync-now "Synkronisera nu",
  :load-texts-from-ptv "Hämta texter från PTV",

--- a/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
@@ -18,4 +18,7 @@
  "Ersätt sammanfattningen och beskrivningen med texterna som för närvarande finns i PTV. Osparade ändringar går förlorade.",
  :refresh-data "Hämta all data på nytt från PTV",
  :archive-in-ptv "Arkivera platsen i PTV",
+ :archive "Arkivera",
+ :archive-confirm "Vill du arkivera idrottsanläggningen i PTV? Du kan återställa den senare genom att aktivera synkroniseringen på nytt.",
+ :archived-in-ptv "Idrottsanläggningen arkiverad i PTV",
  :integration-enabled "PTV-integrationen aktiv"}

--- a/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv_actions.edn
@@ -21,4 +21,5 @@
  :archive "Arkivera",
  :archive-confirm "Vill du arkivera idrottsanläggningen i PTV? Du kan återställa den senare genom att aktivera synkroniseringen på nytt.",
  :archived-in-ptv "Idrottsanläggningen arkiverad i PTV",
+ :archive-on-sync-off-confirm "Synkroniseringen stängs av. Vill du arkivera servicestället i PTV? Du kan återställa det senare genom att aktivera synkroniseringen på nytt.",
  :integration-enabled "PTV-integrationen aktiv"}

--- a/webapp/src/cljc/lipas/i18n/se/ptv_double-link.edn
+++ b/webapp/src/cljc/lipas/i18n/se/ptv_double-link.edn
@@ -1,0 +1,8 @@
+{:warning-title "Servicestället delas mellan flera idrottsanläggningar",
+ :linked-also-to "Detta PTV-serviceställe är också kopplat till: {1}.",
+ :explanation
+ "Ett serviceställe kan höra till endast en idrottsanläggning. Att koppla två anläggningar till samma serviceställe orsakar konflikter: synkroniseringarna skriver över varandras uppgifter och arkivering gäller det gemensamma servicestället.",
+ :remediation
+ "Ta bort kopplingen och synkronisera, så skapas ett eget serviceställe för detta objekt i PTV.",
+ :blocked
+ "Servicestället är redan kopplat till {1} och kan därför inte kopplas till denna anläggning."}

--- a/webapp/src/cljc/lipas/i18n/utils.cljc
+++ b/webapp/src/cljc/lipas/i18n/utils.cljc
@@ -58,6 +58,7 @@
    :ptv.actions
    :ptv.audit
    :ptv.audit.status
+   :ptv.double-link
    :ptv.drift
    :ptv.name-conflict
    :ptv.service

--- a/webapp/src/cljc/lipas/schema/sports_sites/ptv.cljc
+++ b/webapp/src/cljc/lipas/schema/sports_sites/ptv.cljc
@@ -1,6 +1,7 @@
 (ns lipas.schema.sports-sites.ptv
   "Schema definitions for PTV (Palvelutietovaranto) integration in sports sites."
-  (:require [malli.core :as m]))
+  (:require [lipas.data.ptv :as ptv-data]
+            [malli.core :as m]))
 
 (defn localized-string-schema
   "Creates schema for localized strings with optional constraints."
@@ -67,9 +68,15 @@
     [:service-ids [:vector :string]]
     [:languages {:optional true} [:vector :string]]
 
-    [:summary (localized-string-schema {:max 150})]
-    [:description (localized-string-schema {})]
-    [:user-instruction {:optional true} (localized-string-schema {})]
+    ;; Per-language character limits enforced by PTV (see lipas.data.ptv).
+    ;; The :error/message values are localization keys resolved via `tr`
+    ;; in the UI (e.g. the sync-button why-disabled tooltip).
+    [:summary (localized-string-schema {:max ptv-data/max-summary-length
+                                        :error/message :ptv/error-summary-too-long})]
+    [:description (localized-string-schema {:max ptv-data/max-description-length
+                                            :error/message :ptv/error-description-too-long})]
+    [:user-instruction {:optional true} (localized-string-schema {:max ptv-data/max-user-instruction-length
+                                                                  :error/message :ptv/error-user-instruction-too-long})]
 
     [:audit {:optional true} ptv-audit]]))
 

--- a/webapp/src/cljc/lipas/schema/sports_sites/ptv.cljc
+++ b/webapp/src/cljc/lipas/schema/sports_sites/ptv.cljc
@@ -81,10 +81,14 @@
     [:audit {:optional true} ptv-audit]]))
 
 (def create-ptv-service-location
-  "Schema for creating PTV service locations."
+  "Schema for creating PTV service locations.
+   `:archive?` requests an explicit archive (publishingStatus \"Deleted\")
+   instead of a publish/update — used by the explicit \"Archive in PTV\"
+   actions in both the wizard and the sports-site PTV tab."
   (m/schema
    [:map
     {:closed true}
     [:org-id :string]
     [:lipas-id :int]
+    [:archive? {:optional true} :boolean]
     [:ptv ptv-meta]]))

--- a/webapp/src/cljs/lipas/ui/ptv/components.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/components.cljs
@@ -507,6 +507,7 @@
                {:on-change #(rf/dispatch [::events/set-service-candidate-summary @source-id @selected-tab %])
                 :fullWidth true
                 :multiline true :variant "outlined" :label (tr :ptv/summary) :value v
+                :inputProps #js {:maxLength ptv-data/max-summary-length}
                 :helperText (str (count v) "/" ptv-data/max-summary-length)
                 :error (> (count v) ptv-data/max-summary-length)}])
 
@@ -515,6 +516,7 @@
                {:on-change #(rf/dispatch [::events/set-service-candidate-description @source-id @selected-tab %])
                 :fullWidth true
                 :variant "outlined" :rows 5 :multiline true :label (tr :ptv/description) :value v
+                :inputProps #js {:maxLength ptv-data/max-description-length}
                 :helperText (str (count v) "/" ptv-data/max-description-length)
                 :error (> (count v) ptv-data/max-description-length)}])
 
@@ -523,6 +525,7 @@
                {:on-change #(rf/dispatch [::events/set-service-candidate-user-instruction @source-id @selected-tab %])
                 :fullWidth true
                 :variant "outlined" :rows 3 :multiline true :label (tr :ptv/user-instruction) :value v
+                :inputProps #js {:maxLength ptv-data/max-user-instruction-length}
                 :helperText (str (count v) "/" ptv-data/max-user-instruction-length)
                 :error (> (count v) ptv-data/max-user-instruction-length)}])]])]])))
 

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -1428,17 +1428,10 @@
     ;; This event is used to save :ptv data for sites which have :sync-enabled false
     (when (seq sports-sites)
       (let [token (-> db :user :login :token)
-            ks [:languages
-                :summary
-                :description
-                :last-sync
-                :org-id
-                :sync-enabled
-                :service-integration
-                :descriptions-integration
-                :service-channel-integration
-                :service-ids
-                :service-channel-ids]]
+            ;; Same editable keys the sync path persists (shared source of
+            ;; truth). The backend preserves server-owned lifecycle keys
+            ;; (:source-id, :publishing-status, :previous-type-code) itself.
+            ks ptv-data/persisted-ptv-keys]
         {:db (assoc-in db [:ptv :save-in-progress] true)
          :fx [[:http-xhrio
                {:method :post

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -420,12 +420,30 @@
   (fn [db [_ org-id lipas-id v]]
     (assoc-in db [:ptv :org org-id :data :sports-sites lipas-id :ptv :sync-enabled] v)))
 
+(rf/reg-event-fx ::persist-ptv-meta
+  ;; Persist a single site's :ptv meta (sync-enabled, texts, links, ...) via
+  ;; save-ptv-meta without syncing to PTV. Reads the (already-updated) app-db
+  ;; site, so dispatch any flag change before this. save-ptv-meta keys off the
+  ;; top-level :lipas-id and reads the remaining meta from the flattened map.
+  (fn [{:keys [db]} [_ lipas-id]]
+    (let [org-id (-get-ptv-org-id db)
+          site (get-in db [:ptv :org org-id :data :sports-sites lipas-id])]
+      {:fx [[:dispatch [::save-ptv-meta [(assoc (:ptv site) :lipas-id lipas-id)]]]]})))
+
 (rf/reg-event-fx ::toggle-sync-enabled
   ;; Turning sync OFF on a site that is currently published in PTV prompts the
   ;; user whether to also archive the PTV service-location (Kyllä = archive,
   ;; Ei = keep it frozen in PTV, Peruuta = leave sync on). Other toggles just
   ;; flip the flag.
-  (fn [{:keys [db]} [_ {:keys [lipas-id service-channel-publishing-status]} v]]
+  ;;
+  ;; With :persist? true (the Liikuntapaikat tab, which has no batch "save all"
+  ;; step) turning sync OFF is written to the backend via save-ptv-meta so the
+  ;; switch sticks across reloads: "Ei" and a non-prompt off persist directly,
+  ;; "Kyllä"/archive persists on its own, and "Peruuta" persists nothing (and
+  ;; doesn't flip the flag). Turning sync ON is NOT persisted here — that's the
+  ;; "Synkronoi nyt" button's job. Callers without :persist? (the wizard, which
+  ;; persists later via its batch export) keep the app-db-only behaviour.
+  (fn [{:keys [db]} [_ {:keys [lipas-id service-channel-publishing-status]} v & {:keys [persist?]}]]
     (let [org-id (-get-ptv-org-id db)
           tr (:translator db)
           published? (= "Published" service-channel-publishing-status)]
@@ -436,8 +454,11 @@
                             (rf/dispatch [::set-sync-enabled org-id lipas-id false])
                             (rf/dispatch [::archive-ptv-service-location lipas-id]))
                           (fn []
-                            (rf/dispatch [::set-sync-enabled org-id lipas-id false]))]]]}
-        {:fx [[:dispatch [::set-sync-enabled org-id lipas-id v]]]}))))
+                            (rf/dispatch [::set-sync-enabled org-id lipas-id false])
+                            (when persist? (rf/dispatch [::persist-ptv-meta lipas-id])))]]]}
+        {:fx (cond-> [[:dispatch [::set-sync-enabled org-id lipas-id v]]]
+               ;; Persist OFF only; ON is persisted by an actual sync.
+               (and persist? (not v)) (conj [:dispatch [::persist-ptv-meta lipas-id]]))}))))
 
 (rf/reg-event-fx ::toggle-site-sync-enabled
   ;; Site-tab specific: toggle :ptv :sync-enabled on the site's edit-buffer.

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -490,6 +490,10 @@
 (rf/reg-event-db ::select-service-channels
   (fn [db [_ {:keys [lipas-id]} v]]
     (let [org-id (-get-ptv-org-id db)
+          ;; Clearing the single-select autocomplete fires on-change with [nil];
+          ;; normalize to [] so "no link" is represented consistently — clean
+          ;; sync payload, and link-removed? (drift detection) actually fires.
+          v (vec (remove str/blank? v))
           new-id (first v)
           sites (get-in db [:ptv :org org-id :data :sports-sites])
           ;; Hard-block double-linking: refuse to bind this site to a

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -1256,6 +1256,40 @@
        :fx (into (or (seq extra-fx) [])
                  [[:dispatch [:lipas.ui.events/set-active-notification notification]]])})))
 
+;;; Explicit archive (publishingStatus "Deleted") ;;;
+
+(rf/reg-event-fx ::archive-ptv-service-location
+  ;; Explicit, user-requested archive of a previously-published service-location.
+  ;; Posts the same payload as a sync but with :archive? true, so the backend
+  ;; PUTs publishingStatus "Deleted" while preserving the channel link (a later
+  ;; re-activation re-publishes the same channel). Reuses the sync failure
+  ;; handler so PTV errors (incl. name conflicts) surface the same way.
+  (fn [{:keys [db]} [_ lipas-id]]
+    (let [token (-> db :user :login :token)]
+      {:db (-> db
+               (assoc-in [:ptv :loading-from-lipas :service-locations] true)
+               (assoc-in [:ptv :syncing :service-location lipas-id] true))
+       :fx [[:http-xhrio
+             {:method :post
+              :headers {:Authorization (str "Token " token)}
+              :uri (str (:backend-url db) "/actions/save-ptv-service-location")
+              :params (assoc (service-location-payload db lipas-id) :archive? true)
+              :format (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success [::archive-ptv-service-location-success lipas-id]
+              :on-failure [::create-ptv-service-location-failure lipas-id []]}]]})))
+
+(rf/reg-event-fx ::archive-ptv-service-location-success
+  (fn [{:keys [db]} [_ lipas-id {:keys [ptv]}]]
+    (let [tr (:translator db)
+          org-id (-get-ptv-org-id db)]
+      {:db (-> db
+               (assoc-in [:ptv :loading-from-lipas :service-locations] false)
+               (update-in [:ptv :syncing :service-location] dissoc lipas-id)
+               (assoc-in [:ptv :org org-id :data :sports-sites lipas-id :ptv] ptv))
+       :fx [[:dispatch [:lipas.ui.events/set-active-notification
+                        {:message (tr :ptv.actions/archived-in-ptv) :success? true}]]]})))
+
 (rf/reg-event-fx ::create-all-ptv-service-locations*
   (fn [{:keys [db]} [_ org-id ids]]
     (let [halt? (get-in db [:ptv :service-locations-creation :halt?] false)

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -489,8 +489,25 @@
 
 (rf/reg-event-db ::select-service-channels
   (fn [db [_ {:keys [lipas-id]} v]]
-    (let [org-id (-get-ptv-org-id db)]
-      (assoc-in db [:ptv :org org-id :data :sports-sites lipas-id :ptv :service-channel-ids] v))))
+    (let [org-id (-get-ptv-org-id db)
+          new-id (first v)
+          sites (get-in db [:ptv :org org-id :data :sports-sites])
+          ;; Hard-block double-linking: refuse to bind this site to a
+          ;; service-location another loaded site already holds. Clearing the
+          ;; link (empty v) is always allowed — it's the remediation path.
+          conflict (when new-id
+                     (some (fn [[other-lipas-id site]]
+                             (when (and (not= other-lipas-id lipas-id)
+                                        (contains? (set (-> site :ptv :service-channel-ids)) new-id))
+                               {:lipas-id other-lipas-id
+                                :name (:name site)
+                                :service-channel-id new-id}))
+                           sites))]
+      (if conflict
+        (assoc-in db [:ptv :double-link-block lipas-id] conflict)
+        (-> db
+            (update-in [:ptv :double-link-block] dissoc lipas-id)
+            (assoc-in [:ptv :org org-id :data :sports-sites lipas-id :ptv :service-channel-ids] v))))))
 
 (rf/reg-event-db ::select-service-integration
   (fn [db [_ {:keys [lipas-id]} v]]
@@ -1454,6 +1471,33 @@
   (fn [{:keys [db]} [_ lipas-id org-id resp]]
     {:db (-> db)}))
              ;; (assoc-in [:ptv :loading-from-ptv :ptv-text] false)
+
+;;; Double-link detection (single-site PTV tab) ;;;
+
+(rf/reg-event-fx ::check-double-link
+  ;; Ask the backend whether another sports-site is linked to the same PTV
+  ;; service-location. The single-site view can't detect this locally (it loads
+  ;; neither the org's channels nor its sibling sites).
+  (fn [{:keys [db]} [_ lipas-id service-channel-id]]
+    (let [token (-> db :user :login :token)]
+      {:fx [[:http-xhrio
+             {:method :post
+              :headers {:Authorization (str "Token " token)}
+              :uri (str (:backend-url db) "/actions/check-ptv-service-channel-link")
+              :params {:lipas-id lipas-id
+                       :service-channel-id service-channel-id}
+              :format (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success [::check-double-link-success lipas-id]
+              :on-failure [::check-double-link-failure lipas-id]}]]})))
+
+(rf/reg-event-db ::check-double-link-success
+  (fn [db [_ lipas-id resp]]
+    (assoc-in db [:ptv :double-link-check lipas-id] (:other-sites resp))))
+
+(rf/reg-event-db ::check-double-link-failure
+  (fn [db [_ lipas-id _resp]]
+    (update-in db [:ptv :double-link-check] dissoc lipas-id)))
 
 (rf/reg-event-fx ::set-manual-services
   (fn [{:keys [db]} [_ org-id source-ids subcategories]]

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -47,26 +47,52 @@
                       v)))
             body))))
 
+(defn ptv-duplicate-name
+  "If the PTV sync failed because the service-channel name already exists in
+  the organization, return the offending name (e.g. \"Haapamäen
+  urheilukenttä\"). Otherwise nil.
+
+  PTV returns `:ServiceChannelNames [\"Value 'X' of language code 'fi'
+  already exists within organization. The name must be unique.\"]`."
+  [resp]
+  (let [body (ptv-error-payload resp)]
+    (when (map? body)
+      (some (fn [[k v]]
+              (when (and (= "ServiceChannelNames" (name k))
+                         (sequential? v))
+                (some (fn [msg]
+                        (when (and (string? msg)
+                                   (str/includes? msg "already exists within organization"))
+                          (second (re-find #"'([^']+)'" msg))))
+                      v)))
+            body))))
+
 (def ^:private dialog-body-keys
   {:modified            :ptv/sync-failed-body-ptv-modified
-   :invalid-postal-code :ptv/sync-failed-body-invalid-postal-code})
+   :invalid-postal-code :ptv/sync-failed-body-invalid-postal-code
+   :duplicate-name      :ptv/sync-failed-body-name-conflict})
 
 (def ^:private save-body-keys
   {:modified            :ptv/saved-but-sync-failed-body-ptv-modified
-   :invalid-postal-code :ptv/saved-but-sync-failed-body-invalid-postal-code})
+   :invalid-postal-code :ptv/saved-but-sync-failed-body-invalid-postal-code
+   :duplicate-name      :ptv/saved-but-sync-failed-body-name-conflict})
 
 (defn- ptv-sync-error-body
   "Localized actionable body text for a PTV sync failure. `body-keys`
   selects the translation family. Returns nil for generic failures with no
   specific detail beyond the title."
   [tr resp body-keys]
-  (let [bad-code (ptv-invalid-postal-code resp)]
+  (let [bad-code (ptv-invalid-postal-code resp)
+        dup-name (ptv-duplicate-name resp)]
     (cond
       (ptv-modified-error? resp)
       (tr (:modified body-keys))
 
       bad-code
       (tr (:invalid-postal-code body-keys) bad-code)
+
+      dup-name
+      (tr (:duplicate-name body-keys) dup-name)
 
       :else
       nil)))
@@ -1148,31 +1174,36 @@
 
 ;;; Create service locations in PTV ;;;
 
+(defn service-location-payload
+  "Build the exact request body posted to /actions/save-ptv-service-location
+  for `lipas-id`. Shared by the sync event and the client-side schema
+  validation (see ::service-location-schema-errors) so the validation always
+  matches what actually gets sent."
+  [db lipas-id]
+  (let [org-id (-get-ptv-org-id db)
+        ;; Add default org-id for service-ids linking
+        sports-site (-> (get-in db [:ptv :org org-id :data :sports-sites lipas-id])
+                        (update :ptv #(merge {:org-id org-id} %)))
+        ;; Always use org languages (site typically doesn't store this)
+        org-languages (get-in db [:ptv :selected-org :ptv-data :supported-languages] ptv-data/fallback-languages)
+        ptv (merge (select-keys (:default-settings (:ptv db))
+                                [:sync-enabled])
+                   {:service-channel-ids []}
+                   (select-keys (:ptv sports-site)
+                                [:org-id
+                                 :sync-enabled
+                                 :service-channel-ids
+                                 :service-ids
+                                 :summary
+                                 :description])
+                   {:languages org-languages})]
+    {:lipas-id lipas-id
+     :org-id org-id
+     :ptv ptv}))
+
 (rf/reg-event-fx ::create-ptv-service-location
   (fn [{:keys [db]} [_ lipas-id success-fx failure-fx]]
-    (let [token (-> db :user :login :token)
-          ;; Or per site?
-          org-id (-get-ptv-org-id db)
-
-          sports-site (get-in db [:ptv :org org-id :data :sports-sites lipas-id])
-
-          ;; Add default org-id for service-ids linking
-          sports-site (update sports-site :ptv #(merge {:org-id org-id} %))
-
-          ;; Add other defaults and merge with summary/description from the UI
-          org-languages (get-in db [:ptv :selected-org :ptv-data :supported-languages] ptv-data/fallback-languages)
-          ptv-data (merge (select-keys (:default-settings (:ptv db))
-                                       [:sync-enabled])
-                          {:service-channel-ids []}
-                          (select-keys (:ptv sports-site)
-                                       [:org-id
-                                        :sync-enabled
-                                        :service-channel-ids
-                                        :service-ids
-                                        :summary
-                                        :description])
-                          ;; Always use org languages (site typically doesn't store this)
-                          {:languages org-languages})]
+    (let [token (-> db :user :login :token)]
       {:db (-> db
                (assoc-in [:ptv :loading-from-lipas :service-locations] true)
                (assoc-in [:ptv :syncing :service-location lipas-id] true))
@@ -1180,9 +1211,7 @@
              {:method :post
               :headers {:Authorization (str "Token " token)}
               :uri (str (:backend-url db) "/actions/save-ptv-service-location")
-              :params {:lipas-id lipas-id
-                       :org-id org-id
-                       :ptv ptv-data}
+              :params (service-location-payload db lipas-id)
               :format (ajax/transit-request-format)
               :response-format (ajax/transit-response-format)
               :on-success [::create-ptv-service-location-success lipas-id success-fx]

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -416,10 +416,28 @@
 
 ;;; Service locations views and manipulation ;;;
 
-(rf/reg-event-db ::toggle-sync-enabled
-  (fn [db [_ {:keys [lipas-id]} v]]
-    (let [org-id (-get-ptv-org-id db)]
-      (assoc-in db [:ptv :org org-id :data :sports-sites lipas-id :ptv :sync-enabled] v))))
+(rf/reg-event-db ::set-sync-enabled
+  (fn [db [_ org-id lipas-id v]]
+    (assoc-in db [:ptv :org org-id :data :sports-sites lipas-id :ptv :sync-enabled] v)))
+
+(rf/reg-event-fx ::toggle-sync-enabled
+  ;; Turning sync OFF on a site that is currently published in PTV prompts the
+  ;; user whether to also archive the PTV service-location (Kyllä = archive,
+  ;; Ei = keep it frozen in PTV, Peruuta = leave sync on). Other toggles just
+  ;; flip the flag.
+  (fn [{:keys [db]} [_ {:keys [lipas-id service-channel-publishing-status]} v]]
+    (let [org-id (-get-ptv-org-id db)
+          tr (:translator db)
+          published? (= "Published" service-channel-publishing-status)]
+      (if (and (not v) published?)
+        {:fx [[:dispatch [:lipas.ui.events/confirm
+                          (tr :ptv.actions/archive-on-sync-off-confirm)
+                          (fn []
+                            (rf/dispatch [::set-sync-enabled org-id lipas-id false])
+                            (rf/dispatch [::archive-ptv-service-location lipas-id]))
+                          (fn []
+                            (rf/dispatch [::set-sync-enabled org-id lipas-id false]))]]]}
+        {:fx [[:dispatch [::set-sync-enabled org-id lipas-id v]]]}))))
 
 (rf/reg-event-fx ::toggle-site-sync-enabled
   ;; Site-tab specific: toggle :ptv :sync-enabled on the site's edit-buffer.
@@ -430,15 +448,39 @@
           latest-id (get-in db [:sports-sites lipas-id :latest])
           latest-site (get-in db [:sports-sites lipas-id :history latest-id])
           user-orgs (get-in db [:user :orgs])
+          tr (:translator db)
           persisted-org-id (get-in (or edit-site latest-site) [:ptv :org-id])
           resolved-org-id (or persisted-org-id
                               (ptv-data/resolve-org-id (or edit-site latest-site)
-                                                       user-orgs))]
-      {:fx (cond-> [[:dispatch [:lipas.ui.sports-sites.events/edit-field
-                                lipas-id [:ptv :sync-enabled] enabled?]]]
-             (and enabled? (not persisted-org-id) resolved-org-id)
-             (conj [:dispatch [:lipas.ui.sports-sites.events/edit-field
-                               lipas-id [:ptv :org-id] resolved-org-id]]))})))
+                                                       user-orgs))
+          ;; Published in PTV right now? Archiving only makes sense then.
+          published? (ptv-data/is-sent-to-ptv? (or edit-site latest-site))
+          set-flag (fn [v] [:dispatch [:lipas.ui.sports-sites.events/edit-field
+                                       lipas-id [:ptv :sync-enabled] v]])
+          set-archive (fn [v] [:dispatch [:lipas.ui.sports-sites.events/edit-field
+                                          lipas-id [:ptv :delete-existing] v]])]
+      (cond
+        ;; Enabling: keep existing behaviour (set flag + maybe org-id invariant).
+        enabled?
+        {:fx (cond-> [(set-flag true)]
+               (and (not persisted-org-id) resolved-org-id)
+               (conj [:dispatch [:lipas.ui.sports-sites.events/edit-field
+                                 lipas-id [:ptv :org-id] resolved-org-id]]))}
+
+        ;; Disabling a published site: ask whether to archive in PTV. The archive
+        ;; itself is deferred to the next sports-site save (via :delete-existing).
+        published?
+        {:fx [[:dispatch [:lipas.ui.events/confirm
+                          (tr :ptv.actions/archive-on-sync-off-confirm)
+                          (fn []
+                            (rf/dispatch (set-flag false))
+                            (rf/dispatch (set-archive true)))
+                          (fn []
+                            (rf/dispatch (set-flag false)))]]]}
+
+        ;; Disabling a not-yet-published site: just turn it off.
+        :else
+        {:fx [(set-flag false)]}))))
 
 (rf/reg-event-db ::select-services
   (fn [db [_ {:keys [lipas-id]} v]]

--- a/webapp/src/cljs/lipas/ui/ptv/site_view.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/site_view.cljs
@@ -144,7 +144,8 @@
                                                    :value (:org-id ptv-data)}))))
                                     [orgs])
         single-org? (= 1 (count org-options))
-        service-channel-modified? (= "Modified" (-> site :ptv :service-channel-publishing-status))]
+        service-channel-modified? (= "Modified" (-> site :ptv :service-channel-publishing-status))
+        double-link-others @(rf/subscribe [::subs/double-link-others lipas-id])]
 
     ;; Load user orgs on mount if not already loaded
     ;; Note: orgs is nil when not loaded, empty vector [] when loaded but user has no orgs
@@ -181,6 +182,15 @@
                           (rf/dispatch [:lipas.ui.sports-sites.events/edit-field
                                         lipas-id [:ptv :service-ids] [matching-service-id]])))
                       [editing? sync-enabled candidate-now? matching-service-id])
+
+    ;; Detect a pre-existing double-link: another sports-site bound to the same
+    ;; PTV service-location. This view loads neither the org's channels nor its
+    ;; sibling sites, so the backend resolves it whenever the linked channel
+    ;; changes.
+    (hooks/use-effect (fn []
+                        (when-let [channel-id (first (:service-channel-ids (:ptv site)))]
+                          (rf/dispatch [::events/check-double-link lipas-id channel-id])))
+                      [lipas-id (first (:service-channel-ids (:ptv site)))])
 
     [:> Stack
      {:direction "column"
@@ -364,6 +374,20 @@
                  :sx #js {:textTransform "none" :alignSelf "flex-start"}
                  :on-click #(set-creating-service? true)}
                 (tr :ptv.service/create-new)]]))]))
+
+     ;; Double-link warning: another sports-site is bound to the same PTV
+     ;; service-location. Always shown (independent of sync state) since it's a
+     ;; data-integrity problem. Remediation is the unlink → sync flow.
+     (when (seq double-link-others)
+       [:> Alert {:severity "warning" :variant "outlined"}
+        [:> AlertTitle (tr :ptv.double-link/warning-title)]
+        [:> Typography {:variant "body2"}
+         (tr :ptv.double-link/linked-also-to
+             (str/join ", " (map :name double-link-others)))]
+        [:> Typography {:variant "body2" :sx #js {:mt 1}}
+         (tr :ptv.double-link/explanation)]
+        [:> Typography {:variant "body2" :sx #js {:mt 1}}
+         (tr :ptv.double-link/remediation)]])
 
      ;; 5. Descriptions and everything below — gated on sync-enabled + org-id.
      (when (and sync-enabled org-id)

--- a/webapp/src/cljs/lipas/ui/ptv/site_view.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/site_view.cljs
@@ -441,6 +441,7 @@
                          (rf/dispatch [:lipas.ui.sports-sites.events/edit-field lipas-id [:ptv :summary selected-tab] v]))
             :label (tr :ptv/summary)
             :value v
+            :inputProps #js {:maxLength ptv-data/max-summary-length}
             :helperText (str (count v) "/" ptv-data/max-summary-length)
             :error (> (count v) ptv-data/max-summary-length)}])
 
@@ -464,6 +465,7 @@
                          (rf/dispatch [:lipas.ui.sports-sites.events/edit-field lipas-id [:ptv :description selected-tab] v]))
             :label (tr :ptv/description)
             :value v
+            :inputProps #js {:maxLength ptv-data/max-description-length}
             :helperText (str (count v) "/" ptv-data/max-description-length)
             :error (> (count v) ptv-data/max-description-length)}])
 

--- a/webapp/src/cljs/lipas/ui/ptv/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/subs.cljs
@@ -5,8 +5,10 @@
             [lipas.roles :as roles]
             [lipas.schema.sports-sites.ptv :as ptv-schema]
             [lipas.ui.map.utils :as map-utils]
+            [lipas.ui.ptv.events :as events]
             [lipas.ui.utils :as utils :refer [prod?]]
             [malli.core :as m]
+            [malli.error :as me]
             [re-frame.core :as rf]))
 
 (rf/reg-sub ::ptv
@@ -316,6 +318,23 @@
                                        (comp map-utils/wgs84->epsg3067 clj->js)
                                        (utils/timestamp)
                                        site))))
+
+(rf/reg-sub ::service-location-schema-errors
+  ;; Localized error-message keys for the would-be /save-ptv-service-location
+  ;; payload of `lipas-id`, validated against the same malli schema the backend
+  ;; coerces against. Returns a distinct vector of localization keys (from the
+  ;; schema's :error/message props) — empty when the payload is valid. Only
+  ;; keyword messages are surfaced; structural errors (missing required keys)
+  ;; are left to the business-level sync hints. Used to disable the sync button
+  ;; and explain why in its tooltip.
+  (fn [db [_ lipas-id]]
+    (let [payload (events/service-location-payload db lipas-id)]
+      (->> (some-> (m/explain ptv-schema/create-ptv-service-location payload)
+                   :errors)
+           (map me/error-message)
+           (filter keyword?)
+           distinct
+           vec))))
 
 (rf/reg-sub ::service-candidate-descriptions
   :<- [::ptv]

--- a/webapp/src/cljs/lipas/ui/ptv/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/subs.cljs
@@ -390,6 +390,40 @@
       {:service-channel-id (:id m)
        :name (ptv-data/resolve-service-channel-name m)})))
 
+(rf/reg-sub ::double-link-others
+  ;; Other sports-sites linked to this site's PTV service-location, as resolved
+  ;; by the backend check (see ::events/check-double-link). Empty/nil = no
+  ;; double-link.
+  :<- [::ptv]
+  (fn [ptv [_ lipas-id]]
+    (get-in ptv [:double-link-check lipas-id])))
+
+(rf/reg-sub ::double-link-block
+  ;; A blocked attempt to link this site to a service-location another site
+  ;; already owns (see ::events/select-service-channels). nil = no block.
+  :<- [::ptv]
+  (fn [ptv [_ lipas-id]]
+    (get-in ptv [:double-link-block lipas-id])))
+
+(rf/reg-sub ::channel-id->lipas-ids
+  ;; {service-channel-id #{lipas-id ...}} across the org's loaded sites.
+  :<- [::ptv]
+  (fn [ptv [_ org-id]]
+    (let [sites (get-in ptv [:org org-id :data :sports-sites])]
+      (reduce (fn [m [lipas-id site]]
+                (reduce (fn [m cid] (update m cid (fnil conj #{}) lipas-id))
+                        m
+                        (-> site :ptv :service-channel-ids)))
+              {}
+              sites))))
+
+(rf/reg-sub ::double-linked-lipas-ids
+  ;; Set of lipas-ids that share a PTV service-location with at least one other
+  ;; loaded site — used to flag double-linked rows in the table.
+  (fn [[_ org-id]] (rf/subscribe [::channel-id->lipas-ids org-id]))
+  (fn [idx _]
+    (->> idx vals (filter #(> (count %) 1)) (apply concat) set)))
+
 (rf/reg-sub ::sports-sites
   (fn [[_ org-id]]
     [(rf/subscribe [::ptv])

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -213,6 +213,7 @@
           channel-id (first (:service-channel-ids site))
           channel-name (:service-channel-name site)
           name-conflict (:name-conflict site)
+          double-link-block (<== [::subs/double-link-block (:lipas-id site)])
           sync-status (:sync-status site)
           needs-sync? (contains? #{:out-of-date :content-drift} sync-status)]
       [:> Stack {:spacing 2}
@@ -311,6 +312,16 @@
                              {:lipas-id (:lipas-id site)}
                              [(:service-channel-id name-conflict)]])}
            (tr :ptv.wizard/attach-to-conflicting-service-channel)]])
+
+       ;; Double-link block: the user tried to attach a service-location that
+       ;; another site already owns. The link was refused (not set); explain why.
+       (when double-link-block
+         [:> Alert {:severity "error" :variant "outlined"}
+          [:> AlertTitle (tr :ptv.double-link/warning-title)]
+          [:> Typography {:variant "body2"}
+           (tr :ptv.double-link/blocked (:name double-link-block))]
+          [:> Typography {:variant "body2" :sx #js {:mt 1}}
+           (tr :ptv.double-link/explanation)]])
 
        ;; AI generate + translate buttons
        (let [from-lang @selected-tab
@@ -595,6 +606,7 @@
           sites (<== [::subs/sports-sites org-id])
           filtered-sites (filter-sites sites @search-text @status-filter)
           sync-all-enabled? (<== [::subs/sync-all-enabled? org-id])
+          double-linked-ids (<== [::subs/double-linked-lipas-ids org-id])
 
           ;; Audit status component
           audit-status-cell (fn [site]
@@ -765,7 +777,11 @@
 
                 ;; Name
                   [:> TableCell
-                   (:name site)]
+                   [:> Stack {:direction "row" :spacing 0.5 :align-items "center"}
+                    (when (contains? double-linked-ids (:lipas-id site))
+                      [:> Tooltip {:title (tr :ptv.double-link/warning-title)}
+                       [:> WarningIcon {:color "warning" :sx #js {:fontSize "1rem"}}]])
+                    [:span (:name site)]]]
 
                 ;; Type
                   [:> TableCell

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -212,6 +212,7 @@
           linked-services (filter #(contains? service-ids (:service-id %)) services)
           channel-id (first (:service-channel-ids site))
           channel-name (:service-channel-name site)
+          name-conflict (:name-conflict site)
           sync-status (:sync-status site)
           needs-sync? (contains? #{:out-of-date :content-drift} sync-status)]
       [:> Stack {:spacing 2}
@@ -284,6 +285,32 @@
                         :sx #js {:textTransform "none" :alignSelf "flex-start" :p 0}
                         :on-click #(reset! editing-channel? true)}
              (tr :ptv.actions/attach-existing-service-channel)])])
+
+       ;; Name conflict warning. PTV enforces unique service-location names
+       ;; per org, so syncing this site (which on next sync creates/updates a
+       ;; channel named after the site) would collide with an existing,
+       ;; differently-linked channel of the same name. Surface it here with
+       ;; the same guidance the wizard uses; otherwise the conflict only
+       ;; manifests as a PTV 400 at sync time.
+       (when name-conflict
+         [:> Alert {:severity "warning" :variant "outlined"}
+          [:> AlertTitle
+           (tr :ptv.wizard/service-channel-name-conflict (:name site))]
+          [:> Typography {:variant "body2"}
+           (tr :ptv.name-conflict/do-one-of-these)]
+          [:ul {:style {:margin 0}}
+           [:li (tr :ptv.name-conflict/opt1)]
+           [:li (tr :ptv.name-conflict/opt2)]
+           [:li (tr :ptv.name-conflict/opt3)]]
+          [:> Button
+           {:size "small"
+            :variant "outlined"
+            :color "warning"
+            :sx #js {:textTransform "none"}
+            :on-click #(==> [::events/select-service-channels
+                             {:lipas-id (:lipas-id site)}
+                             [(:service-channel-id name-conflict)]])}
+           (tr :ptv.wizard/attach-to-conflicting-service-channel)]])
 
        ;; AI generate + translate buttons
        (let [from-lang @selected-tab

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -516,7 +516,8 @@
        [checkboxes/switch
         {:label (tr :ptv.actions/export-disclaimer)
          :value (:sync-enabled site)
-         :on-change #(==> [::events/toggle-sync-enabled site %])}]
+         ;; Liikuntapaikat tab has no batch "save all" — persist the toggle now.
+         :on-change #(==> [::events/toggle-sync-enabled site % :persist? true])}]
 
        [:> Grid {:container true :spacing 3}
         [:> Grid {:item true :xs 12 :md 5}

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -373,10 +373,12 @@
             [:> Typography {:variant "caption" :color "text.secondary"}
              (str/join " " reasons)])
 
-          ;; Explicit archive — only for a site currently published in PTV.
-          ;; Two-step confirm; reversible by re-enabling sync (resurrects the
-          ;; same channel), so no destructive recreate.
-          (when (and channel-id (= "Published" (:service-channel-publishing-status site)))
+          ;; Explicit archive — only when sync is OFF and the site is currently
+          ;; published in PTV (mirrors the sports-site PTV tab). Two-step confirm;
+          ;; reversible by re-enabling sync (resurrects the same channel).
+          (when (and (not sync-enabled?)
+                     channel-id
+                     (= "Published" (:service-channel-publishing-status site)))
             (if @confirm-archive?
               [:> Stack {:direction "row" :spacing 1 :sx #js {:mt 1 :alignItems "center"}}
                [:> Typography {:variant "caption" :color "text.secondary"}

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -204,7 +204,8 @@
 (defn form-left-column
   [{:keys [org-id tr site services ptv-base org-languages selected-tab]}]
   (r/with-let [editing-services? (r/atom false)
-               editing-channel? (r/atom false)]
+               editing-channel? (r/atom false)
+               confirm-archive? (r/atom false)]
     (let [generating? (<== [::subs/generating-descriptions?])
           syncing? (<== [::subs/syncing-service-location? (:lipas-id site)])
           service-ids (set (:service-ids site))
@@ -370,7 +371,33 @@
                (tr :ptv.wizard/export-service-locations-to-ptv))]]]
           (when (or hint (seq schema-errors))
             [:> Typography {:variant "caption" :color "text.secondary"}
-             (str/join " " reasons)])])])))
+             (str/join " " reasons)])
+
+          ;; Explicit archive — only for a site currently published in PTV.
+          ;; Two-step confirm; reversible by re-enabling sync (resurrects the
+          ;; same channel), so no destructive recreate.
+          (when (and channel-id (= "Published" (:service-channel-publishing-status site)))
+            (if @confirm-archive?
+              [:> Stack {:direction "row" :spacing 1 :sx #js {:mt 1 :alignItems "center"}}
+               [:> Typography {:variant "caption" :color "text.secondary"}
+                (tr :ptv.actions/archive-confirm)]
+               [:> Button {:size "small" :variant "outlined" :color "error"
+                           :disabled syncing?
+                           :sx #js {:textTransform "none"}
+                           :on-click (fn []
+                                       (reset! confirm-archive? false)
+                                       (==> [::events/archive-ptv-service-location (:lipas-id site)]))}
+                (tr :ptv.actions/archive)]
+               [:> Button {:size "small" :variant "text"
+                           :sx #js {:textTransform "none"}
+                           :on-click #(reset! confirm-archive? false)}
+                (tr :actions/cancel)]]
+              [:> Button {:size "small" :variant "text" :color "error"
+                          :disabled syncing?
+                          :sx #js {:textTransform "none" :alignSelf "flex-start"}
+                          :startIcon (r/as-element [:> Icon "archive"])
+                          :on-click #(reset! confirm-archive? true)}
+               (tr :ptv.actions/archive-in-ptv)]))])])))
 
 (defn form-right-column
   [{:keys [org-id tr site org-languages selected-tab]}]

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -328,7 +328,13 @@
              has-service? (seq (:service-ids site))
              has-summary? (some-> site :summary :fi count (> 5))
              has-description? (some-> site :description :fi count (> 5))
-             valid? (and sync-enabled? has-service? has-summary? has-description?)
+             ;; Validate the would-be payload against the same malli schema the
+             ;; backend coerces against, so an over-length text (or other schema
+             ;; violation) is caught here instead of bouncing as a 400.
+             schema-error-keys (<== [::subs/service-location-schema-errors (:lipas-id site)])
+             schema-errors (map tr schema-error-keys)
+             valid? (and sync-enabled? has-service? has-summary? has-description?
+                         (empty? schema-error-keys))
              synced? (:last-sync site)
              modified? (= "Modified" (:service-channel-publishing-status site))
              disabled? (or syncing? modified? (not valid?) (and synced? (not needs-sync?)))
@@ -338,26 +344,33 @@
                     (not has-service?) (tr :ptv/hint-select-service)
                     (not has-summary?) (tr :ptv/hint-add-summary)
                     (not has-description?) (tr :ptv/hint-add-description)
-                    (and synced? (not needs-sync?)) (tr :ptv/hint-up-to-date))]
+                    (and synced? (not needs-sync?)) (tr :ptv/hint-up-to-date))
+             ;; Every reason the button is disabled, for the tooltip.
+             reasons (->> (concat (when hint [hint]) schema-errors)
+                          (remove nil?))]
          [:<>
-          [:> Button
-           {:variant "contained"
-            :color "secondary"
-            :size "small"
-            :full-width true
-            :disabled disabled?
-            :sx #js {:textTransform "none"}
-            :startIcon (r/as-element
-                         (if syncing?
-                           [:> CircularProgress {:size 16 :color "inherit"}]
-                           [:> Icon (if synced? "sync" "ios_share")]))
-            :on-click #(==> [::events/create-ptv-service-location (:lipas-id site) [] []])}
-           (if synced?
-             (tr :ptv.actions/sync-now)
-             (tr :ptv.wizard/export-service-locations-to-ptv))]
-          (when hint
+          [:> Tooltip {:title (if (and disabled? (seq reasons))
+                                (str/join " " reasons)
+                                "")}
+           [:span
+            [:> Button
+             {:variant "contained"
+              :color "secondary"
+              :size "small"
+              :full-width true
+              :disabled disabled?
+              :sx #js {:textTransform "none"}
+              :startIcon (r/as-element
+                           (if syncing?
+                             [:> CircularProgress {:size 16 :color "inherit"}]
+                             [:> Icon (if synced? "sync" "ios_share")]))
+              :on-click #(==> [::events/create-ptv-service-location (:lipas-id site) [] []])}
+             (if synced?
+               (tr :ptv.actions/sync-now)
+               (tr :ptv.wizard/export-service-locations-to-ptv))]]]
+          (when (or hint (seq schema-errors))
             [:> Typography {:variant "caption" :color "text.secondary"}
-             hint])])])))
+             (str/join " " reasons)])])])))
 
 (defn form-right-column
   [{:keys [org-id tr site org-languages selected-tab]}]
@@ -390,6 +403,7 @@
          :on-change #(==> [::events/set-summary site @selected-tab %])
          :label (tr :ptv/summary)
          :value v
+         :inputProps #js {:maxLength ptv-data/max-summary-length}
          :helperText (str (count v) "/" ptv-data/max-summary-length)
          :error (> (count v) ptv-data/max-summary-length)}])
 
@@ -407,6 +421,7 @@
          :on-change #(==> [::events/set-description site @selected-tab %])
          :label (tr :ptv/description)
          :value v
+         :inputProps #js {:maxLength ptv-data/max-description-length}
          :helperText (str (count v) "/" ptv-data/max-description-length)
          :error (> (count v) ptv-data/max-description-length)}])
 
@@ -1148,6 +1163,7 @@
                         :on-change #(==> [::events/set-service-candidate-summary source-id @selected-tab %])
                         :label (tr :ptv/summary)
                         :value summary-val
+                        :inputProps #js {:maxLength ptv-data/max-summary-length}
                         :helperText (str summary-len "/" ptv-data/max-summary-length)
                         :error (> summary-len ptv-data/max-summary-length)}])
 
@@ -1161,6 +1177,7 @@
                         :on-change #(==> [::events/set-service-candidate-description source-id @selected-tab %])
                         :label (tr :ptv/description)
                         :value desc-val
+                        :inputProps #js {:maxLength ptv-data/max-description-length}
                         :helperText (str desc-len "/" ptv-data/max-description-length)
                         :error (> desc-len ptv-data/max-description-length)}])
 
@@ -1174,6 +1191,7 @@
                         :on-change #(==> [::events/set-service-candidate-user-instruction source-id @selected-tab %])
                         :label (tr :ptv/user-instruction)
                         :value ui-val
+                        :inputProps #js {:maxLength ptv-data/max-user-instruction-length}
                         :helperText (str ui-len "/" ptv-data/max-user-instruction-length)
                         :error (> ui-len ptv-data/max-user-instruction-length)}])])
 
@@ -1764,6 +1782,7 @@
          :variant "outlined"
          :label (tr :ptv/summary)
          :value v
+         :inputProps #js {:maxLength ptv-data/max-summary-length}
          :helperText (str (count v) "/" ptv-data/max-summary-length)
          :error (> (count v) ptv-data/max-summary-length)}])
 
@@ -1776,6 +1795,7 @@
          :multiline true
          :label (tr :ptv/description)
          :value v
+         :inputProps #js {:maxLength ptv-data/max-description-length}
          :helperText (str (count v) "/" ptv-data/max-description-length)
          :error (> (count v) ptv-data/max-description-length)}])
 
@@ -1788,6 +1808,7 @@
          :multiline true
          :label (tr :ptv/user-instruction)
          :value v
+         :inputProps #js {:maxLength ptv-data/max-user-instruction-length}
          :helperText (str (count v) "/" ptv-data/max-user-instruction-length)
          :error (> (count v) ptv-data/max-user-instruction-length)}])]))
 

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -211,7 +211,12 @@
           service-ids (set (:service-ids site))
           linked-services (filter #(contains? service-ids (:service-id %)) services)
           channel-id (first (:service-channel-ids site))
-          channel-name (:service-channel-name site)
+          ;; An archived (PTV "Deleted") channel is gone from /list/organization,
+          ;; so its name can't be resolved — label it instead of showing the
+          ;; bare UUID. Its PTV link 404s, so drop it (rendered as plain text).
+          archived? (= "Deleted" (:publishing-status site))
+          channel-name (or (:service-channel-name site)
+                           (when archived? (tr :ptv.actions/service-channel-archived)))
           name-conflict (:name-conflict site)
           double-link-block (<== [::subs/double-link-block (:lipas-id site)])
           sync-status (:sync-status site)
@@ -248,7 +253,8 @@
            :label (str (tr :ptv/service-channel) " PTV:ssä")
            :items [{:id channel-id
                     :name channel-name
-                    :url (str ptv-base "/channels/serviceLocation/" channel-id)}]
+                    :url (when-not archived?
+                           (str ptv-base "/channels/serviceLocation/" channel-id))}]
            :editing? @editing-channel?
            :on-edit #(reset! editing-channel? true)
            :on-cancel #(reset! editing-channel? false)

--- a/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
+++ b/webapp/src/cljs/lipas/ui/sports_sites/views.cljs
@@ -8,6 +8,7 @@
             ["recharts/es6/component/Legend" :refer [Legend]]
             ["recharts/es6/component/ResponsiveContainer" :refer [ResponsiveContainer]]
             ["recharts/es6/component/Tooltip" :refer [Tooltip]]
+            [lipas.data.ptv :as ptv-data]
             [lipas.ui.charts :as charts]
             [lipas.ui.components.buttons :as buttons]
             [lipas.ui.components.checkboxes :as checkboxes]
@@ -1089,7 +1090,15 @@
         [selects/year-selector
          {:label (tr :time/year)
           :value year
-          :on-change #(==> [::events/select-delete-year %])}])]]))
+          :on-change #(==> [::events/select-delete-year %])}])
+
+      ;; If this facility is integrated to PTV, a permanently-out / incorrect-data
+      ;; deletion also archives the PTV service-location. Surface it here, where
+      ;; the user is consciously marking the facility gone.
+      (when (and (contains? #{"out-of-service-permanently" "incorrect-data"} status)
+                 (ptv-data/is-sent-to-ptv? data))
+        [:> Alert {:severity "info" :sx #js {:mt 2}}
+         (tr :ptv/delete-will-archive)])]]))
 
 (defn site-view [{:keys [title on-close close-label bottom-actions lipas-id]}
                  & contents]

--- a/webapp/test/clj/lipas/backend/ptv/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/ptv/handler_test.clj
@@ -660,6 +660,33 @@
                              (tu/token-header token)))]
       (is (= 200 (:status resp))))))
 
+(deftest save-ptv-meta-persists-sync-enabled-test
+  (testing "save-ptv-meta turns sync off in the DB without touching PTV"
+    ;; This is the contract the Liikuntapaikat-tab toggle relies on: turning the
+    ;; switch off persists sync-enabled=false via save-ptv-meta (no sync), and
+    ;; it sticks. The site keeps its channel link (frozen in PTV).
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [pool]} (seed-double-link-scenario! admin)
+          before (core/get-sports-site (test-db) pool)
+          resp (test-app (-> (mock/request :post "/api/actions/save-ptv-meta")
+                             (mock/content-type "application/json")
+                             (mock/body (tu/->json {pool {:org-id ptv-org-id
+                                                          :sync-enabled false
+                                                          :service-ids []
+                                                          :service-channel-ids [pool-channel]
+                                                          :summary {:fi "Test summary"}
+                                                          :description {:fi "Test description"}}}))
+                             (tu/token-header token)))
+          after (core/get-sports-site (test-db) pool)]
+      (is (= 200 (:status resp)))
+      ;; precondition: seeded as sync-enabled
+      (is (true? (get-in before [:ptv :sync-enabled])))
+      ;; persisted off
+      (is (false? (get-in after [:ptv :sync-enabled])))
+      ;; channel link preserved (frozen, not unlinked)
+      (is (= [pool-channel] (get-in after [:ptv :service-channel-ids]))))))
+
 (deftest save-ptv-service-location-rejects-double-link-test
   (testing "Syncing a service-location to a channel another site owns is rejected with 409 (before any PTV call)"
     (let [admin (tu/gen-admin-user :db-component (test-db))

--- a/webapp/test/clj/lipas/backend/ptv/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/ptv/handler_test.clj
@@ -660,32 +660,60 @@
                              (tu/token-header token)))]
       (is (= 200 (:status resp))))))
 
-(deftest save-ptv-meta-persists-sync-enabled-test
-  (testing "save-ptv-meta turns sync off in the DB without touching PTV"
-    ;; This is the contract the Liikuntapaikat-tab toggle relies on: turning the
-    ;; switch off persists sync-enabled=false via save-ptv-meta (no sync), and
-    ;; it sticks. The site keeps its channel link (frozen in PTV).
+(deftest save-ptv-meta-preserves-lifecycle-keys-test
+  (testing "save-ptv-meta turns sync off without wiping server-owned lifecycle keys"
+    ;; Contract the Liikuntapaikat-tab toggle relies on: turning the switch off
+    ;; persists sync-enabled=false via save-ptv-meta (no PTV call) AND keeps the
+    ;; channel link plus the lifecycle keys (:source-id, :publishing-status,
+    ;; :previous-type-code) the sync path owns. A blanket :ptv replace used to
+    ;; wipe those, breaking is-sent-to-ptv? and the reversible-archive flow.
     (let [admin (tu/gen-admin-user :db-component (test-db))
           token (jwt/create-token admin)
-          {:keys [pool]} (seed-double-link-scenario! admin)
-          before (core/get-sports-site (test-db) pool)
+          channel "b0000000-0000-4000-8000-000000000abc"
+          source-id (str "lipas-" ptv-org-id "-700001-2026-01-01T00-00-00.000Z")
+          texts {:summary {:fi "Kesäkäyttöinen urheilukenttä."}
+                 :description {:fi "Limingan keskustan urheilukenttä."}}
+          ;; A published, synced site carrying the full lifecycle meta.
+          site (core/upsert-sports-site!*
+                (test-db) admin
+                {:status "active"
+                 :event-date "2026-01-02T00:00:00.000Z"
+                 :name "Limingan urheilukenttä"
+                 :owner "city" :admin "city-sports"
+                 :type {:type-code 1210}
+                 :location {:city {:city-code 425}
+                            :address "Kentäntie 1" :postal-code "91900" :postal-office "Liminka"
+                            :geometries {:type "FeatureCollection"
+                                         :features [{:type "Feature"
+                                                     :geometry {:type "Point" :coordinates [25.41 64.81]}}]}}
+                 :ptv (merge texts
+                             {:org-id ptv-org-id
+                              :sync-enabled true
+                              :last-sync "2026-01-02T00:00:00.000Z"
+                              :source-id source-id
+                              :publishing-status "Published"
+                              :previous-type-code 1210
+                              :service-ids []
+                              :service-channel-ids [channel]})})
+          lipas-id (:lipas-id site)
           resp (test-app (-> (mock/request :post "/api/actions/save-ptv-meta")
                              (mock/content-type "application/json")
-                             (mock/body (tu/->json {pool {:org-id ptv-org-id
-                                                          :sync-enabled false
-                                                          :service-ids []
-                                                          :service-channel-ids [pool-channel]
-                                                          :summary {:fi "Test summary"}
-                                                          :description {:fi "Test description"}}}))
+                             (mock/body (tu/->json {lipas-id (merge texts
+                                                                    {:org-id ptv-org-id
+                                                                     :sync-enabled false
+                                                                     :service-ids []
+                                                                     :service-channel-ids [channel]})}))
                              (tu/token-header token)))
-          after (core/get-sports-site (test-db) pool)]
+          after (:ptv (core/get-sports-site (test-db) lipas-id))]
       (is (= 200 (:status resp)))
-      ;; precondition: seeded as sync-enabled
-      (is (true? (get-in before [:ptv :sync-enabled])))
-      ;; persisted off
-      (is (false? (get-in after [:ptv :sync-enabled])))
-      ;; channel link preserved (frozen, not unlinked)
-      (is (= [pool-channel] (get-in after [:ptv :service-channel-ids]))))))
+      ;; editable key updated
+      (is (false? (:sync-enabled after)))
+      ;; server-owned lifecycle keys preserved (not wiped)
+      (is (= source-id (:source-id after)))
+      (is (= "Published" (:publishing-status after)))
+      (is (= 1210 (:previous-type-code after)))
+      ;; channel link preserved (frozen in PTV, not unlinked)
+      (is (= [channel] (:service-channel-ids after))))))
 
 (deftest save-ptv-service-location-rejects-double-link-test
   (testing "Syncing a service-location to a channel another site owns is rejected with 409 (before any PTV call)"

--- a/webapp/test/clj/lipas/backend/ptv/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/ptv/handler_test.clj
@@ -493,6 +493,199 @@
       (is (= 403 (:status save-meta-resp))
           "PTV auditor should not be able to save PTV meta data"))))
 
+;;; PTV service-channel double-link detection ;;;
+
+;; Realistic PTV organisation + service-location channel UUIDs (PTV uses UUIDs
+;; for both). Two of the seeded sites share `rink-channel`, which is the
+;; double-link scenario.
+(def ^:private ptv-org-id "7fdd7f84-e52a-4c17-a59a-d7c2a3095ed5")
+(def ^:private rink-channel "a1b2c3d4-0001-4abc-9def-000000000001")
+(def ^:private pool-channel "a1b2c3d4-0002-4abc-9def-000000000002")
+
+(defn- seed-ptv-site!
+  "Seeds a realistic, PTV-synced sports-site bound to `channel-ids`."
+  [user {:keys [name type-code city-code address postal-code postal-office coords channel-ids]}]
+  (core/upsert-sports-site!*
+   (test-db) user
+   {:status "active"
+    :event-date "2025-01-01T00:00:00.000Z"
+    :name name
+    :owner "city"
+    :admin "city-sports"
+    :type {:type-code type-code}
+    :location {:city {:city-code city-code}
+               :address address
+               :postal-code postal-code
+               :postal-office postal-office
+               :geometries {:type "FeatureCollection"
+                            :features [{:type "Feature"
+                                        :geometry {:type "Point"
+                                                   :coordinates coords}}]}}
+    :ptv {:org-id ptv-org-id
+          :sync-enabled true
+          :last-sync "2025-01-02T00:00:00.000Z"
+          :summary {:fi "Kuvaus" :se "Beskrivning" :en "Summary"}
+          :description {:fi "Pidempi kuvaus" :se "Beskrivning" :en "Description"}
+          :service-ids []
+          :service-channel-ids channel-ids}}))
+
+(defn- check-link
+  "Calls the check endpoint as `token` and returns parsed body."
+  [token lipas-id service-channel-id]
+  (-> (test-app (-> (mock/request :post "/api/actions/check-ptv-service-channel-link")
+                    (mock/content-type "application/json")
+                    (mock/body (tu/->json {:lipas-id lipas-id
+                                           :service-channel-id service-channel-id}))
+                    (tu/token-header token)))))
+
+(defn- seed-double-link-scenario!
+  "Seeds Oulunkylän tekojää + Helsingin jäähalli (both on `rink-channel`) and
+  Yrjönkadun uimahalli (on `pool-channel`). Returns their lipas-ids."
+  [user]
+  {:rink-a (:lipas-id (seed-ptv-site! user {:name "Oulunkylän tekojää"
+                                            :type-code 2510 :city-code 91
+                                            :address "Käärmetie 8" :postal-code "00640"
+                                            :postal-office "Helsinki" :coords [24.9612 60.2289]
+                                            :channel-ids [rink-channel]}))
+   :rink-b (:lipas-id (seed-ptv-site! user {:name "Helsingin jäähalli"
+                                            :type-code 2520 :city-code 91
+                                            :address "Nordenskiöldinkatu 11-13" :postal-code "00250"
+                                            :postal-office "Helsinki" :coords [24.9226 60.1872]
+                                            :channel-ids [rink-channel]}))
+   :pool (:lipas-id (seed-ptv-site! user {:name "Yrjönkadun uimahalli"
+                                          :type-code 3110 :city-code 91
+                                          :address "Yrjönkatu 21 b" :postal-code "00100"
+                                          :postal-office "Helsinki" :coords [24.9384 60.1677]
+                                          :channel-ids [pool-channel]}))})
+
+(deftest check-service-channel-link-no-conflict-test
+  (testing "Channel held only by the queried site returns no other sites"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [pool]} (seed-double-link-scenario! admin)
+          resp (check-link token pool pool-channel)
+          body (tu/safe-parse-json resp)]
+      (is (= 200 (:status resp)))
+      (is (= pool-channel (:service-channel-id body)))
+      (is (= [] (:other-sites body))))))
+
+(deftest check-service-channel-link-single-sibling-test
+  (testing "A channel shared with one other site returns that sibling, excluding self"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [rink-a rink-b]} (seed-double-link-scenario! admin)
+          body (tu/safe-parse-json (check-link token rink-a rink-channel))
+          others (:other-sites body)]
+      (is (= 1 (count others)))
+      (is (= rink-b (-> others first :lipas-id)))
+      (is (= "Helsingin jäähalli" (-> others first :name)))
+      ;; self is excluded
+      (is (not (contains? (set (map :lipas-id others)) rink-a))))))
+
+(deftest check-service-channel-link-multiple-siblings-test
+  (testing "A channel shared with several other sites returns all of them"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [rink-a rink-b]} (seed-double-link-scenario! admin)
+          ;; a third site joins the same rink channel
+          rink-c (:lipas-id (seed-ptv-site! admin {:name "Pirkkolan jäähalli"
+                                                   :type-code 2520 :city-code 91
+                                                   :address "Pirkkolan metsätie 4" :postal-code "00630"
+                                                   :postal-office "Helsinki" :coords [24.9046 60.2389]
+                                                   :channel-ids [rink-channel]}))
+          body (tu/safe-parse-json (check-link token rink-a rink-channel))
+          other-ids (set (map :lipas-id (:other-sites body)))]
+      (is (= #{rink-b rink-c} other-ids))
+      (is (not (contains? other-ids rink-a))))))
+
+(deftest check-service-channel-link-unknown-channel-test
+  (testing "An unused channel id returns no sites"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [rink-a]} (seed-double-link-scenario! admin)
+          body (tu/safe-parse-json (check-link token rink-a "ffffffff-ffff-ffff-ffff-ffffffffffff"))]
+      (is (= [] (:other-sites body))))))
+
+(deftest check-service-channel-link-requires-ptv-access-test
+  (testing "Regular users without PTV privileges get 403"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          regular (tu/gen-user {:db? true :db-component (test-db) :admin? false})
+          token (jwt/create-token regular)
+          {:keys [rink-a]} (seed-double-link-scenario! admin)
+          resp (check-link token rink-a rink-channel)]
+      (is (= 403 (:status resp))))))
+
+;;; Double-link enforcement at the persistence boundary ;;;
+
+(deftest save-ptv-meta-rejects-double-link-test
+  (testing "Saving meta that binds a site to a channel another site owns is rejected with 409"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          ;; rink-b already owns rink-channel
+          {:keys [rink-b]} (seed-double-link-scenario! admin)
+          ;; an unrelated site tries to grab the same channel
+          intruder (:lipas-id (seed-ptv-site! admin {:name "Malmin jäähalli"
+                                                     :type-code 2520 :city-code 91
+                                                     :address "Pekanraitti 4" :postal-code "00700"
+                                                     :postal-office "Helsinki" :coords [25.0103 60.2503]
+                                                     :channel-ids []}))
+          resp (test-app (-> (mock/request :post "/api/actions/save-ptv-meta")
+                             (mock/content-type "application/json")
+                             (mock/body (tu/->json {intruder {:org-id ptv-org-id
+                                                              :sync-enabled true
+                                                              :service-ids []
+                                                              :service-channel-ids [rink-channel]
+                                                              :summary {:fi "Test summary"}
+                                                              :description {:fi "Test description"}}}))
+                             (tu/token-header token)))
+          body (tu/safe-parse-json resp)]
+      (is (= 409 (:status resp)))
+      (is (= "double-link" (:type body)))
+      (is (= rink-channel (:service-channel-id body)))
+      (is (contains? (set (map :lipas-id (:other-sites body))) rink-b)))))
+
+(deftest save-ptv-meta-allows-own-channel-test
+  (testing "Re-saving meta for the site that already owns the channel is allowed (self excluded)"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [pool]} (seed-double-link-scenario! admin)
+          resp (test-app (-> (mock/request :post "/api/actions/save-ptv-meta")
+                             (mock/content-type "application/json")
+                             (mock/body (tu/->json {pool {:org-id ptv-org-id
+                                                          :sync-enabled true
+                                                          :service-ids []
+                                                          :service-channel-ids [pool-channel]
+                                                          :summary {:fi "Test summary"}
+                                                          :description {:fi "Test description"}}}))
+                             (tu/token-header token)))]
+      (is (= 200 (:status resp))))))
+
+(deftest save-ptv-service-location-rejects-double-link-test
+  (testing "Syncing a service-location to a channel another site owns is rejected with 409 (before any PTV call)"
+    (let [admin (tu/gen-admin-user :db-component (test-db))
+          token (jwt/create-token admin)
+          {:keys [rink-b]} (seed-double-link-scenario! admin)
+          intruder (:lipas-id (seed-ptv-site! admin {:name "Kontulan jäähalli"
+                                                     :type-code 2520 :city-code 91
+                                                     :address "Kontulankaari 11" :postal-code "00940"
+                                                     :postal-office "Helsinki" :coords [25.0732 60.2419]
+                                                     :channel-ids []}))
+          resp (test-app (-> (mock/request :post "/api/actions/save-ptv-service-location")
+                             (mock/content-type "application/json")
+                             (mock/body (tu/->json {:lipas-id intruder
+                                                    :org-id ptv-org-id
+                                                    :ptv {:org-id ptv-org-id
+                                                          :sync-enabled true
+                                                          :service-ids []
+                                                          :service-channel-ids [rink-channel]
+                                                          :summary {:fi "Test summary"}
+                                                          :description {:fi "Test description"}}}))
+                             (tu/token-header token)))
+          body (tu/safe-parse-json resp)]
+      (is (= 409 (:status resp)))
+      (is (= "double-link" (:type body)))
+      (is (contains? (set (map :lipas-id (:other-sites body))) rink-b)))))
+
 (comment
   (clojure.test/run-tests *ns*)
   (clojure.test/run-test-var #'save-ptv-audit-success-test)

--- a/webapp/test/clj/lipas/backend/ptv_test.clj
+++ b/webapp/test/clj/lipas/backend/ptv_test.clj
@@ -326,6 +326,103 @@
         (is (= stale-put-resp ptv-resp)
             "Refetch failure must fall back to PUT response, not throw")))))
 
+;;; Archiving behaviour ;;;
+
+(defn- sent-ptv [extra]
+  (merge {:org-id "org-x" :source-id "src-1" :service-channel-ids ["chan-1"]
+          :publishing-status "Published" :service-ids [] :sync-enabled true
+          :languages ["fi"] :summary {:fi "summary"} :description {:fi "description"}}
+         extra))
+
+(deftest to-archive?-decision-test
+  (let [sent (fn [status & [ptv-extra]]
+               {:status status :ptv (sent-ptv ptv-extra)})]
+    (testing "Previously-published site is archived only on a genuine removal"
+      (is (true?  (ptv-core/to-archive? (sent "out-of-service-permanently") {}))
+          "status permanently-out archives")
+      (is (true?  (ptv-core/to-archive? (sent "incorrect-data") {}))
+          "status incorrect-data archives")
+      (is (true?  (ptv-core/to-archive? (sent "active") {:delete-existing true}))
+          "explicit :delete-existing archives"))
+    (testing "Edits that previously auto-archived no longer do"
+      (is (false? (ptv-core/to-archive? (sent "active") {}))
+          "plain active save does not archive")
+      (is (false? (ptv-core/to-archive?
+                    {:status "active" :owner "private"
+                     :ptv (sent-ptv nil)} {}))
+          "owner change does not archive")
+      (is (false? (ptv-core/to-archive?
+                    (sent "active" {:summary {:fi ""} :description {:fi ""}}) {}))
+          "blanked texts do not archive a published site"))
+    (testing "Never-published site is never archived"
+      (is (false? (ptv-core/to-archive?
+                    {:status "out-of-service-permanently" :ptv {}} {}))))))
+
+(deftest archive-preserves-ptv-link-test
+  (let [channel-id "chan-1"
+        site {:lipas-id 12345 :name "Arkistoitava" :status "out-of-service-permanently"
+              :type {:type-code 1210}
+              :location {:city {:city-code 425} :address "Katu 1" :postal-code "91900"
+                         :geometries {:type "FeatureCollection"
+                                      :features [{:type "Feature"
+                                                  :geometry {:type "Point" :coordinates [25.0 65.0]}}]}}
+              :search-meta {:location {:wgs84-point [25.0 65.0]}}
+              :ptv (sent-ptv {:delete-existing true})}
+        deleted-resp {:id channel-id :sourceId "src-1" :publishingStatus "Deleted"
+                      :services [] :serviceChannelNames [] :serviceChannelDescriptions []}]
+    (with-redefs [core/enrich identity
+                  ptv-integ/get-org-ptv-config-with-fallback (fn [_ _] {:supported-languages ["fi"]})
+                  ptv-integ/get-org-service-channel (fn [_ _ _] deleted-resp)
+                  ptv-integ/update-service-location (fn [_ _ data] (assoc deleted-resp :publishingStatus (:publishingStatus data)))
+                  ptv-integ/update-service-connections (fn [_ _ _ _] nil)]
+      (let [[ptv-resp new-ptv-data]
+            (ptv-core/upsert-ptv-service-location!*
+              {} {:org-id "org-x" :site site :ptv (:ptv site) :archive? true})]
+        (testing "Archive sends publishingStatus Deleted"
+          (is (= "Deleted" (:publishingStatus ptv-resp))))
+        (testing "LIPAS↔PTV link is preserved (source-id + channel-id kept)"
+          (is (= "src-1" (:source-id new-ptv-data)))
+          (is (= [channel-id] (:service-channel-ids new-ptv-data))))
+        (testing "Stored publishing-status is Deleted (so is-sent-to-ptv? stays false)"
+          (is (= "Deleted" (:publishing-status new-ptv-data)))
+          (is (not (ptv-data/is-sent-to-ptv? {:ptv new-ptv-data}))))
+        (testing "One-shot :delete-existing flag is cleared"
+          (is (not (contains? new-ptv-data :delete-existing))))))))
+
+(deftest resurrect-reuses-channel-test
+  (let [channel-id "chan-1"
+        calls (atom [])
+        site {:lipas-id 12345 :name "Palautettava" :status "active"
+              :type {:type-code 1210}
+              :location {:city {:city-code 425} :address "Katu 1" :postal-code "91900"
+                         :geometries {:type "FeatureCollection"
+                                      :features [{:type "Feature"
+                                                  :geometry {:type "Point" :coordinates [25.0 65.0]}}]}}
+              :search-meta {:location {:wgs84-point [25.0 65.0]}}
+              ;; Previously archived: link kept, status "Deleted".
+              :ptv (sent-ptv {:publishing-status "Deleted"})}
+        published-resp {:id channel-id :sourceId "src-1" :publishingStatus "Published"
+                        :services [] :serviceChannelNames [] :serviceChannelDescriptions []}
+        notfound (ex-info "HTTP Error: 404" {:resp {:status 404}})]
+    (with-redefs [core/enrich identity
+                  ptv-integ/get-org-ptv-config-with-fallback (fn [_ _] {:supported-languages ["fi"]})
+                  ;; Archived channels 404 on every read endpoint.
+                  ptv-integ/get-org-service-channel (fn [_ _ _] (swap! calls conj :get) (throw notfound))
+                  ptv-integ/update-service-location (fn [_ _ data] (swap! calls conj :put) (assoc published-resp :publishingStatus (:publishingStatus data)))
+                  ptv-integ/create-service-location (fn [_ _] (swap! calls conj :create) published-resp)
+                  ptv-integ/update-service-connections (fn [_ _ _ _] nil)]
+      (let [[ptv-resp new-ptv-data]
+            (ptv-core/upsert-ptv-service-location!*
+              {} {:org-id "org-x" :site site :ptv (:ptv site)})]
+        (testing "Re-publishes the SAME channel (PUT), never creates a duplicate"
+          (is (some #{:put} @calls))
+          (is (not (some #{:create} @calls))))
+        (testing "Pre-fetch 404 on the archived channel is tolerated"
+          (is (= "Published" (:publishingStatus ptv-resp))))
+        (testing "Channel-id is retained and status flips back to Published"
+          (is (= [channel-id] (:service-channel-ids new-ptv-data)))
+          (is (= "Published" (:publishing-status new-ptv-data))))))))
+
 (comment
   (t/run-tests *ns*)
   (t/run-test-var #'init-site-ptv))

--- a/webapp/test/clj/lipas/data/ptv_test.cljc
+++ b/webapp/test/clj/lipas/data/ptv_test.cljc
@@ -721,3 +721,25 @@
         (is (= :out-of-date
                (status (assoc-in base [:ptv :service-channel-ids] cleared)))
             (str "cleared as " (pr-str cleared)))))))
+
+(deftest sync-status-archived-resync-test
+  (let [ctx {:org-id "o" :types {} :org-defaults {} :org-langs ["fi"]}
+        status (fn [site] (:sync-status (sut/sports-site->ptv-input ctx {} {} site)))
+        ;; Archived in PTV but still linked, event-date == last-sync (the
+        ;; archive). service-channels {} so the archived channel can't be diffed.
+        base {:lipas-id 1 :name "X" :event-date "T1"
+              :ptv {:last-sync "T1"
+                    :publishing-status "Deleted"
+                    :service-channel-ids ["C1"]
+                    :summary {:fi "aaaaaa"}
+                    :description {:fi "bbbbbb"}}}]
+    (testing "re-enabling an archived site needs a resurrect sync (:out-of-date)"
+      (is (= :out-of-date (status (assoc-in base [:ptv :sync-enabled] true)))))
+
+    (testing "an archived site left disabled is not forced to needs-sync"
+      (is (= :ok (status (assoc-in base [:ptv :sync-enabled] false)))))
+
+    (testing "a published, up-to-date site stays :ok"
+      (is (= :ok (status (-> base
+                             (assoc-in [:ptv :publishing-status] "Published")
+                             (assoc-in [:ptv :sync-enabled] true))))))))

--- a/webapp/test/clj/lipas/data/ptv_test.cljc
+++ b/webapp/test/clj/lipas/data/ptv_test.cljc
@@ -697,3 +697,27 @@
             drift (sut/compute-service-channel-drift site ptv-channel {} ["fi"])]
         (is (seq drift))
         (is (= #{:name} (set (map :field drift))))))))
+
+(deftest sync-status-unlink-test
+  (let [ctx {:org-id "o" :types {} :org-defaults {} :org-langs ["fi"]}
+        status (fn [site] (:sync-status (sut/sports-site->ptv-input ctx {} {} site)))
+        base {:lipas-id 1 :name "X" :event-date "T1"
+              :ptv {:last-sync "T1"
+                    :summary {:fi "aaaaaa"}
+                    :description {:fi "bbbbbb"}}}]
+    (testing "synced, linked and up to date is :ok"
+      (is (= :ok (status (assoc-in base [:ptv :service-channel-ids] ["C1"])))))
+
+    (testing "never-synced (no last-sync) is :not-synced"
+      (is (= :not-synced
+             (status (-> base
+                         (update :ptv dissoc :last-sync)
+                         (assoc-in [:ptv :service-channel-ids] []))))))
+
+    (testing "unlinking a previously-synced site re-activates sync (:out-of-date)"
+      ;; Clearing the single-select autocomplete can leave service-channel-ids
+      ;; as [], [nil] or [""] — all must be detected as a removed link.
+      (doseq [cleared [[] [nil] [""] ["   "]]]
+        (is (= :out-of-date
+               (status (assoc-in base [:ptv :service-channel-ids] cleared)))
+            (str "cleared as " (pr-str cleared)))))))

--- a/webapp/test/clj/lipas/data/ptv_test.cljc
+++ b/webapp/test/clj/lipas/data/ptv_test.cljc
@@ -598,3 +598,102 @@
                                 2 {:pageNumber 2
                                    :pageCount 2
                                    :itemList ["h" "i"]}))))))
+
+(deftest normalize-ws-test
+  (testing "nil / blank / whitespace-only collapse to nil"
+    (is (nil? (sut/normalize-ws nil)))
+    (is (nil? (sut/normalize-ws "")))
+    (is (nil? (sut/normalize-ws "   ")))
+    (is (nil? (sut/normalize-ws "\t \t")))
+    (is (nil? (sut/normalize-ws "\n\n")))
+    (is (nil? (sut/normalize-ws "  \n  \n  "))))
+
+  (testing "plain text is unchanged"
+    (is (= "hello" (sut/normalize-ws "hello")))
+    (is (= "hello world" (sut/normalize-ws "hello world"))))
+
+  (testing "leading/trailing whitespace is trimmed"
+    (is (= "hello" (sut/normalize-ws "  hello  ")))
+    (is (= "hello" (sut/normalize-ws "\t hello \n")))
+    (is (= "a b" (sut/normalize-ws "\n  a b  \n"))))
+
+  (testing "internal horizontal whitespace runs collapse to a single space"
+    ;; This is the PTV double-space-in-name case.
+    (is (= "a b" (sut/normalize-ws "a  b")))
+    (is (= "a b" (sut/normalize-ws "a     b")))
+    (is (= "a b" (sut/normalize-ws "a\tb")))
+    (is (= "a b" (sut/normalize-ws "a\t\tb")))
+    (is (= "a b" (sut/normalize-ws "a \t b")))
+    (is (= "a b c" (sut/normalize-ws "a   b   c"))))
+
+  (testing "line endings are normalized to LF"
+    (is (= "a\nb" (sut/normalize-ws "a\r\nb")))
+    (is (= "a\nb" (sut/normalize-ws "a\rb")))
+    (is (= "a\nb\nc" (sut/normalize-ws "a\r\nb\rc"))))
+
+  (testing "newlines (paragraph structure) are preserved"
+    (is (= "a\nb" (sut/normalize-ws "a\nb")))
+    (is (= "a\n\nb" (sut/normalize-ws "a\n\nb")))
+    ;; horizontal whitespace hugging a newline is dropped, the newline stays
+    (is (= "a\nb" (sut/normalize-ws "a  \n  b")))
+    (is (= "a\nb" (sut/normalize-ws "a\t\n\tb")))
+    (is (= "a\n\nb" (sut/normalize-ws "a \n \n b")))
+    ;; a blank paragraph break survives even with surrounding spaces
+    (is (= "para one\n\npara two" (sut/normalize-ws "para one  \n\n  para two"))))
+
+  (testing "combination: collapse horizontal ws but keep multi-paragraph layout"
+    (is (= "Title here\n\nBody line one\nBody line two"
+           (sut/normalize-ws "  Title   here \r\n\r\n Body  line one\r\nBody\tline two  "))))
+
+  (testing "idempotent"
+    (doseq [s ["a  b" "a \n b" "  x\ty  " "p\r\n\r\nq" "a\n\n\nb"]]
+      (is (= (sut/normalize-ws s)
+             (sut/normalize-ws (sut/normalize-ws s)))
+          (str "idempotent for " (pr-str s)))))
+
+  (testing "the real PTV name case: double space vs PTV-collapsed single space compare equal"
+    (is (= (sut/normalize-ws "Rantakylän stadionalueen  puolikota")
+           (sut/normalize-ws "Rantakylän stadionalueen puolikota")
+           "Rantakylän stadionalueen puolikota"))))
+
+(deftest texts-match?-whitespace-test
+  (testing "texts differing only by collapsible whitespace match"
+    (is (sut/texts-match? {:summary {:fi "a  b"}}
+                          {:summary {:fi "a b"}}
+                          [:summary]))
+    (is (sut/texts-match? {:description {:fi "line1\r\n\r\nline2"}}
+                          {:description {:fi "line1\n\nline2"}}
+                          [:description]))
+    ;; nil vs all-whitespace are treated as equal (both normalize to nil)
+    (is (sut/texts-match? {:summary {:fi nil}}
+                          {:summary {:fi "   "}}
+                          [:summary])))
+  (testing "genuine content differences still don't match"
+    (is (not (sut/texts-match? {:summary {:fi "a b"}}
+                               {:summary {:fi "a c"}}
+                               [:summary])))))
+
+(deftest compute-service-channel-drift-whitespace-test
+  (let [ptv-channel {:serviceChannelNames [{:type "Name" :language "fi" :value "Rantakylä stadion"}]
+                     :serviceChannelDescriptions [{:type "Summary" :language "fi" :value "Tiivistelmä"}
+                                                  {:type "Description" :language "fi" :value "Kuvaus rivi 1\n\nrivi 2"}]
+                     :services []}
+        base-site {:ptv {:summary {:fi "Tiivistelmä"}
+                         :description {:fi "Kuvaus rivi 1\n\nrivi 2"}
+                         :service-ids []}}]
+    (testing "PTV-collapsed whitespace in the name is NOT reported as drift"
+      (let [site (assoc base-site :name "Rantakylä  stadion")] ; double space, PTV stored single
+        (is (empty? (sut/compute-service-channel-drift site ptv-channel {} ["fi"])))))
+
+    (testing "whitespace-only differences in description are NOT drift"
+      (let [site (assoc base-site
+                        :name "Rantakylä stadion"
+                        :ptv (assoc (:ptv base-site)
+                                    :description {:fi "Kuvaus   rivi 1\r\n\r\nrivi 2"}))]
+        (is (empty? (sut/compute-service-channel-drift site ptv-channel {} ["fi"])))))
+
+    (testing "a genuine name change IS still reported as drift"
+      (let [site (assoc base-site :name "Eri nimi")
+            drift (sut/compute-service-channel-drift site ptv-channel {} ["fi"])]
+        (is (seq drift))
+        (is (= #{:name} (set (map :field drift))))))))


### PR DESCRIPTION
  1. f6801dcb — Re-enable sync after unlinking a service-location
  2. d4234a14 — Detect/prevent service-location double-linking (+ API tests)
  3. 3acb383e — Ignore meaningless whitespace in PTV text comparisons
  4. 91c30653 — Fix unlink not re-enabling sync when channel cleared to [nil]
  5. 8dcdd24f — Persist sync-enabled toggle in the Liikuntapaikat tab
  6. 824f3c49 — Harden PTV archive/reactivation lifecycle (meta-save key preservation, archived label, archived-resync)