### PR TITLE
Generate GeoServer SLD styles from canonical LIPAS style data

### DIFF
--- a/webapp/src/clj/lipas/wfs/core.clj
+++ b/webapp/src/clj/lipas/wfs/core.clj
@@ -15,6 +15,7 @@
   standards."
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
+            [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
             [honey.sql :as sql]
@@ -24,6 +25,7 @@
             [lipas.backend.system :as system]
             [lipas.data.types :as types]
             [lipas.wfs.mappings :as mappings]
+            [lipas.wfs.sld :as sld]
             [lipas.utils :as utils]
             [next.jdbc :as jdbc]
             [taoensso.timbre :as log]))
@@ -346,6 +348,101 @@
   (let [url (str (:root-url geoserver-config) "/styles.json")
         response (http/get url (:default-http-opts geoserver-config))]
     (get-in response [:body :styles :style])))
+
+(defn style-exists?
+  "True if a workspace-scoped style with this name exists in GeoServer."
+  [style-name]
+  (let [url (str (:root-url geoserver-config) "/workspaces/"
+                 (:workspace-name geoserver-config) "/styles/" style-name ".json")]
+    (try
+      (http/get url (:default-http-opts geoserver-config))
+      true
+      (catch Exception ex
+        (if (= 404 (:status (ex-data ex)))
+          false
+          (throw ex))))))
+
+(defn publish-style!
+  "Creates or updates a workspace-scoped GeoServer style with the given SLD body.
+
+  Existing layers that reference the named style (e.g. lipas:tyyli_pisteet) pick
+  up the new rules immediately - no layer changes needed. GeoServer validates the
+  SLD on write and rejects malformed documents with a 400.
+
+  - style-name: GeoServer style name, e.g. \"tyyli_pisteet\"
+  - sld-xml:    SLD 1.0.0 document string"
+  [style-name sld-xml]
+  (let [base (str (:root-url geoserver-config) "/workspaces/"
+                  (:workspace-name geoserver-config) "/styles")
+        opts (merge (:default-http-opts geoserver-config)
+                    {:body sld-xml
+                     :content-type "application/vnd.ogc.sld+xml"})]
+    (if (style-exists? style-name)
+      (do (log/info "Updating style" style-name)
+          (http/put (str base "/" style-name) opts))
+      (do (log/info "Creating style" style-name)
+          (http/post (str base "?name=" style-name) opts)))))
+
+(defn publish-all-styles!
+  "Regenerates the three shared named styles (tyyli_pisteet, tyyli_reitit,
+  tyyli_alueet_2) from `lipas.data.styles` and publishes them to GeoServer."
+  []
+  (log/info "Publishing legacy WFS/WMS styles from lipas.data.styles")
+  (doseq [[style-name sld-xml] (sld/all-slds)]
+    (publish-style! style-name sld-xml))
+  (log/info "All styles published."))
+
+(defn get-style-sld
+  "Fetches the current SLD XML body of a workspace-scoped style from GeoServer."
+  [style-name]
+  (let [url  (str (:root-url geoserver-config) "/workspaces/"
+                  (:workspace-name geoserver-config) "/styles/" style-name ".sld")
+        opts (-> (:default-http-opts geoserver-config)
+                 (dissoc :as :accept)
+                 (assoc :headers {"Accept" "application/vnd.ogc.sld+xml"}))]
+    (:body (http/get url opts))))
+
+(defn backup-styles!
+  "Downloads the current SLD of each shared named style (tyyli_pisteet,
+  tyyli_reitit, tyyli_alueet_2) from GeoServer and writes each to a .sld file
+  under a timestamped directory. Run this before overwriting styles with
+  `publish-all-styles!`; the saved files are directly re-publishable via
+  `publish-style!`.
+
+  - dir: target directory (created if missing), defaults to \"/tmp\"
+
+  Returns the seq of written file paths."
+  ([] (backup-styles! "/tmp"))
+  ([dir]
+   (let [ts     (.format (java.time.LocalDateTime/now)
+                         (java.time.format.DateTimeFormatter/ofPattern "yyyyMMdd-HHmmss"))
+         target (io/file dir (str "geoserver-styles-backup-" ts))]
+     (.mkdirs target)
+     (log/info "Backing up GeoServer styles to" (.getPath target))
+     (doall
+      (for [{:keys [style-name]} sld/style-defs]
+        (let [f (io/file target (str style-name ".sld"))]
+          (spit f (get-style-sld style-name))
+          (log/info "Wrote" (.getPath f))
+          (.getPath f)))))))
+
+(comment
+  ;;; Style workflow ;;;
+
+  ;; Back up the live styles before overwriting (writes to /tmp by default).
+  (def backup-paths (backup-styles!))
+
+  ;; Regenerate all three named styles from lipas.data.styles and publish.
+  (publish-all-styles!)
+
+  ;; Rollback: re-publish a saved .sld from a backup directory.
+  (publish-style! "tyyli_pisteet"
+                  (slurp "/tmp/geoserver-styles-backup-20260609-121847/tyyli_pisteet.sld"))
+  ;; ...or roll back everything from a backup dir:
+  (doseq [path backup-paths]
+    (let [style-name (subs (.getName (io/file path)) 0
+                           (- (count (.getName (io/file path))) 4))] ; strip ".sld"
+      (publish-style! style-name (slurp path)))))
 
 (defn publish-layer
   "Publishes a new vector layer from an existing datastore.

--- a/webapp/src/clj/lipas/wfs/sld.clj
+++ b/webapp/src/clj/lipas/wfs/sld.clj
@@ -1,0 +1,211 @@
+(ns lipas.wfs.sld
+  "Generates GeoServer SLD (Styled Layer Descriptor) styles from the canonical
+  LIPAS vector style definitions in `lipas.data.styles`.
+
+  GeoServer publishes the legacy WFS/WMS layers (see `lipas.wfs.core`). Every
+  per-type-code layer of a given geometry references one of three shared,
+  named styles:
+
+    - point layers      -> lipas:tyyli_pisteet
+    - linestring layers -> lipas:tyyli_reitit
+    - polygon layers    -> lipas:tyyli_alueet_2
+
+  Historically these SLDs were hand-rolled and drifted from the webapp colors;
+  newer type codes were missing rules entirely and rendered as nothing in WMS
+  clients. This namespace makes `lipas.data.styles/symbols` the single source
+  of truth: each named style is one SLD document containing one <Rule> per type
+  code, selected by a `tyyppikoodi = <code>` filter.
+
+  Pure generation only — no I/O. Publishing lives in `lipas.wfs.core`."
+  (:require [clojure.string :as str]
+            [lipas.data.styles :as styles]
+            [lipas.data.types :as types]))
+
+;;; Minimal hiccup -> XML emitter ;;;
+;;
+;; SLD is a small, fixed-shape XML document, so a tiny emitter beats pulling in
+;; a dependency. Nodes are `[:ns/Tag {attr val ...} & children]`; children may
+;; be strings (escaped as text), nested nodes, or nil (skipped). Namespaced
+;; keyword tags like :sld/Rule render as `sld:Rule`.
+
+(defn- esc [s]
+  (-> (str s)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")))
+
+(defn- esc-attr [s]
+  (-> (esc s) (str/replace "\"" "&quot;")))
+
+(defn- nm
+  "Renders a tag/attr key. Keywords with a namespace become `ns:name`."
+  [k]
+  (if (keyword? k)
+    (if-let [ns (namespace k)] (str ns ":" (name k)) (name k))
+    (str k)))
+
+(defn emit
+  "Renders a hiccup-like node into an XML string."
+  [node]
+  (cond
+    (nil? node)    ""
+    (string? node) (esc node)
+    (vector? node)
+    (let [[tag & more]      node
+          [attrs children]  (if (map? (first more))
+                              [(first more) (next more)]
+                              [nil more])
+          t                 (nm tag)
+          attr-str          (apply str (for [[k v] attrs]
+                                         (str " " (nm k) "=\"" (esc-attr v) "\"")))
+          kids              (remove nil? children)]
+      (if (seq kids)
+        (str "<" t attr-str ">" (apply str (map emit kids)) "</" t ">")
+        (str "<" t attr-str "/>")))
+    :else (esc node)))
+
+;;; Symbolizers (one per geometry family) ;;;
+
+(defn- point-symbolizer
+  "Point layers (circle/square marks)."
+  [{:keys [shape radius fill stroke]}]
+  [:sld/PointSymbolizer
+   [:sld/Graphic
+    (cond-> [:sld/Mark
+             [:sld/WellKnownName shape]]
+      (:color fill)   (conj [:sld/Fill [:sld/CssParameter {:name "fill"} (:color fill)]])
+      (:color stroke) (conj [:sld/Stroke [:sld/CssParameter {:name "stroke"} (:color stroke)]]))
+    [:sld/Size (str (or radius 9))]]])
+
+(defn- line-symbolizer
+  "Linestring layers (colored, rounded, dashed)."
+  [{:keys [stroke]}]
+  (let [{:keys [color width line-cap line-join line-dash]} stroke]
+    [:sld/LineSymbolizer
+     (cond-> [:sld/Stroke]
+       color            (conj [:sld/CssParameter {:name "stroke"} color])
+       line-cap         (conj [:sld/CssParameter {:name "stroke-linecap"} line-cap])
+       line-join        (conj [:sld/CssParameter {:name "stroke-linejoin"} line-join])
+       width            (conj [:sld/CssParameter {:name "stroke-width"} (str width)])
+       (seq line-dash)  (conj [:sld/CssParameter {:name "stroke-dasharray"}
+                               (str/join " " line-dash)]))]))
+
+(defn- polygon-symbolizer
+  "Polygon layers (filled, thin outline)."
+  [{:keys [fill stroke]}]
+  [:sld/PolygonSymbolizer
+   (when (:color fill)
+     [:sld/Fill [:sld/CssParameter {:name "fill"} (:color fill)]])
+   (cond-> [:sld/Stroke]
+     (:color stroke) (conj [:sld/CssParameter {:name "stroke"} (:color stroke)])
+     (:width stroke) (conj [:sld/CssParameter {:name "stroke-width"} (str (:width stroke))]))])
+
+;;; Rule + document assembly ;;;
+
+(defn- slug
+  "ascii-folds a Finnish type name into a rule-name-friendly token."
+  [s]
+  (when s
+    (-> (str/lower-case s)
+        (str/replace "ä" "a") (str/replace "å" "a") (str/replace "ö" "o")
+        (str/replace #"[^a-z0-9]+" "_")
+        (str/replace #"^_+|_+$" ""))))
+
+(defn- rule-name [type-code]
+  (let [n (slug (get-in types/all [type-code :name :fi]))]
+    (str "lipas_" type-code (when n (str "_" n)))))
+
+(defn- rule [symbolizer-fn type-code sym]
+  [:sld/Rule
+   [:sld/Name (rule-name type-code)]
+   [:ogc/Filter
+    [:ogc/PropertyIsEqualTo
+     [:ogc/PropertyName "tyyppikoodi"]
+     [:ogc/Literal (str type-code)]]]
+   (symbolizer-fn sym)])
+
+(defn ->sld
+  "Builds a complete SLD 1.0.0 document string. `entries` is a seq of
+  [type-code symbol-def] pairs, one <Rule> each."
+  [user-style symbolizer-fn entries]
+  (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+       (emit
+         [:sld/StyledLayerDescriptor
+          {"xmlns:sld" "http://www.opengis.net/sld"
+           "xmlns"     "http://www.opengis.net/sld"
+           "xmlns:gml" "http://www.opengis.net/gml"
+           "xmlns:ogc" "http://www.opengis.net/ogc"
+           "version"   "1.0.0"}
+          [:sld/NamedLayer
+           [:sld/Name (str "lipas:" user-style)]
+           [:sld/UserStyle
+            [:sld/Name (str "lipas:" user-style)]
+            (into [:sld/FeatureTypeStyle [:sld/Name "name"]]
+                  (for [[code sym] entries]
+                    (rule symbolizer-fn code sym)))]]])))
+
+;;; Style definitions ;;;
+
+(def ^:private shape->family
+  {"circle"     :point
+   "square"     :point
+   "linestring" :line
+   "polygon"    :polygon})
+
+(def style-defs
+  "Each shared GeoServer named style and how to build it.
+  :style-name is the GeoServer style; :user-style the internal UserStyle name
+  (kept identical to the historical hand-rolled styles)."
+  [{:style-name "tyyli_pisteet"  :user-style "pisteet" :family :point   :symbolizer point-symbolizer}
+   {:style-name "tyyli_reitit"   :user-style "reitit"  :family :line    :symbolizer line-symbolizer}
+   {:style-name "tyyli_alueet_2" :user-style "alueet"  :family :polygon :symbolizer polygon-symbolizer}])
+
+(defn- entries-for
+  "type-code -> symbol-def pairs for one geometry family, sorted by type code.
+
+  Only emits rules for type codes that exist in `lipas.data.types/all` - this
+  keeps the SLD and its WMS legend matched to the live type catalog. Orphan
+  style entries (codes in styles.cljc with no type definition and no data, e.g.
+  2710, 5155) are dropped."
+  [family]
+  (->> styles/symbols
+       (filter (fn [[code sym]]
+                 (and (contains? types/all code)
+                      (= family (shape->family (:shape sym))))))
+       (sort-by key)))
+
+(defn sld-for
+  "Generates the SLD XML string for one named style (e.g. \"tyyli_pisteet\")."
+  [style-name]
+  (let [{:keys [user-style family symbolizer]}
+        (first (filter #(= style-name (:style-name %)) style-defs))]
+    (->sld user-style symbolizer (entries-for family))))
+
+(defn all-slds
+  "Returns {style-name -> sld-xml} for all three shared named styles."
+  []
+  (into {} (for [{:keys [style-name]} style-defs]
+             [style-name (sld-for style-name)])))
+
+(comment
+  ;; Coverage / sanity checks.
+
+  ;; Type codes present in styles.cljc but missing a geometry-type in types/all
+  ;; (would still get a rule, just an odd one):
+  (->> styles/symbols keys (remove #(get-in types/all [% :geometry-type])))
+
+  ;; Disagreements between the styles.cljc :shape family and the canonical
+  ;; geometry-type in types/all (should be empty):
+  (->> styles/symbols
+       (keep (fn [[code {:keys [shape]}]]
+               (let [fam     (shape->family shape)
+                     geom    (get-in types/all [code :geometry-type])
+                     geom-fam ({"Point" :point "LineString" :line "Polygon" :polygon} geom)]
+                 (when (and geom-fam (not= fam geom-fam))
+                   [code shape geom]))))
+       (into {}))
+
+  ;; Type codes in types/all that have NO style at all (the WMS gap):
+  (->> (keys types/all) (remove (set (keys styles/symbols))) sort)
+
+  (println (sld-for "tyyli_pisteet")))


### PR DESCRIPTION
The legacy WFS/WMS layers reference three shared named styles (tyyli_pisteet, tyyli_reitit, tyyli_alueet_2). These were hand-rolled SLDs that had drifted from the webapp colors and were missing rules for newer type codes, leaving those facilities unrendered in WMS clients.

Add lipas.wfs.sld: a dependency-free generator that builds the three SLD documents from lipas.data.styles/symbols (the single source of truth), one <Rule> per type code, filtered to codes present in lipas.data.types/all so the SLD and its WMS legend match the live type catalog (drops orphan style entries 2710/5155).

Add to lipas.wfs.core: style-exists?, publish-style!, publish-all-styles! (REST upsert of named styles), get-style-sld + backup-styles! (download current styles to disk before overwriting), and a comment block documenting the backup/publish/rollback workflow.