### PR TITLE
Fix flaky dense_vector mapping in legacy ES index

### DIFF
--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -233,9 +233,24 @@
                      {:type "geo_shape"}}}}
    :legacy-sports-site
    {:mappings
-    {:properties
-     {:location.coordinates.wgs84 {:type "geo_point"}
+    {:date_detection false
+     :properties
+     {;; Raw GeoJSON kept in _source for API responses only. Must not be
+      ;; indexed: coordinates are float arrays and ES 8.11+ dynamic mapping
+      ;; guesses arrays of 128+ floats as dense_vector, after which docs
+      ;; with other geometries fail to index. Geo queries use the explicitly
+      ;; mapped fields below instead.
+      :location.geometries        {:type "object" :enabled false}
+      :location.coordinates.wgs84 {:type "geo_point"}
       :location.geom-coll         {:type "geo_shape"}
+      ;; Fields queried by the V1 API. Everything else (legacy camelCase
+      ;; properties etc.) is left to dynamic mapping because V1 search
+      ;; multi_matches against "*".
+      :sportsPlaceId              {:type "long"}
+      :type.typeCode              {:type "integer"}
+      :location.city.cityCode     {:type "integer"}
+      :properties.mayBeShownInExcursionMapFi   {:type "boolean"}
+      :properties.mayBeShownInHarrastuspassiFi {:type "boolean"}
       :lastModified               {:type   "date"
                                    :format legacy-date-format}}}}})
 

--- a/webapp/test/clj/lipas/backend/api/v1/legacy_index_sync_test.clj
+++ b/webapp/test/clj/lipas/backend/api/v1/legacy_index_sync_test.clj
@@ -13,6 +13,8 @@
     [lipas.backend.core :as core]
     [lipas.backend.search :as search]
     [lipas.test-utils :as test-utils]
+    [qbits.spandex :as es]
+    [qbits.spandex.utils :as es-utils]
     [ring.mock.request :as mock]))
 
 ;;; Test system setup ;;;
@@ -238,6 +240,44 @@
       (let [{:keys [status]} (query-legacy-api "/v1/sports-places/2000006")]
         (is (= 404 status)
             "Inactive site should return 404 from legacy API")))))
+
+(deftest long-route-does-not-poison-legacy-mapping-test
+  (testing "a long route indexed first does not break later sites"
+    ;; ES 8.11+ dynamic mapping guesses an all-float array of 128+ elements as
+    ;; dense_vector. A LineString with 200 points flattens to 400 floats, so
+    ;; without the explicit location.geometries mapping the first-indexed
+    ;; route would lock the coordinates field to dense_vector and every
+    ;; following doc with different geometry would fail to index.
+    (let [coords (vec (for [i (range 200)]
+                        [(+ 25.0001 (* i 0.0001))
+                         (+ 60.2001 (* i 0.0001))]))
+          route (test-utils/make-route-site 2000007
+                                            :name "Long Route"
+                                            :type-code 4401
+                                            :segments [coords])
+          point (test-utils/make-point-site 2000008 :name "Point After Route")]
+      (create-site-in-db! route)
+      (save-site! route)
+      (create-site-in-db! point)
+      (save-site! point)
+      (Thread/sleep 200)
+
+      (is (legacy-doc-exists? 2000007)
+          "Long route should exist in legacy index")
+      (is (legacy-doc-exists? 2000008)
+          "Point site indexed after a long route should exist in legacy index")
+
+      (let [{:keys [client indices]} (test-search)
+            idx-name (get-in indices [:legacy-sports-site :search])
+            mapping (-> (es/request client {:method :get
+                                            :url (es-utils/url [idx-name :_mapping])})
+                        :body vals first)
+            geometries (get-in mapping [:mappings :properties :location
+                                        :properties :geometries])]
+        (is (false? (:enabled geometries))
+            "location.geometries must stay un-indexed")
+        (is (nil? (:properties geometries))
+            "No dynamic submappings should appear under location.geometries")))))
 
 (comment
   ;; Run all tests in this namespace


### PR DESCRIPTION
The legacy index relied on dynamic mapping for everything except three fields. The legacy document embeds raw GeoJSON in location.geometries, and ES 8.11+ dynamic mapping guesses an all-float array of 128+ elements as dense_vector. ES flattens nested arrays, so a LineString with 64+ points locks features.geometry.coordinates to dense_vector and every later doc with a different geometry fails to index. With generated test data the outcome depended on indexing order, causing flaky CI.

Disable indexing of location.geometries (display-only, kept in _source; geo queries use location.coordinates.wgs84 and location.geom-coll), turn off date detection, and map the fields the V1 API queries explicitly. Everything else stays dynamic because V1 search multi_matches against "*".

Production note: the new mapping takes effect on the next legacy reindex (search-indexer "legacy").