### PR TITLE
Fix PTV sync rejecting sites that reference an existing service

### DIFF
--- a/webapp/src/clj/lipas/backend/ptv/core.clj
+++ b/webapp/src/clj/lipas/backend/ptv/core.clj
@@ -526,6 +526,32 @@
          (or (contains? removal-statuses (:status sports-site))
              (:delete-existing ptv)))))
 
+(defn- site->missing-services
+  "Services the site's sub-category still needs in PTV before it can sync;
+  a seq of missing services, empty when the site is satisfied.
+
+  A site is satisfied as soon as it references a service (`:ptv
+  :service-ids` non-empty). That deliberately covers all three kinds of
+  service: LIPAS sub-category-managed (`lipas-{org}-{sub-category}`),
+  adopted (`lipas-{org}-ptv-{id}`), and services the org created in PTV
+  directly (no LIPAS sourceId, so absent from `source-id->service`). The
+  presence of a service-id is the durable signal — we do NOT require a
+  `lipas-{org}-{sub-category}` service to exist.
+
+  History: the old call hard-coded `:service-ids #{}` and so only ever
+  recognized sub-category-managed services. That was correct when the BE
+  auto-created missing services (pre-62fb687a), but once creation moved to
+  the FE and adoption was added the check was never reconciled, wrongly
+  rejecting sites that reference an existing PTV service. The input shape
+  here mirrors what the FE feeds `resolve-missing-services` (full sites
+  with `:ptv`), so FE and BE agree on what 'missing' means."
+  [types source-id->service org-id sports-site]
+  (ptv-data/resolve-missing-services
+    org-id source-id->service
+    [{:ptv {:service-ids (-> sports-site :ptv :service-ids)}
+      :sub-category-id (-> sports-site :type :type-code types :sub-category)
+      :sub-category (-> sports-site :search-meta :type :sub-category :name :fi)}]))
+
 ;; Used through resolve due to circular dep
 ;; TODO: Check if code can be moved around to avoid this
 ^{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
@@ -551,15 +577,13 @@
                           source-id->service (->> services
                                                   (utils/index-by :sourceId))
 
-                           ;; Check if services for the current/new site type-code exist
-                          missing-services-input [{:service-ids #{}
-                                                   :sub-category-id (-> sports-site :type :type-code types :sub-category)
-                                                   :sub-cateogry (-> sports-site :search-meta :type :sub-category :name :fi)}]
-                          missing-services (ptv-data/resolve-missing-services org-id source-id->service missing-services-input)
-
-                           ;; FE doesn't update the :ptv :service-ids, that is still handled here.
-                           ;; This code just presumes the user has created the possibly missing Sercices
-                           ;; in the FE first.
+                           ;; Block only sites whose sub-category has NO service
+                           ;; at all. A site that already references a service
+                           ;; (LIPAS-managed, adopted, or created directly in
+                           ;; PTV by the org) is satisfied — see
+                           ;; site->missing-services. The FE is expected to have
+                           ;; created/linked the service first.
+                          missing-services (site->missing-services types source-id->service org-id sports-site)
 
                           _ (when (seq missing-services)
                               (throw (ex-info "Site needs a PTV Service that doesn't exists"

--- a/webapp/test/clj/lipas/backend/ptv/core_test.clj
+++ b/webapp/test/clj/lipas/backend/ptv/core_test.clj
@@ -2,10 +2,48 @@
   (:require [clojure.test :refer [deftest is testing]]
             [lipas.backend.ptv.core :as ptv-core]
             [lipas.backend.ptv.integration :as ptv]
-            [lipas.data.ptv :as ptv-data]))
+            [lipas.data.ptv :as ptv-data]
+            [lipas.data.types]))
 
 (def ^:private strip-blanks #'ptv-core/strip-blank-localized-entries)
 (def ^:private normalize #'ptv-core/normalize-ptv-service-for-update)
+(def ^:private site->missing-services #'ptv-core/site->missing-services)
+
+(deftest site->missing-services-test
+  ;; The sync-ptv! guard throws "Site needs a PTV Service that doesn't
+  ;; exists" iff this returns non-empty. Regression: it used to hard-code
+  ;; :service-ids #{} and so rejected sites that reference a service PTV
+  ;; created directly (no LIPAS sourceId) or an adopted service.
+  (let [org-id "7fdd7f84-e52a-4c17-a59a-d7c2a3095ed5"
+        types lipas.data.types/all
+        ;; type-code 1370 -> sub-category 1300 (Pallokentät)
+        sub-cat-id (-> 1370 types :sub-category)
+        managed-source-id (ptv-data/->service-source-id org-id sub-cat-id)
+        ;; org's services keyed by :sourceId, as get-org-services returns them
+        no-managed-service {}
+        with-managed-service {managed-source-id {:id "managed-svc" :sourceId managed-source-id}}
+        site (fn [service-ids]
+               {:type {:type-code 1370}
+                :ptv {:org-id org-id :service-ids service-ids}})]
+
+    (testing "no service for the sub-category and site references none -> missing"
+      (let [missing (site->missing-services types no-managed-service org-id (site []))]
+        (is (= 1 (count missing)))
+        (is (= managed-source-id (-> missing first :source-id)))
+        (is (= sub-cat-id (-> missing first :sub-category-id)))))
+
+    (testing "site references an existing PTV-created service (no LIPAS sourceId) -> NOT missing"
+      ;; The native service isn't in source-id->service at all, yet the
+      ;; site is satisfied because it already carries a service-id.
+      (is (empty? (site->missing-services types no-managed-service org-id
+                                          (site ["77100eae-native-service"])))))
+
+    (testing "site references an adopted service -> NOT missing"
+      (is (empty? (site->missing-services types no-managed-service org-id
+                                          (site [(str "adopted-" org-id)])))))
+
+    (testing "LIPAS sub-category service exists, site references none yet -> NOT missing"
+      (is (empty? (site->missing-services types with-managed-service org-id (site [])))))))
 
 (deftest strip-blank-localized-entries-test
   (testing "strips blank-valued entries from localized list fields"

--- a/webapp/test/clj/lipas/data/ptv_test.cljc
+++ b/webapp/test/clj/lipas/data/ptv_test.cljc
@@ -743,3 +743,34 @@
       (is (= :ok (status (-> base
                              (assoc-in [:ptv :publishing-status] "Published")
                              (assoc-in [:ptv :sync-enabled] true))))))))
+
+(deftest resolve-missing-services-test
+  ;; Shared by the FE (wizard "missing services" list) and the BE
+  ;; (sync-ptv! guard). A sub-category needs a new service ONLY when the
+  ;; site has no service-id yet AND no LIPAS-managed service exists for it.
+  (let [org-id "org-1"
+        managed-source-id (sut/->service-source-id org-id 2100)
+        ;; services keyed by :sourceId (as get-org-services / app-db hold them).
+        ;; A service the org created in PTV directly has :sourceId nil.
+        services {managed-source-id {:id "managed" :sourceId managed-source-id}
+                  "native" {:id "native" :sourceId nil}}
+        site (fn [service-ids] {:ptv {:service-ids service-ids}
+                                :sub-category-id 2100
+                                :sub-category "Kuntoilukeskukset ja liikuntasalit"})]
+
+    (testing "site with no service-ids and no managed service -> reported missing"
+      (is (= [{:source-id managed-source-id
+               :sub-category "Kuntoilukeskukset ja liikuntasalit"
+               :sub-category-id 2100}]
+             (sut/resolve-missing-services org-id {} [(site [])]))))
+
+    (testing "site already referencing a service is never missing (origin-agnostic)"
+      ;; native (no LIPAS sourceId), managed, or any id all count as satisfied.
+      (is (empty? (sut/resolve-missing-services org-id services [(site ["native"])])))
+      (is (empty? (sut/resolve-missing-services org-id {} [(site ["any-existing-id"])]))))
+
+    (testing "managed service exists -> not missing even with no service-id on the site yet"
+      (is (empty? (sut/resolve-missing-services org-id services [(site [])]))))
+
+    (testing "dedups and only reports genuinely missing sub-categories"
+      (is (empty? (sut/resolve-missing-services org-id services [(site []) (site [])]))))))


### PR DESCRIPTION
sync-ptv! threw "Site needs a PTV Service that doesn't exists" for any site whose sub-category lacked a LIPAS sub-category-managed service (sourceId lipas-{org}-{sub-category}), even when the site already referenced a perfectly valid PTV service — one the org created directly in PTV (no LIPAS sourceId) or one adopted via lipas-{org}-ptv-{id}.

Root cause is a stale check, not intent. The missing-services input was introduced (7c9766c7) to drive backend AUTO-CREATION of missing services, where hard-coding :service-ids #{} and matching only the sub-category sourceId was correct. When creation moved to the FE and the reduce was replaced by a throw (62fb687a), and later when service adoption was added (ba552c37, viikko 13), this guard was never reconciled. The FE's own resolve-missing-services call already passes full sites with their real :service-ids; only the backend fed the synthetic empty set.

Extract site->missing-services, which feeds resolve-missing-services the site's actual :ptv :service-ids (nested as the fn expects), so a site that already references a service is satisfied regardless of the service's origin. A site with genuinely no service for its sub-category is still blocked. Everything downstream (->ptv-service-location :services, update-service-connections, drift detection) already handled raw service-ids, so this is the only change required. Also drops the :sub-cateogry typo that surfaced :sub-category nil in the error ex-data.

Tests:
- core-test/site->missing-services-test pins the fix locus (native and adopted services count as satisfied; empty sub-category still missing).
- ptv-test/resolve-missing-services-test pins the shared FE/BE contract.