### PR TITLE
Diacritic-insensitive search + locale-correct name sorting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -345,7 +345,12 @@ services:
       - ./db:/docker-entrypoint-initdb.d:z
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.9
+    # Stock Elasticsearch + analysis-icu plugin (locale-correct name sorting).
+    # See elasticsearch/Dockerfile. Rebuild with: docker compose build elasticsearch
+    build:
+      context: ./elasticsearch
+      dockerfile: Dockerfile
+    image: lipas/elasticsearch:8.19.9-icu
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
       interval: 30s

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,17 @@
+# LIPAS Elasticsearch image.
+#
+# Extends the stock Elasticsearch image with the analysis-icu plugin, which
+# provides:
+#   - icu_collation_keyword: locale-correct (Finnish/Swedish/English) sort order
+#     for facility names, so accented letters (ä, ö, á, č, ...) sort in the
+#     order users expect rather than by raw Unicode code point.
+#
+# Diacritic-insensitive *search* (e.g. "Njalla" matching "Njálla") is handled
+# by the built-in asciifolding token filter and does not require this plugin.
+#
+# Keep the base version in sync with the `elasticsearch` service in
+# docker-compose.yml. After bumping it, rebuild the image:
+#   docker compose build elasticsearch
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.19.9
+
+RUN bin/elasticsearch-plugin install --batch analysis-icu

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -23,6 +23,43 @@
   [client]
   (es/close! client))
 
+;; Index analysis settings
+;;
+;; `folding-analysis` makes free-text search diacritic-insensitive: the custom
+;; `default` analyzer overrides the standard analyzer for every text field at
+;; both index- and search-time, so e.g. "Njalla" matches "Njálla" and
+;; "thorsteinn" matches "Þorsteinn". `asciifolding` is a Lucene core filter — no
+;; plugin required. It covers á→a, č→c, đ→d, Þ→th, etc.
+;;
+;; The `eng` char_filter handles the one case asciifolding gets "wrong" for our
+;; users: the Sami eng ŋ folds to "n" by default, but users type "ng"
+;; (Deatŋu → "deatngu"). The mapping runs before tokenization/folding.
+(def folding-analysis
+  {:char_filter
+   {:eng {:type "mapping" :mappings ["ŋ => ng" "Ŋ => NG"]}}
+   :analyzer
+   {:default
+    {:type        "custom"
+     :char_filter ["eng"]
+     :tokenizer   "standard"
+     :filter      ["lowercase" "asciifolding"]}}})
+
+(defn- collation-field
+  "An `icu_collation_keyword` sub-field for locale-correct sorting. Unlike a
+  plain keyword (raw Unicode code-point order, where 'Ä' sorts after 'Z') this
+  sorts accented letters in the given locale's collation order. Requires the
+  analysis-icu plugin (see elasticsearch/Dockerfile)."
+  [language]
+  {:type "icu_collation_keyword" :language language})
+
+(defn- text-with-sort
+  "Text field with a `keyword` sub-field (exact match / aggregations) plus a
+  `sort` sub-field collated for `language`, used by the UI for name sorting."
+  [language]
+  {:type   "text"
+   :fields {:keyword {:type "keyword"}
+            :sort    (collation-field language)}})
+
 ;; Helper functions for generating explicit ES mappings from prop-types
 
 (defn- prop-type->es-mapping
@@ -90,26 +127,29 @@
         ;; Name fields use text for case-insensitive search + keyword subfield for sorting
         text-with-keyword {:type "text" :fields {:keyword {:type "keyword"}}}
 
+        ;; Name fields the UI offers as sort columns get an icu_collation_keyword
+        ;; `sort` sub-field (see text-with-sort). LIPAS locale `se` is Swedish,
+        ;; hence the "sv" ICU collation.
         search-meta-fields
-        {:search-meta.name text-with-keyword
-         :search-meta.admin.name.fi text-with-keyword
-         :search-meta.admin.name.se text-with-keyword
-         :search-meta.admin.name.en text-with-keyword
-         :search-meta.owner.name.fi text-with-keyword
-         :search-meta.owner.name.se text-with-keyword
-         :search-meta.owner.name.en text-with-keyword
-         :search-meta.location.city.name.fi text-with-keyword
-         :search-meta.location.city.name.se text-with-keyword
-         :search-meta.location.city.name.en text-with-keyword
+        {:search-meta.name (text-with-sort "fi")
+         :search-meta.admin.name.fi (text-with-sort "fi")
+         :search-meta.admin.name.se (text-with-sort "sv")
+         :search-meta.admin.name.en (text-with-sort "en")
+         :search-meta.owner.name.fi (text-with-sort "fi")
+         :search-meta.owner.name.se (text-with-sort "sv")
+         :search-meta.owner.name.en (text-with-sort "en")
+         :search-meta.location.city.name.fi (text-with-sort "fi")
+         :search-meta.location.city.name.se (text-with-sort "sv")
+         :search-meta.location.city.name.en (text-with-sort "en")
          :search-meta.location.province.name.fi text-with-keyword
          :search-meta.location.province.name.se text-with-keyword
          :search-meta.location.province.name.en text-with-keyword
          :search-meta.location.avi-area.name.fi text-with-keyword
          :search-meta.location.avi-area.name.se text-with-keyword
          :search-meta.location.avi-area.name.en text-with-keyword
-         :search-meta.type.name.fi text-with-keyword
-         :search-meta.type.name.se text-with-keyword
-         :search-meta.type.name.en text-with-keyword
+         :search-meta.type.name.fi (text-with-sort "fi")
+         :search-meta.type.name.se (text-with-sort "sv")
+         :search-meta.type.name.en (text-with-sort "en")
          ;; Tags are multilingual arrays - keep as keyword for exact matching
          :search-meta.type.tags.fi {:type "keyword"}
          :search-meta.type.tags.se {:type "keyword"}
@@ -200,7 +240,8 @@
 
     {:settings
      {:max_result_window 60000
-      :index {:mapping {:total_fields {:limit total-fields-limit}}}}
+      :index {:mapping   {:total_fields {:limit total-fields-limit}}
+              :analysis  folding-analysis}}
      :mappings
      {:dynamic "strict"
       :date_detection false
@@ -229,7 +270,8 @@
   {:sports-site   (generate-explicit-mapping)
    :analytics     (generate-analytics-mapping)
    :lois          {:settings
-                   {:max_result_window 50000}
+                   {:max_result_window 50000
+                    :index {:analysis folding-analysis}}
                    :mappings
                    {:date_detection false
                     :properties

--- a/webapp/src/cljs/lipas/ui/search/events.cljs
+++ b/webapp/src/cljs/lipas/ui/search/events.cljs
@@ -14,15 +14,18 @@
   (update-in m [:query :function_score :query :bool :filter] conj filter))
 
 (defn ->sort-key [k locale]
+  ;; Name fields sort on the `.sort` sub-field (icu_collation_keyword), which
+  ;; orders accented letters in the locale's collation order instead of raw
+  ;; Unicode code-point order. See lipas.backend.search/text-with-sort.
   (case k
     (:lipas-id) :lipas-id
-    (:name) :search-meta.name.keyword
+    (:name) :search-meta.name.sort
     (:location.city.name
      :type.name
      :admin.name
      :owner.name) (-> k name
                       (->> (str "search-meta."))
-                      (str "." (name locale) ".keyword")
+                      (str "." (name locale) ".sort")
                       keyword)
     (:event-date
      :construction-year

--- a/webapp/test/clj/lipas/backend/search_folding_test.clj
+++ b/webapp/test/clj/lipas/backend/search_folding_test.clj
@@ -1,0 +1,103 @@
+(ns lipas.backend.search-folding-test
+  "Integration tests for diacritic-insensitive search and locale-correct name
+   sorting. Exercises the real /api/actions/search path against Elasticsearch,
+   so the test ES instance must have the analysis-icu plugin (collation sort)
+   and a freshly created index carrying the folding analyzer + collation
+   sub-fields from lipas.backend.search/mappings.
+
+   NOTE: locally, run `(lipas.test-utils/reset-test-infra! search)` after pulling
+   these mapping changes - prune-es! empties docs but does not re-map an existing
+   index, so the new analyzer/collation only appears on a recreated index. CI
+   always starts fresh."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [lipas.backend.core :as core]
+            [lipas.test-utils :refer [<-json ->json] :as tu]
+            [ring.mock.request :as mock]))
+
+(defonce test-system (atom nil))
+
+(let [{:keys [once each]} (tu/full-system-fixture test-system)]
+  (use-fixtures :once once)
+  (use-fixtures :each each))
+
+(defn test-search [] (:lipas/search @test-system))
+(defn test-app [req] ((:lipas/app @test-system) req))
+
+(defn- index-named-sites!
+  "Indexes one active point site per name, returns the names indexed."
+  [names]
+  (doseq [[i name] (map-indexed vector names)]
+    (core/index! (test-search)
+                 (tu/make-point-site (+ 970000 i) :name name)
+                 :sync))
+  names)
+
+(defn- search-names
+  "Runs the production-shaped query (simple_query_string + trailing wildcard,
+   analyze_wildcard) and returns the set of result names."
+  [query]
+  (let [body {:size 50
+              :_source ["name"]
+              :query {:simple_query_string
+                      {:query (str query "*")
+                       :fields ["name" "search-meta.name"]
+                       :default_operator "AND"
+                       :analyze_wildcard true}}}
+        resp (test-app (-> (mock/request :post "/api/actions/search")
+                           (mock/content-type "application/json")
+                           (mock/body (->json body))))]
+    (->> resp :body <-json :hits :hits (map (comp :name :_source)) set)))
+
+(deftest diacritic-insensitive-search-test
+  ;; Each [indexed-name ascii-query] pair: typing the accent-free query must
+  ;; find the accented facility. Mirrors the bug report's examples.
+  (let [cases [["Njálla-halli"  "Njalla"]      ; á -> a
+               ["Deatŋu-halli"  "Deatngu"]     ; ŋ -> ng (Sami eng)
+               ["Þorsteinn-talli" "Thorsteinn"] ; Þ -> th (Icelandic horse stable)
+               ["Čáhci-areena"  "Cahci"]       ; č -> c, á -> a
+               ["Iđut-kenttä"   "Idut"]]       ; đ -> d
+        control "Helsinki Areena"]
+    (index-named-sites! (conj (mapv first cases) control))
+
+    (doseq [[indexed-name query] cases]
+      (testing (str "'" query "' finds '" indexed-name "'")
+        (is (contains? (search-names query) indexed-name))))
+
+    (testing "symmetry: an accented query finds an accent-free name"
+      (index-named-sites! ["Njalla-rinne"])
+      (is (contains? (search-names "Njálla") "Njalla-rinne")))
+
+    (testing "negative control: unrelated facility is not matched"
+      (is (not (contains? (search-names "Njalla") control))))))
+
+(defn- sorted-names
+  "Returns result names sorted by the collation sort sub-field in `order`."
+  [order]
+  (let [body {:size 50
+              :_source ["name"]
+              :sort [{:search-meta.name.sort {:order order}}]
+              :query {:simple_query_string {:query "Lajittelu*"
+                                            :fields ["name"]
+                                            :analyze_wildcard true}}}
+        resp (test-app (-> (mock/request :post "/api/actions/search")
+                           (mock/content-type "application/json")
+                           (mock/body (->json body))))]
+    (->> resp :body <-json :hits :hits (mapv (comp :name :_source)))))
+
+(deftest locale-correct-name-sort-test
+  ;; Finnish collation orders å, ä, ö after z (and å before ä). Raw code-point
+  ;; order gets å/ä wrong: ä (U+00E4) sorts before å (U+00E5). This asserts the
+  ;; icu_collation_keyword sort sub-field produces Finnish order. All names share
+  ;; the "Lajittelu" prefix purely to isolate them from any other indexed sites.
+  (index-named-sites! ["Lajittelu Aho"
+                       "Lajittelu Åke"
+                       "Lajittelu Äänekoski"
+                       "Lajittelu Östersundom"])
+  (let [expected ["Lajittelu Aho"        ; a
+                  "Lajittelu Åke"         ; å  (before ä - the case raw order breaks)
+                  "Lajittelu Äänekoski"   ; ä
+                  "Lajittelu Östersundom"]] ; ö
+    (testing "ascending is Finnish collation order"
+      (is (= expected (sorted-names "asc"))))
+    (testing "descending is the reverse"
+      (is (= (reverse expected) (sorted-names "desc"))))))

--- a/webapp/test/clj/lipas/backend/search_mapping_test.clj
+++ b/webapp/test/clj/lipas/backend/search_mapping_test.clj
@@ -104,3 +104,43 @@
 
       (is (false? (:enabled (get properties :location.geometries))))
       (is (false? (:enabled (get properties :search-meta.location.simple-geoms)))))))
+
+(deftest folding-analysis-test
+  (testing "sports-site index has a diacritic-folding default analyzer"
+    (let [analyzer (get-in (:sports-site search/mappings)
+                           [:settings :index :analysis :analyzer :default])]
+      (is (= "custom" (:type analyzer)))
+      (is (some #{"asciifolding"} (:filter analyzer))
+          "asciifolding filter makes search diacritic-insensitive")
+      (is (some #{"lowercase"} (:filter analyzer)))))
+
+  (testing "analytics index inherits the folding analyzer"
+    (is (some #{"asciifolding"}
+              (get-in (:analytics search/mappings)
+                      [:settings :index :analysis :analyzer :default :filter]))))
+
+  (testing "lois index has the folding analyzer"
+    (is (some #{"asciifolding"}
+              (get-in (:lois search/mappings)
+                      [:settings :index :analysis :analyzer :default :filter])))))
+
+(deftest collation-sort-fields-test
+  (testing "sortable name fields have an icu_collation_keyword sort sub-field"
+    (let [properties (get-in (:sports-site search/mappings) [:mappings :properties])
+          ;; field -> expected ICU collation language
+          expected {:search-meta.name "fi"
+                    :search-meta.location.city.name.fi "fi"
+                    :search-meta.location.city.name.se "sv"
+                    :search-meta.location.city.name.en "en"
+                    :search-meta.type.name.fi "fi"
+                    :search-meta.type.name.se "sv"
+                    :search-meta.admin.name.fi "fi"
+                    :search-meta.owner.name.se "sv"}]
+      (doseq [[field lang] expected]
+        (let [sort-field (get-in properties [field :fields :sort])]
+          (is (= "icu_collation_keyword" (:type sort-field))
+              (str field " should have a collation sort sub-field"))
+          (is (= lang (:language sort-field))
+              (str field " should collate in " lang))
+          ;; keep the plain keyword sub-field for exact match / aggregations
+          (is (= "keyword" (get-in properties [field :fields :keyword :type]))))))))


### PR DESCRIPTION
## Problem

Facility search required typing the exact accented characters present in a name. Sports facilities in the Sámi region and Icelandic-horse stables therefore couldn't be found unless the user produced characters not on a normal keyboard — e.g. searching `Njalla` returned nothing for **Njálla-halli**.

From the report, the characters that need to be reachable from their plain forms:

| In the data | Typed as |
|---|---|
| `á` (and other accented vowels) | `a` |
| `ŋ` | `ng` |
| `č` | `c` |
| `đ` | `d` |
| `Þ` / `þ` | `th` |

…and the same for uppercase.

## Solution

Make Elasticsearch text analysis **diacritic-insensitive** at both index- and query-time, and — since accents now collapse for matching — make name **sorting** locale-aware so accented names still order correctly.

### Diacritic-insensitive search
- A custom `default` analyzer (`lowercase` + `asciifolding`) overrides the standard analyzer for every text field. Because the same folding runs at index- and query-time, this fixes **every** query path (the UI `simple_query_string` and the V1 API `multi_match`) with **no query-code changes**.
- `asciifolding` covers `á→a`, `č→c`, `đ→d`, `Þ→th`, etc. The one exception is the Sámi eng: plain `asciifolding` folds `ŋ→n`, but users type `ng`, so a small `mapping` char_filter (`ŋ ⇒ ng`, `Ŋ ⇒ NG`) runs first.
- Applied to the `sports-site` and `lois` indices; `analytics` inherits it.

### Locale-correct sort
- The name fields the UI offers as sort columns get an `icu_collation_keyword` `sort` sub-field, collated per locale (`fi` / `sv` / `en`). This sorts accented letters in collation order (e.g. Finnish `å` < `ä` < `ö`, all after `z`) instead of raw Unicode code-point order, which gets `å`/`ä` wrong. `->sort-key` now points at the `.sort` sub-field.
- Collation only affects sort order, never matching — so the `fi/sv/en` scope has zero impact on searchability. Sámi/Icelandic letters simply alphabetize by Finnish rules (still a strict improvement over the old code-point order).

### Infrastructure
- `icu_collation_keyword` needs the `analysis-icu` plugin, which isn't in the stock image, so the `elasticsearch` service now builds from `elasticsearch/Dockerfile` (stock 8.19.9 + plugin). The same compose file is used in dev and prod.

## Testing

- Mapping unit tests assert the analyzer + collation sub-fields are present (and that org-mgmt fields are unaffected).
- Integration tests against a real ICU-enabled ES cover each report example (`á/ŋ/Þ/č/đ`), reverse-direction symmetry, a negative control, and Finnish collation order (asc/desc) on the `å`-before-`ä` case.
- Verified end-to-end on a full local reindex (57k sites): `Njalla` now returns `Njálla-halli` & co.

**`bb test-ns lipas.backend.search-mapping-test lipas.backend.search-folding-test` → 5 tests, 250 assertions, 0 failures.**

## ⚠️ Deployment steps (not automatic)

The analyzer/collation only take effect after the ES image is rebuilt and the index is reindexed:

```bash
docker compose build elasticsearch          # ICU plugin image
docker compose up -d elasticsearch          # recreate (esdata volume persists)
docker compose run --rm backend-index-search             # reindex search (new mapping + alias swap)
docker compose run --rm backend-index-search --analytics # reindex analytics
```

Caveat: the reindex swaps the `sports_sites_current` **alias** — if that name is a concrete index rather than an alias, drop it first or the swap fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
