### PR TITLE
Sweep stale ES indices by name pattern on re-index

### DIFF
--- a/webapp/src/clj/lipas/backend/analysis/common.clj
+++ b/webapp/src/clj/lipas/backend/analysis/common.clj
@@ -98,9 +98,10 @@
       (dissoc :WKT)))
 
 (defn *seed-population-grid-from-csv!
-  [{:keys [client]} csv-path idx-name idx-alias batch-size]
+  [{:keys [client]} csv-path idx-name idx-alias batch-size prefix]
   (assert idx-name "Index name is required")
   (assert batch-size "Batch size is required")
+  (assert prefix "Index prefix is required")
 
   (with-open [rdr (io/reader csv-path)]
     (log/info "Creating index" idx-name)
@@ -121,18 +122,28 @@
   (log/info "Swapping alias" idx-alias "to point to" idx-name)
   (search/swap-alias! client {:new-idx idx-name :alias idx-alias})
 
+  ;; Reclaim the previous grid index (and any orphans from failed runs),
+  ;; guarding each delete so a single failure can't strand the rest.
+  (let [{:keys [deleted failed]} (search/delete-stale-indices! client prefix idx-name)]
+    (doseq [idx deleted]
+      (log/info "Deleted stale index" idx))
+    (when (seq failed)
+      (log/error "Failed to delete stale indices" failed)))
+
   (log/info "All done!"))
 
 (defn seed-population-1km-grid-from-csv!
   [{:keys [indices] :as search} csv-path]
-  (let [idx-name   (str "population-1km-" (search/gen-idx-name))
+  (let [prefix     "population-1km"
+        idx-name   (str prefix "-" (search/gen-idx-name))
         idx-alias  (get-in indices [:analysis :population])
         batch-size 100]
-    (*seed-population-grid-from-csv! search csv-path idx-name idx-alias batch-size)))
+    (*seed-population-grid-from-csv! search csv-path idx-name idx-alias batch-size prefix)))
 
 (defn seed-population-250m-grid-from-csv!
   [{:keys [indices] :as search} csv-path]
-  (let [idx-name   (str "population-250m-" (search/gen-idx-name))
+  (let [prefix     "population-250m"
+        idx-name   (str prefix "-" (search/gen-idx-name))
         idx-alias  (get-in indices [:analysis :population-high-def])
         batch-size 1000]
-    (*seed-population-grid-from-csv! search csv-path idx-name idx-alias batch-size)))
+    (*seed-population-grid-from-csv! search csv-path idx-name idx-alias batch-size prefix)))

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -376,6 +376,35 @@
                         :body   {:actions actions}})
     old-idxs))
 
+(defn indices-matching
+  "Returns a set of index names (strings) matching the pattern `<prefix>-*`.
+  Returns #{} when nothing matches or the request fails."
+  [client prefix]
+  (let [res (es/request client {:method            :get
+                                :url               (es-utils/url [(str prefix "-*") "_alias"])
+                                :exception-handler (constantly nil)})]
+    (into #{} (map name) (keys (:body res)))))
+
+(defn delete-stale-indices!
+  "Deletes every `<prefix>-*` index except `keep-idx`.
+
+  Unlike deleting only the index the alias previously pointed to, this reclaims
+  orphans left behind by earlier runs that failed after the alias swap (an
+  orphaned index is no longer on the alias, so nothing else would ever delete
+  it). Each delete is guarded so a single failure can't strand the rest of the
+  sweep or abort the surrounding re-index.
+
+  Returns `{:deleted [...] :failed [...]}` with the index names in each outcome."
+  [client prefix keep-idx]
+  (reduce (fn [acc idx]
+            (try
+              (delete-index! client idx)
+              (update acc :deleted conj idx)
+              (catch Exception _e
+                (update acc :failed conj idx))))
+          {:deleted [] :failed []}
+          (disj (indices-matching client prefix) keep-idx)))
+
 (defn create-alias!
   [client {:keys [alias idx-name]}]
   (es/request client {:method :post

--- a/webapp/src/clj/lipas/search_indexer.clj
+++ b/webapp/src/clj/lipas/search_indexer.clj
@@ -254,10 +254,16 @@
 
      (log/info "Indexing data done!")
      (log/info "Swapping alias" alias "to point to index" idx-name)
-     (let [old-idxs (search/swap-alias! client {:new-idx idx-name :alias alias})]
-       (doseq [idx old-idxs]
-         (log/info "Deleting old index" idx)
-         (search/delete-index! client idx)))
+     (search/swap-alias! client {:new-idx idx-name :alias alias})
+     ;; Delete every stale index for this mode, not just the one the alias
+     ;; previously pointed to. This also reclaims orphans left by earlier runs
+     ;; that failed after the alias swap. Deletes are guarded individually so a
+     ;; single failure can't strand the rest.
+     (let [{:keys [deleted failed]} (search/delete-stale-indices! client mode idx-name)]
+       (doseq [idx deleted]
+         (log/info "Deleted stale index" idx))
+       (when (seq failed)
+         (log/error "Failed to delete stale indices" failed)))
      (log/info "All done!"))))
 
 (defn -main [& args]

--- a/webapp/test/clj/lipas/backend/search_index_lifecycle_test.clj
+++ b/webapp/test/clj/lipas/backend/search_index_lifecycle_test.clj
@@ -1,0 +1,73 @@
+(ns lipas.backend.search-index-lifecycle-test
+  "Integration tests for the index-lifecycle helpers used when re-indexing
+  Elasticsearch. These run against the real (local/CI) ES cluster but need no
+  database, so they build a bare client from the test config."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [lipas.backend.search :as search]
+   [lipas.test-utils :as tu]))
+
+;; Prefix used for the throwaway indices this ns creates. Deliberately unique so
+;; the pattern-based sweep can never touch real indices.
+(def ^:private prefix "zzsweep-test")
+(def ^:private alias-name "zzsweep-current") ; NB: does not match `<prefix>-*`
+
+(def ^:private ^:dynamic *client* nil)
+
+(defn- mk [suffix] (str prefix "-" suffix))
+
+(defn- create! [suffix]
+  (search/create-index! *client* (mk suffix) {:mappings {:dynamic false}}))
+
+(defn- cleanup! [client]
+  ;; Deleting the indices also removes their aliases, so `alias-name` needs no
+  ;; separate teardown.
+  (doseq [idx (search/indices-matching client prefix)]
+    (try (search/delete-index! client idx) (catch Exception _ nil))))
+
+(defn- with-fresh-es [f]
+  (binding [*client* (search/create-cli
+                      (let [{:keys [hosts user pass]} (:search tu/config)]
+                        {:hosts hosts :user user :password pass}))]
+    (cleanup! *client*)          ; guard against leftovers from a crashed run
+    (try (f)
+         (finally (cleanup! *client*)))))
+
+(use-fixtures :each with-fresh-es)
+
+(deftest indices-matching-test
+  (testing "returns #{} when no index matches the prefix"
+    (is (= #{} (search/indices-matching *client* "zzsweep-does-not-exist"))))
+
+  (testing "lists every matching index as a string, alias or not"
+    (create! "cur")
+    (create! "orphan-1")
+    (create! "orphan-2")
+    (search/swap-alias! *client* {:new-idx (mk "cur") :alias alias-name})
+    (is (= #{(mk "cur") (mk "orphan-1") (mk "orphan-2")}
+           (search/indices-matching *client* prefix)))))
+
+(deftest delete-stale-indices!-test
+  (testing "deletes the previous index AND orphans not on any alias, keeping keep-idx"
+    (create! "cur")
+    (create! "orphan-1") ; simulates an index stranded by an earlier failed run
+    (create! "orphan-2")
+    (search/swap-alias! *client* {:new-idx (mk "cur") :alias alias-name})
+
+    (let [{:keys [deleted failed]} (search/delete-stale-indices! *client* prefix (mk "cur"))]
+      (is (empty? failed))
+      (is (= #{(mk "orphan-1") (mk "orphan-2")} (set deleted))
+          "both the previous-run orphans are reclaimed")
+      (is (= #{(mk "cur")} (search/indices-matching *client* prefix))
+          "only the kept index remains")
+      (is (= #{(mk "cur")} (set (map name (search/current-idxs *client* {:alias alias-name}))))
+          "the live alias still points at the kept index"))
+
+    (testing "and is idempotent — a second sweep finds nothing to delete"
+      (let [{:keys [deleted failed]} (search/delete-stale-indices! *client* prefix (mk "cur"))]
+        (is (empty? deleted))
+        (is (empty? failed)))))
+
+  (testing "is a no-op (never throws) when nothing matches the prefix"
+    (let [res (search/delete-stale-indices! *client* "zzsweep-empty" (mk "cur"))]
+      (is (= {:deleted [] :failed []} res)))))


### PR DESCRIPTION
## Problem
Re-indexing (`search-indexer/main`) created a new `<mode>-<timestamp>` index, swapped the alias, then deleted **only the index the alias previously pointed to** (`swap-alias!`'s `old-idxs`). Orphaned indices — left by a run that died after the swap, or by an errored delete (the loop had no `try/catch`) — were never on the alias again, so nothing ever cleaned them up.

In prod this accumulated **9 stale `analytics-*` indices**. The `analytics*` Kibana data view matched all of them, so `count`/`sum` visualizations double/triple-counted (up to ~3.5× for older months; recent months were fine), which distorted totals and even inverted month-over-month trends. `cardinality` metrics were unaffected.

## Fix
Sweep by **name pattern** instead of by alias, after the swap:

- `search/indices-matching` — set of `<prefix>-*` index names.
- `search/delete-stale-indices!` — deletes all `<prefix>-*` except the new index, each delete guarded; returns `{:deleted [...] :failed [...]}` for logging.
- Wired into `search-indexer/main` (search/analytics/legacy) and into `analysis/common` population-grid seeding, which had the same "swap but never delete" gap.

Every re-index is now self-healing: it reclaims whatever earlier failures left behind, and one failed delete no longer strands the rest.

## Test
`search-index-lifecycle-test` (integration against real ES, no DB): the sweep deletes the previous index **and** non-aliased orphans while keeping the current index and its alias; is idempotent; and is a no-op when nothing matches. 2 tests / 9 assertions, green via `bb test-ns`.

## Ops follow-up (not in this PR)
- The 9 existing prod orphans predate this fix — delete them manually (or the next re-index will now sweep them).
- Separately, repoint the `analytics*` Kibana data view to the single-index `analytics` alias so historical counts are correct immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)