### PR TITLE
Batch diversity grid precompute: tiled OSRM tables, single ES site query

### DIFF
--- a/docs/analysis-diversity.md
+++ b/docs/analysis-diversity.md
@@ -104,9 +104,24 @@ OSRM response) are skipped; if nothing is routable the minimums are
 ## Typical High Scale Case
 
 - **Grid items per analysis**: 50-200 (depending on area size)
-- **Sports sites per grid item**: 150-300 (in urban areas)
+- **Sports sites per grid item**: 150-450 (in urban areas)
 - **OSRM table requests per analysis**: 3 per ~2km tile of cells
-  (typically 3-12 per job; more when destination chunking kicks in)
+  (typically 3-15 per job; more when destination chunking kicks in)
+
+Measured on a Helsinki-center point-site job (49 cells, 827 candidate
+sites, real local OSRM): the old per-site implementation made 50,193
+HTTP requests in ~324s; the tiled implementation makes 15 requests
+(~3,300x fewer) in ~160s on the same 4-core host. Wall time is bound
+by foot-profile table computation (~20ms per destination + ~1ms per
+source-destination pair), which is why tile size matters more than
+request count - see the `tile-size-m` docstring.
+
+Note on OSRM snapping: table values for coordinates that sit off the
+routable network (e.g. facilities inside parks) can differ slightly
+depending on the other coordinates in the same request. In an
+old-vs-new comparison of ~100k cell/site/profile values, exactly one
+pair differed for this reason (3.9m vs 3054m by car for a park
+facility - the larger value routes via the real road network).
 
 ## Configuration Parameters
 

--- a/docs/analysis-diversity.md
+++ b/docs/analysis-diversity.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The diversity analysis system calculates accessibility and diversity indices for geographic grid areas by analyzing the distribution and accessibility of sports facilities. This document describes the system's architecture, data flow, and critical performance considerations discovered during memory leak analysis.
+The diversity analysis system calculates accessibility and diversity indices for geographic grid areas by analyzing the distribution and accessibility of sports facilities. This document describes the system's architecture, data flow, and performance considerations.
 
 ## System Architecture
 
@@ -17,8 +17,8 @@ The diversity analysis system calculates accessibility and diversity indices for
 
 ```
 MML Grid Items → Fetch Sports Sites → Calculate Distances → Compute Indices → Bulk Index Results
-     ↓                    ↓                    ↓                    ↓                  ↓
-  (250m grid)      (within radius)        (via OSRM)        (diversity)      (Elasticsearch)
+     ↓              (one ES query)         (via OSRM         (diversity)      (Elasticsearch,
+  (250m grid)                            table batches)                         per tile)
 ```
 
 ## Key Functions
@@ -33,38 +33,47 @@ Main orchestration function that processes grid items for a given geographic are
 **Process**:
 1. Creates a 2km buffer around the analysis area
 2. Fetches all grid items intersecting the buffer
-3. Processes each grid item to find nearby sports sites
-4. Calculates distances using OSRM
-5. Bulk indexes results back to Elasticsearch
+3. Delegates to `process-cells!`
 
-### `process-grid-item`
-Processes a single grid item to calculate sports site accessibility.
+### `process-cells!`
+Shared batch engine used by both `recalc-grid!` and CSV seeding
+(`seed-new-grid-from-csv!`):
 
-**Input**:
-- Grid item with WKT point and population data
-- Search radius (typically 2km)
+1. **One ES query** fetches every candidate sports site over the whole
+   area (cells buffered by `cell-radius-m`, 2km), instead of one geo
+   query per grid cell.
+2. **Assignment**: each cell gets the sites with at least one
+   destination vertex within `cell-radius-m` (+`assignment-margin-m`)
+   by haversine distance. Route distance is never shorter than
+   euclidean distance, so the prefilter keeps every site whose OSRM
+   minimum could matter.
+3. **Tiling**: cells are grouped into 2km TM35FIN tiles
+   (`tile-size-m`). Each tile issues **one multi-source OSRM table
+   request per profile** — all tile cells as sources, the deduplicated
+   union of the tile's site vertices as destinations. Destination
+   lists larger than `max-table-locations` are chunked and the matrix
+   columns merged back (`merge-table-chunks`).
+4. **Assembly**: each cell/site pair takes per-profile minimums over
+   the site's matrix columns (`site-osrm-mins`); min distance and min
+   duration are computed independently, like the interactive analysis
+   does.
+5. Each tile's docs are bulk-indexed as soon as the tile completes,
+   keeping memory bounded.
 
-**Output**:
-- Original grid data enriched with `:sports-sites` vector containing:
-  - Site ID, type code, and status
-  - OSRM distances and durations for each transport mode
+The old implementation issued 3 OSRM requests (car/bicycle/foot) *per
+site per cell* plus one ES geo query per cell — on the order of 100k
+HTTP calls for an urban point site. The tiled table requests reduce
+that to a handful of requests per tile (typically 3-12 per job) and
+1-2 ES queries, without changing the stored document shape.
 
-### `apply-mins`
-Transforms OSRM response to extract minimum distances for each transport mode.
+### `site-osrm-mins`
+Extracts per-profile minimums from the tile's table matrices for one
+cell (matrix row) and one site (its destination columns).
 
-**Behavior**: Takes the minimum value across ALL destinations for EACH mode independently.
-
-```clojure
-;; Input
-{:car     {:distances [[2000.0 1234.5 3000.0]]}
- :bicycle {:distances [[2500.0 1500.0 3500.0]]}
- :foot    {:distances [[1900.0 1100.0 900.0]]}}
-
-;; Output
-{:car     {:distance-m 1234.5}  ; minimum for car
- :bicycle {:distance-m 1500.0}  ; minimum for bicycle
- :foot    {:distance-m 900.0}}  ; minimum for foot
-```
+**Behavior**: Takes the minimum value across the site's destinations
+for EACH mode independently. Unroutable destinations (`null` in the
+OSRM response) are skipped; if nothing is routable the minimums are
+`nil`.
 
 ## Data Structures
 
@@ -96,26 +105,40 @@ Transforms OSRM response to extract minimum distances for each transport mode.
 
 - **Grid items per analysis**: 50-200 (depending on area size)
 - **Sports sites per grid item**: 150-300 (in urban areas)
-- **OSRM calls per analysis**: 15,000-60,000
+- **OSRM table requests per analysis**: 3 per ~2km tile of cells
+  (typically 3-12 per job; more when destination chunking kicks in)
 
 ## Configuration Parameters
+
+Read-time (interactive API):
 
 - `analysis-radius-km`: Search radius for sports sites (default: 5km)
 - `max-distance-m`: Maximum distance for diversity calculations (default: 800m)
 - `distance-mode`: `:euclid` or `:route` (route uses OSRM)
 - `categories`: Sport type codes to include in analysis
 
+Precompute-time (constants in `lipas.backend.analysis.diversity`):
+
+- `cell-radius-m`: Site search radius around each cell (2000)
+- `assignment-margin-m`: Slack in the euclidean cell↔site assignment (250)
+- `tile-size-m`: Tile edge for grouped OSRM table requests (2000)
+- `max-table-locations`: Sources + destinations budget per table
+  request (1500; deployment runs osrm-routed with `--max-table-size 3000`)
+
 ## Testing Strategy
 
 ### Unit Tests
-- Pure functions: `apply-mins`, `calc-aggs`, `bool->num`
-- Data transformation: `resolve-dests`, `prepare-categories`
+- Pure functions: `site-osrm-mins`, `min-finite`, `calc-aggs`, `bool->num`
+- Batching logic: `prepare-site-entry`, `assign-sites`, `index-dests`,
+  `merge-table-chunks`
 - No external dependencies required
 
 ### Integration Tests
-- Full workflow with mocked OSRM responses
-- Elasticsearch operations with test indices
-- Memory usage monitoring
+- Full workflow with a matrix-shaped OSRM mock whose distances are
+  haversine-derived, so stored minimums are asserted against
+  independently computed expected values
+- Chunking invariance: tiny `max-table-locations` must not change results
+- Profile failure / total failure / timeout degradation
 - Concurrent processing verification
 
 ### Test Data

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -273,12 +273,15 @@ curl -X POST "localhost:9209/_aliases?pretty" -H 'Content-Type: application/json
 
 Diversity grid is calculated from the 250m population grid by  amending each grid item with distances and travel times to each sports facility within 2km radius. OSRM is used for calculating the distances and travel times.
 
-NOTE: Calculation takes about 8 hours
+NOTE: The July 2026 batching rewrite (tiled multi-source OSRM table
+requests, ~3000x fewer HTTP round-trips) replaced the implementation
+that took about 8 hours for a full-country seed. Expect the seed to be
+dominated by dense urban tiles' foot-profile tables; re-measure on the
+first full run and update this note.
 
 - Run lipas.backend.analysis.diversity/seed-new-grid-from-csv!
   - use 250m population grid as the input
     - sports facilities are queried from Elasticsearch, so make sure it contains up-to-date data from production
-  - Takes about 8 HOURS
 - Copy the reuslts using elasticdump to a new index in production
   - Open tunnel lipas-prod-tunnel-elastic
 

--- a/webapp/src/clj/lipas/backend/analysis/common.clj
+++ b/webapp/src/clj/lipas/backend/analysis/common.clj
@@ -1,5 +1,6 @@
 (ns lipas.backend.analysis.common
   (:require
+   [clojure.core.async :as async]
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.set :as set]
@@ -33,28 +34,44 @@
                     (:geometry geom))
         :relation "intersects"}}}}}})
 
+(defn- sports-site-query
+  [fcoll distance-km type-codes statuses]
+  (let [geom (-> fcoll :features first)]
+    (-> (build-query geom distance-km)
+        (assoc :_source [:name
+                         :status
+                         :type.type-code
+                         :search-meta.location.simple-geoms])
+        (update-in [:query :bool :filter :geo_shape] set/rename-keys
+                   {:coords :search-meta.location.geometries})
+        (cond->
+            (or (seq type-codes) (seq statuses)) (assoc-in [:query :bool :must] [])
+            (seq type-codes) (update-in [:query :bool :must] conj
+                                        {:terms {:type.type-code type-codes}})
+            (seq statuses)   (update-in [:query :bool :must] conj
+                                        {:terms {:status statuses}})))))
+
 (defn get-sports-site-data
   ([search fcoll distance-km type-codes]
    (get-sports-site-data search fcoll distance-km type-codes default-statuses))
   ([{:keys [indices client]} fcoll distance-km type-codes statuses]
    (let [idx-name (get-in indices [:sports-site :search])
-         geom     (-> fcoll :features first)
-         query    (-> (build-query geom distance-km)
-                   (assoc :_source [:name
-                                    :status
-                                    :type.type-code
-                                    :search-meta.location.simple-geoms])
-                   (update-in [:query :bool :filter :geo_shape] set/rename-keys
-                              {:coords :search-meta.location.geometries})
-                   (cond->
-                       (or (seq type-codes) (seq statuses)) (assoc-in [:query :bool :must] [])
-                       (seq type-codes) (update-in [:query :bool :must] conj
-                                                   {:terms {:type.type-code type-codes}})
-                       (seq statuses)   (update-in [:query :bool :must] conj
-                                                   {:terms {:status statuses}})))]
+         query (sports-site-query fcoll distance-km type-codes statuses)]
      (-> (search/search client idx-name query)
          :body
          :hits))))
+
+(defn get-sports-site-data-scrolled
+  "Like get-sports-site-data but scrolls through every hit, so results
+  aren't clipped by the query size cap."
+  [{:keys [indices client]} fcoll distance-km type-codes statuses]
+  (let [idx-name (get-in indices [:sports-site :search])
+        query (sports-site-query fcoll distance-km type-codes statuses)
+        in-chan (search/scroll client idx-name query)]
+    {:hits (loop [acc []]
+             (if-let [page (async/<!! in-chan)]
+               (recur (into acc (-> page :body :hits :hits)))
+               acc))}))
 
 (defn get-es-data*
   [idx-name client fcoll distance-km]

--- a/webapp/src/clj/lipas/backend/analysis/diversity.clj
+++ b/webapp/src/clj/lipas/backend/analysis/diversity.clj
@@ -263,7 +263,15 @@
 
 (def tile-size-m
   "Cells are grouped into square TM35FIN tiles; each tile shares one
-  multi-source OSRM table request per profile."
+  multi-source OSRM table request per profile.
+
+  Tile size balances two measured cost terms of OSRM /table (MLD):
+  ~20ms per DESTINATION (foot profile; backward searches, amortized
+  across all sources in the request) plus ~1ms per source x dest PAIR.
+  Small tiles repay the per-destination cost for every cell (a single
+  urban cell sees ~1000 destinations, so per-cell requests are ~20s of
+  foot compute EACH); huge tiles maximize pair count. 2km - matching
+  cell-radius-m - sits near the optimum for dense areas."
   2000)
 
 (def max-table-locations
@@ -272,11 +280,26 @@
   request URLs and response matrices moderate."
   1500)
 
+(def osrm-table-socket-timeout-ms
+  "Response timeout for batch table requests (2 minutes). Large
+  matrices - the foot profile in particular - can take well over the
+  default 30s to compute."
+  120000)
+
 (def osrm-table-timeout-ms
-  "Timeout per OSRM table request (60 seconds)."
-  60000)
+  "Deref timeout per OSRM table request. Slightly above the socket
+  timeout so the socket timeout, not the deref, is what bounds a slow
+  request."
+  150000)
 
 (def osrm-profiles [:car :bicycle :foot])
+
+(def tile-parallelism
+  "Tiles processed concurrently. Each tile issues at most one in-flight
+  request per profile server, so this also bounds concurrent requests
+  per server. The foot profile computes large tables much slower than
+  car/bicycle; overlapping tiles keeps cores busy during those."
+  3)
 
 (defn resolve-dests [site on-error]
   (try
@@ -362,6 +385,7 @@
                      :sources sources
                      :destinations dests
                      :cache? false
+                     :socket-timeout-ms osrm-table-socket-timeout-ms
                      :timeout-ms osrm-table-timeout-ms}
                     osrm/get-distances-and-travel-times
                     (update-vals #(select-keys % [:distances :durations]))
@@ -506,19 +530,24 @@
         assignments (assign-sites cell-points site-entries
                                   (+ cell-radius-m assignment-margin-m))
         tiles (group-by #(tile-key (nth cells-3067 %)) (range (count cells)))
-        osrm-requests (volatile! 0)]
+        osrm-requests (atom 0)]
     (log/info (format "Processing %d cells / %d sites in %d tiles"
                       (count cells) (count site-entries) (count tiles)))
-    (doseq [[tk idxs] tiles]
-      (try
-        (let [tile-cells (mapv (fn [i]
-                                 {:cell (nth cells i)
-                                  :coord (nth cell-coords i)
-                                  :site-idxs (nth assignments i)})
-                               idxs)]
-          (vswap! osrm-requests + (process-tile! client idx-name site-entries tile-cells)))
-        (catch Exception e
-          (log/error e "Failed to process tile" tk))))
+    (doseq [wave (partition-all tile-parallelism tiles)]
+      (->> wave
+           (mapv (fn [[tk idxs]]
+                   (future
+                     (try
+                       (let [tile-cells (mapv (fn [i]
+                                                {:cell (nth cells i)
+                                                 :coord (nth cell-coords i)
+                                                 :site-idxs (nth assignments i)})
+                                              idxs)]
+                         (swap! osrm-requests
+                                + (process-tile! client idx-name site-entries tile-cells)))
+                       (catch Exception e
+                         (log/error e "Failed to process tile" tk))))))
+           (run! deref)))
     {:cells (count cells)
      :sites (count site-entries)
      :tiles (count tiles)

--- a/webapp/src/clj/lipas/backend/analysis/diversity.clj
+++ b/webapp/src/clj/lipas/backend/analysis/diversity.clj
@@ -256,11 +256,9 @@
   2000)
 
 (def assignment-margin-m
-  "Extra slack in the euclidean cell<->site assignment. Compensates for
-  simple-geoms being a simplification of the exact geometries the old
-  per-cell ES radius query matched against. A site outside the margin
-  cannot matter: its route distance is at least its euclidean distance,
-  which already exceeds cell-radius-m."
+  "Extra slack in the cell<->site assignment. Compensates for
+  simple-geoms being a simplification (~111m tolerance) of the exact
+  geometries the per-cell ES radius query used to match against."
   250)
 
 (def tile-size-m
@@ -292,61 +290,46 @@
       (on-error {:site site :error e})
       [])))
 
-(defn- parse-coord-str [s]
-  (let [[lon lat] (str/split s #",")]
-    [(Double/parseDouble lon) (Double/parseDouble lat)]))
-
 (defn prepare-site-entry
-  "Precompute OSRM destination strings and numeric coords for a site.
-  Returns nil when the site has no usable geometry (it could never
-  contribute a distance to the index)."
+  "Precompute OSRM destination strings and a metric (TM35FIN) JTS
+  geometry for a site. Returns nil when the site has no usable
+  geometry (it could never contribute a distance to the index)."
   [site on-error]
-  (let [dests (into [] (distinct) (resolve-dests site on-error))]
-    (when (seq dests)
+  (let [dests (into [] (distinct) (resolve-dests site on-error))
+        geom (when (seq dests)
+               (try
+                 (-> site :_source :search-meta :location :simple-geoms
+                     gis/fcoll->tm35fin-geom)
+                 (catch Exception e
+                   (on-error {:site site :error e})
+                   nil)))]
+    (when geom
       {:id (:_id site)
        :type-code (-> site :_source :type :type-code)
        :status (-> site :_source :status)
        :dests dests
-       :coords (mapv parse-coord-str dests)})))
-
-(defn- coords-bbox
-  "Bounding box of [lon lat] coords expanded by margin-m meters."
-  [coords margin-m]
-  (let [lons (map first coords)
-        lats (map second coords)
-        min-lat (apply min lats)
-        max-lat (apply max lats)
-        dlat (/ margin-m 111320.0)
-        cos-lat (Math/cos (Math/toRadians (max (Math/abs (double min-lat))
-                                               (Math/abs (double max-lat)))))
-        dlon (/ margin-m (* 111320.0 (max 0.01 cos-lat)))]
-    {:min-lon (- (apply min lons) dlon)
-     :max-lon (+ (apply max lons) dlon)
-     :min-lat (- min-lat dlat)
-     :max-lat (+ max-lat dlat)}))
+       :geom-3067 geom})))
 
 (defn assign-sites
-  "For each cell coord, indices of site entries with at least one
-  destination vertex within radius-m (euclidean). Route distance can
-  never be shorter than euclidean distance, so this keeps every site
-  whose OSRM minimum could fall under radius-m. Returns a vector of
-  index vectors aligned with cell-coords."
-  [cell-coords site-entries radius-m]
-  (let [boxes (mapv #(coords-bbox (:coords %) radius-m) site-entries)]
-    (mapv (fn [[lon lat :as coord]]
-            (persistent!
-             (reduce
-              (fn [acc i]
-                (let [box (nth boxes i)]
-                  (if (and (<= (:min-lon box) lon (:max-lon box))
-                           (<= (:min-lat box) lat (:max-lat box))
-                           (some #(<= (gis/haversine coord %) radius-m)
-                                 (:coords (nth site-entries i))))
-                    (conj! acc i)
-                    acc)))
-              (transient [])
-              (range (count site-entries)))))
-          cell-coords)))
+  "For each cell (a TM35FIN JTS point), indices of site entries whose
+  simple-geoms geometry lies within radius-m. This mirrors the old
+  per-cell ES radius query against the exact geometries, to within the
+  simple-geoms simplification tolerance (covered by
+  assignment-margin-m). Returns a vector of index vectors aligned with
+  cell-points."
+  [cell-points site-entries radius-m]
+  (mapv (fn [point]
+          (persistent!
+           (reduce
+            (fn [acc i]
+              (if (gis/within-distance? (:geom-3067 (nth site-entries i))
+                                        radius-m
+                                        point)
+                (conj! acc i)
+                acc))
+            (transient [])
+            (range (count site-entries)))))
+        cell-points))
 
 (defn index-dests
   "Assign one OSRM table column per distinct destination string across
@@ -371,58 +354,73 @@
 
 (defn- fetch-table!
   "One OSRM table request per profile in parallel for sources x dests.
-  Returns {profile {:distances .. :durations ..}}; failed or timed out
-  profiles are omitted."
+  Failed profiles are retried once; still-failing profiles are omitted
+  from the result map."
   [sources dests]
-  (let [futures (mapv (fn [p]
-                        [p (future
-                             (osrm/get-data {:profile p
-                                             :sources sources
-                                             :destinations dests
-                                             :cache? false}))])
-                      osrm-profiles)]
-    (reduce (fn [res [p f]]
-              (let [result (deref f osrm-table-timeout-ms ::timeout)]
-                (cond
-                  (= result ::timeout)
-                  (do
-                    (future-cancel f)
-                    (log/warn "OSRM table request timed out for profile" p)
-                    res)
-
-                  (nil? result)
-                  res
-
-                  :else
-                  (assoc res p (select-keys result [:distances :durations])))))
-            {}
-            futures)))
+  (let [fetch (fn [profiles]
+                (-> {:profiles profiles
+                     :sources sources
+                     :destinations dests
+                     :cache? false
+                     :timeout-ms osrm-table-timeout-ms}
+                    osrm/get-distances-and-travel-times
+                    (update-vals #(select-keys % [:distances :durations]))
+                    (->> (into {} (filter (fn [[_ v]]
+                                            (and (:distances v)
+                                                 (:durations v))))))))
+        first-pass (fetch osrm-profiles)
+        missing (into [] (remove first-pass) osrm-profiles)]
+    (if (seq missing)
+      (merge first-pass (fetch missing))
+      first-pass)))
 
 (defn merge-table-chunks
   "Merge per-profile table results of consecutive destination chunks by
-  concatenating matrix columns. A profile missing from any chunk is
-  dropped entirely so partial data can't skew minimums."
-  [chunk-results]
-  (reduce (fn [acc p]
-            (if (every? #(and (get-in % [p :distances])
-                              (get-in % [p :durations]))
-                        chunk-results)
-              (assoc acc p
-                     {:distances (apply mapv (fn [& rows] (into [] cat rows))
-                                        (map #(get-in % [p :distances]) chunk-results))
-                      :durations (apply mapv (fn [& rows] (into [] cat rows))
-                                        (map #(get-in % [p :durations]) chunk-results))})
-              acc))
-          {}
-          osrm-profiles))
+  concatenating matrix columns. chunk-sizes gives each chunk's column
+  count and n-sources the row count, so a chunk whose request failed
+  for a profile is nil-filled and its column indices reported under
+  :failed-cols - sites touching those columns then omit the profile
+  instead of risking a wrong (partial) minimum."
+  [chunk-results chunk-sizes n-sources]
+  (let [offsets (vec (reductions + 0 chunk-sizes))
+        nil-rows (fn [n-cols]
+                   (vec (repeat n-sources (vec (repeat n-cols nil)))))]
+    (reduce
+     (fn [acc p]
+       (let [per-chunk (mapv #(get % p) chunk-results)]
+         (if (every? nil? per-chunk)
+           acc
+           (let [failed-cols (into (sorted-set)
+                                   (mapcat (fn [i]
+                                             (when (nil? (nth per-chunk i))
+                                               (range (nth offsets i)
+                                                      (+ (nth offsets i)
+                                                         (nth chunk-sizes i))))))
+                                   (range (count per-chunk)))
+                 concat-rows (fn [k]
+                               (apply mapv (fn [& rows] (into [] cat rows))
+                                      (map-indexed
+                                       (fn [i r]
+                                         (if r (k r) (nil-rows (nth chunk-sizes i))))
+                                       per-chunk)))]
+             (-> acc
+                 (assoc-in [:tables p] {:distances (concat-rows :distances)
+                                        :durations (concat-rows :durations)})
+                 (cond-> (seq failed-cols)
+                   (assoc-in [:failed-cols p] failed-cols)))))))
+     {:tables {} :failed-cols {}}
+     osrm-profiles)))
 
 (defn- fetch-tables!
   "Table matrices for sources x dests, chunking destinations so each
-  request stays within max-table-locations."
+  request stays within max-table-locations. Returns
+  {:tables {profile ..} :failed-cols {profile #{col ..}}}."
   [sources dests]
   (let [chunk-size (max 1 (- max-table-locations (count sources)))
-        chunks (partition-all chunk-size dests)]
-    (merge-table-chunks (mapv #(fetch-table! sources (vec %)) chunks))))
+        chunks (mapv vec (partition-all chunk-size dests))]
+    (merge-table-chunks (mapv #(fetch-table! sources %) chunks)
+                        (mapv count chunks)
+                        (count sources))))
 
 (defn min-finite [xs]
   (when-let [vs (seq (remove nil? xs))]
@@ -431,21 +429,24 @@
 (defn site-osrm-mins
   "Per-profile minimum distance/duration for one cell (matrix row) and
   one site (its matrix columns). Min distance and min duration are
-  taken independently, like the old per-site implementation did."
-  [tables row-idx cols]
+  taken independently, like the old per-site implementation did. A
+  profile whose failed columns overlap the site's columns is omitted
+  for this site (same footprint as the old per-site request failure)."
+  [tables failed-cols row-idx cols]
   (not-empty
    (reduce-kv
     (fn [res p {:keys [distances durations]}]
-      (let [drow (nth distances row-idx)
-            trow (nth durations row-idx)]
-        (assoc res p {:distance-m (min-finite (map #(nth drow %) cols))
-                      :duration-s (min-finite (map #(nth trow %) cols))})))
+      (if (some (or (get failed-cols p) #{}) cols)
+        res
+        (let [drow (nth distances row-idx)
+              trow (nth durations row-idx)]
+          (assoc res p {:distance-m (min-finite (map #(nth drow %) cols))
+                        :duration-s (min-finite (map #(nth trow %) cols))}))))
     {}
     tables)))
 
-(defn- tile-key [[lon lat]]
-  (let [[e n] (gis/wgs84->tm35fin-no-wrap [lon lat])]
-    [(quot (long e) tile-size-m) (quot (long n) tile-size-m)]))
+(defn- tile-key [[e n]]
+  [(quot (long e) tile-size-m) (quot (long n) tile-size-m)])
 
 (defn- process-tile!
   "Compute distances for one tile of cells and bulk index the resulting
@@ -456,8 +457,8 @@
         sources (mapv (fn [{:keys [coord]}] (str/join "," coord)) routed)
         [dests site->cols] (index-dests site-entries
                                         (into [] (distinct) (mapcat :site-idxs routed)))
-        tables (when (seq sources)
-                 (fetch-tables! sources dests))
+        {:keys [tables failed-cols]} (when (seq sources)
+                                       (fetch-tables! sources dests))
         chunk-size (max 1 (- max-table-locations (count sources)))
         n-requests (if (seq sources)
                      (* (count osrm-profiles)
@@ -469,7 +470,8 @@
                            :type-code (:type-code entry)
                            :status (:status entry)
                            :osrm (when (seq tables)
-                                   (site-osrm-mins tables row-idx (site->cols site-idx)))}))
+                                   (site-osrm-mins tables failed-cols row-idx
+                                                   (site->cols site-idx)))}))
         docs (concat
               (map-indexed
                (fn [row-idx {:keys [cell site-idxs]}]
@@ -495,16 +497,15 @@
   [{:keys [client] :as search} idx-name cells site-area-fcoll on-error]
   (let [cells (vec cells)
         cell-coords (mapv (comp gis/wkt-point->coords :WKT) cells)
-        site-hits (:hits (common/get-sports-site-data
+        cells-3067 (mapv gis/wgs84->tm35fin-no-wrap cell-coords)
+        cell-points (mapv gis/tm35fin-point cells-3067)
+        site-hits (:hits (common/get-sports-site-data-scrolled
                           search site-area-fcoll (/ cell-radius-m 1000)
                           all-type-codes statuses))
-        _ (when (<= 10000 (count site-hits))
-            ;; ES query size cap - process smaller cell batches if this hits
-            (log/warn "Sports site query returned 10k hits; results may be clipped"))
         site-entries (into [] (keep #(prepare-site-entry % on-error)) site-hits)
-        assignments (assign-sites cell-coords site-entries
+        assignments (assign-sites cell-points site-entries
                                   (+ cell-radius-m assignment-margin-m))
-        tiles (group-by #(tile-key (nth cell-coords %)) (range (count cells)))
+        tiles (group-by #(tile-key (nth cells-3067 %)) (range (count cells)))
         osrm-requests (volatile! 0)]
     (log/info (format "Processing %d cells / %d sites in %d tiles"
                       (count cells) (count site-entries) (count tiles)))

--- a/webapp/src/clj/lipas/backend/analysis/diversity.clj
+++ b/webapp/src/clj/lipas/backend/analysis/diversity.clj
@@ -1,7 +1,6 @@
 (ns lipas.backend.analysis.diversity
   (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :as walk]
             [lipas.backend.analysis.common :as common]
@@ -251,10 +250,35 @@
 
 (def all-type-codes (keys types/all))
 
-(def osrm-site-timeout-ms
-  "Timeout for OSRM request per site (60 seconds).
-  Conservative to handle complex routes with multiple destinations."
+(def cell-radius-m
+  "Radius around each grid cell centroid within which sports sites
+  contribute to the cell's precomputed distances."
+  2000)
+
+(def assignment-margin-m
+  "Extra slack in the euclidean cell<->site assignment. Compensates for
+  simple-geoms being a simplification of the exact geometries the old
+  per-cell ES radius query matched against. A site outside the margin
+  cannot matter: its route distance is at least its euclidean distance,
+  which already exceeds cell-radius-m."
+  250)
+
+(def tile-size-m
+  "Cells are grouped into square TM35FIN tiles; each tile shares one
+  multi-source OSRM table request per profile."
+  2000)
+
+(def max-table-locations
+  "Max sources + destinations per OSRM table request. Deployment runs
+  osrm-routed with --max-table-size 3000; staying well under keeps
+  request URLs and response matrices moderate."
+  1500)
+
+(def osrm-table-timeout-ms
+  "Timeout per OSRM table request (60 seconds)."
   60000)
+
+(def osrm-profiles [:car :bicycle :foot])
 
 (defn resolve-dests [site on-error]
   (try
@@ -268,148 +292,272 @@
       (on-error {:site site :error e})
       [])))
 
-(defn- resolve-min
-  [coll]
-  (let [min* (partial apply min)]
-    (->> coll (remove nil?) min*)))
+(defn- parse-coord-str [s]
+  (let [[lon lat] (str/split s #",")]
+    [(Double/parseDouble lon) (Double/parseDouble lat)]))
 
-(defn apply-mins [m]
-  (reduce-kv
-   (fn [res k v]
-     (assoc res k
-            (some-> v
-                    (update :distances #(-> % first not-empty (some-> resolve-min)))
-                    (update :durations #(-> % first not-empty (some-> resolve-min)))
-                    (dissoc :code)
-                    (set/rename-keys {:distances :distance-m
-                                      :durations :duration-s}))))
-   {}
-   m))
+(defn prepare-site-entry
+  "Precompute OSRM destination strings and numeric coords for a site.
+  Returns nil when the site has no usable geometry (it could never
+  contribute a distance to the index)."
+  [site on-error]
+  (let [dests (into [] (distinct) (resolve-dests site on-error))]
+    (when (seq dests)
+      {:id (:_id site)
+       :type-code (-> site :_source :type :type-code)
+       :status (-> site :_source :status)
+       :dests dests
+       :coords (mapv parse-coord-str dests)})))
 
-(defn process-sites-chunk
-  "Process a chunk of sites to control memory usage.
-  Uses timeout-protected deref to prevent stuck jobs."
-  [sites coords on-error]
-  (mapv (fn [site]
-          (let [dests (resolve-dests site on-error)]
-            (if (empty? dests)
-              {:id (:_id site)
-               :type-code (-> site :_source :type :type-code)
-               :status (-> site :_source :status)
-               :osrm nil}
-              ;; Create futures for just this site
-              (let [futures (mapv (fn [p]
-                                    [p (future
-                                         (osrm/get-data
-                                          {:profile p
-                                           :sources [(str/join "," coords)]
-                                           :destinations dests}))])
-                                  [:car :bicycle :foot])
-                    ;; Collect results with timeout to prevent stuck jobs
-                    osrm-results (reduce (fn [res [p f]]
-                                           (let [result (deref f osrm-site-timeout-ms ::timeout)]
-                                             (cond
-                                               (= result ::timeout)
-                                               (do
-                                                 (future-cancel f)
-                                                 (log/warn "OSRM request timed out for profile" p
-                                                           "site" (:_id site))
-                                                 res)
+(defn- coords-bbox
+  "Bounding box of [lon lat] coords expanded by margin-m meters."
+  [coords margin-m]
+  (let [lons (map first coords)
+        lats (map second coords)
+        min-lat (apply min lats)
+        max-lat (apply max lats)
+        dlat (/ margin-m 111320.0)
+        cos-lat (Math/cos (Math/toRadians (max (Math/abs (double min-lat))
+                                               (Math/abs (double max-lat)))))
+        dlon (/ margin-m (* 111320.0 (max 0.01 cos-lat)))]
+    {:min-lon (- (apply min lons) dlon)
+     :max-lon (+ (apply max lons) dlon)
+     :min-lat (- min-lat dlat)
+     :max-lat (+ max-lat dlat)}))
 
-                                               (nil? result)
-                                               res
+(defn assign-sites
+  "For each cell coord, indices of site entries with at least one
+  destination vertex within radius-m (euclidean). Route distance can
+  never be shorter than euclidean distance, so this keeps every site
+  whose OSRM minimum could fall under radius-m. Returns a vector of
+  index vectors aligned with cell-coords."
+  [cell-coords site-entries radius-m]
+  (let [boxes (mapv #(coords-bbox (:coords %) radius-m) site-entries)]
+    (mapv (fn [[lon lat :as coord]]
+            (persistent!
+             (reduce
+              (fn [acc i]
+                (let [box (nth boxes i)]
+                  (if (and (<= (:min-lon box) lon (:max-lon box))
+                           (<= (:min-lat box) lat (:max-lat box))
+                           (some #(<= (gis/haversine coord %) radius-m)
+                                 (:coords (nth site-entries i))))
+                    (conj! acc i)
+                    acc)))
+              (transient [])
+              (range (count site-entries)))))
+          cell-coords)))
 
-                                               :else
-                                               (assoc res p result))))
-                                         {}
-                                         futures)]
-                {:id (:_id site)
-                 :type-code (-> site :_source :type :type-code)
-                 :status (-> site :_source :status)
-                 :osrm (when (seq osrm-results)
-                         (apply-mins osrm-results))}))))
-        sites))
+(defn index-dests
+  "Assign one OSRM table column per distinct destination string across
+  the given site entries. Returns [dests site-idx->cols]."
+  [site-entries site-idxs]
+  (loop [[site-idx & more] (seq site-idxs)
+         dest->col {}
+         dests []
+         site->cols {}]
+    (if (nil? site-idx)
+      [dests site->cols]
+      (let [[dest->col dests cols]
+            (reduce (fn [[dest->col dests cols] dest]
+                      (if-let [col (dest->col dest)]
+                        [dest->col dests (conj cols col)]
+                        [(assoc dest->col dest (count dests))
+                         (conj dests dest)
+                         (conj cols (count dests))]))
+                    [dest->col dests []]
+                    (:dests (nth site-entries site-idx)))]
+        (recur more dest->col dests (assoc site->cols site-idx cols))))))
 
-(defn process-grid-item
-  [search dist-km m on-error & {:keys [site-chunk-size] :or {site-chunk-size 20}}]
-  (let [coords (-> m :WKT gis/wkt-point->coords)
-        point-fcoll (gis/->fcoll
-                     [(gis/->feature {:type "Point"
-                                      :coordinates coords})])
-        site-data (common/get-sports-site-data
-                   search
-                   point-fcoll
-                   dist-km
-                   all-type-codes
-                   statuses)
-        sites (:hits site-data)
-        ;; Process sites in chunks to control memory usage
-        site-chunks (partition-all site-chunk-size sites)
-        results (atom [])]
+(defn- fetch-table!
+  "One OSRM table request per profile in parallel for sources x dests.
+  Returns {profile {:distances .. :durations ..}}; failed or timed out
+  profiles are omitted."
+  [sources dests]
+  (let [futures (mapv (fn [p]
+                        [p (future
+                             (osrm/get-data {:profile p
+                                             :sources sources
+                                             :destinations dests
+                                             :cache? false}))])
+                      osrm-profiles)]
+    (reduce (fn [res [p f]]
+              (let [result (deref f osrm-table-timeout-ms ::timeout)]
+                (cond
+                  (= result ::timeout)
+                  (do
+                    (future-cancel f)
+                    (log/warn "OSRM table request timed out for profile" p)
+                    res)
 
-    ;; Process each chunk and immediately release futures
-    (doseq [chunk site-chunks]
-      (let [chunk-results (process-sites-chunk chunk coords on-error)]
-        (swap! results into chunk-results)))
+                  (nil? result)
+                  res
 
-    (assoc m :sports-sites @results)))
+                  :else
+                  (assoc res p (select-keys result [:distances :durations])))))
+            {}
+            futures)))
+
+(defn merge-table-chunks
+  "Merge per-profile table results of consecutive destination chunks by
+  concatenating matrix columns. A profile missing from any chunk is
+  dropped entirely so partial data can't skew minimums."
+  [chunk-results]
+  (reduce (fn [acc p]
+            (if (every? #(and (get-in % [p :distances])
+                              (get-in % [p :durations]))
+                        chunk-results)
+              (assoc acc p
+                     {:distances (apply mapv (fn [& rows] (into [] cat rows))
+                                        (map #(get-in % [p :distances]) chunk-results))
+                      :durations (apply mapv (fn [& rows] (into [] cat rows))
+                                        (map #(get-in % [p :durations]) chunk-results))})
+              acc))
+          {}
+          osrm-profiles))
+
+(defn- fetch-tables!
+  "Table matrices for sources x dests, chunking destinations so each
+  request stays within max-table-locations."
+  [sources dests]
+  (let [chunk-size (max 1 (- max-table-locations (count sources)))
+        chunks (partition-all chunk-size dests)]
+    (merge-table-chunks (mapv #(fetch-table! sources (vec %)) chunks))))
+
+(defn min-finite [xs]
+  (when-let [vs (seq (remove nil? xs))]
+    (reduce min vs)))
+
+(defn site-osrm-mins
+  "Per-profile minimum distance/duration for one cell (matrix row) and
+  one site (its matrix columns). Min distance and min duration are
+  taken independently, like the old per-site implementation did."
+  [tables row-idx cols]
+  (not-empty
+   (reduce-kv
+    (fn [res p {:keys [distances durations]}]
+      (let [drow (nth distances row-idx)
+            trow (nth durations row-idx)]
+        (assoc res p {:distance-m (min-finite (map #(nth drow %) cols))
+                      :duration-s (min-finite (map #(nth trow %) cols))})))
+    {}
+    tables)))
+
+(defn- tile-key [[lon lat]]
+  (let [[e n] (gis/wgs84->tm35fin-no-wrap [lon lat])]
+    [(quot (long e) tile-size-m) (quot (long n) tile-size-m)]))
+
+(defn- process-tile!
+  "Compute distances for one tile of cells and bulk index the resulting
+  grid docs. Returns the number of OSRM requests made."
+  [client idx-name site-entries tile-cells]
+  (let [routed (filterv (comp seq :site-idxs) tile-cells)
+        unrouted (remove (comp seq :site-idxs) tile-cells)
+        sources (mapv (fn [{:keys [coord]}] (str/join "," coord)) routed)
+        [dests site->cols] (index-dests site-entries
+                                        (into [] (distinct) (mapcat :site-idxs routed)))
+        tables (when (seq sources)
+                 (fetch-tables! sources dests))
+        chunk-size (max 1 (- max-table-locations (count sources)))
+        n-requests (if (seq sources)
+                     (* (count osrm-profiles)
+                        (long (Math/ceil (/ (count dests) (double chunk-size)))))
+                     0)
+        ->site-result (fn [row-idx site-idx]
+                        (let [entry (nth site-entries site-idx)]
+                          {:id (:id entry)
+                           :type-code (:type-code entry)
+                           :status (:status entry)
+                           :osrm (when (seq tables)
+                                   (site-osrm-mins tables row-idx (site->cols site-idx)))}))
+        docs (concat
+              (map-indexed
+               (fn [row-idx {:keys [cell site-idxs]}]
+                 (assoc cell :sports-sites (mapv #(->site-result row-idx %) site-idxs)))
+               routed)
+              (map (fn [{:keys [cell]}] (assoc cell :sports-sites []))
+                   unrouted))]
+    (->> docs
+         (search/->bulk idx-name :grd_id)
+         (search/bulk-index-sync! client))
+    n-requests))
+
+(defn process-cells!
+  "Compute sports-site OSRM distances for grid cells and bulk index the
+  resulting diversity grid docs into idx-name.
+
+  Fetches all candidate sports sites with one ES query over
+  site-area-fcoll (which must cover every cell buffered by
+  cell-radius-m), assigns sites to cells with a euclidean prefilter and
+  issues chunked multi-source OSRM table requests per tile of cells --
+  instead of one request per site per profile per cell like the old
+  implementation. Returns summary stats."
+  [{:keys [client] :as search} idx-name cells site-area-fcoll on-error]
+  (let [cells (vec cells)
+        cell-coords (mapv (comp gis/wkt-point->coords :WKT) cells)
+        site-hits (:hits (common/get-sports-site-data
+                          search site-area-fcoll (/ cell-radius-m 1000)
+                          all-type-codes statuses))
+        _ (when (<= 10000 (count site-hits))
+            ;; ES query size cap - process smaller cell batches if this hits
+            (log/warn "Sports site query returned 10k hits; results may be clipped"))
+        site-entries (into [] (keep #(prepare-site-entry % on-error)) site-hits)
+        assignments (assign-sites cell-coords site-entries
+                                  (+ cell-radius-m assignment-margin-m))
+        tiles (group-by #(tile-key (nth cell-coords %)) (range (count cells)))
+        osrm-requests (volatile! 0)]
+    (log/info (format "Processing %d cells / %d sites in %d tiles"
+                      (count cells) (count site-entries) (count tiles)))
+    (doseq [[tk idxs] tiles]
+      (try
+        (let [tile-cells (mapv (fn [i]
+                                 {:cell (nth cells i)
+                                  :coord (nth cell-coords i)
+                                  :site-idxs (nth assignments i)})
+                               idxs)]
+          (vswap! osrm-requests + (process-tile! client idx-name site-entries tile-cells)))
+        (catch Exception e
+          (log/error e "Failed to process tile" tk))))
+    {:cells (count cells)
+     :sites (count site-entries)
+     :tiles (count tiles)
+     :osrm-requests @osrm-requests}))
 
 (defn recalc-grid!
-  "Main entry point for recalculating diversity grid.
-   Optimized with batch processing to control memory usage."
-  ([{:keys [indices client] :as search} fcoll]
+  "Main entry point for recalculating the precomputed diversity grid
+  around fcoll (2 km buffer)."
+  ([search fcoll]
    (recalc-grid! search fcoll {}))
-  ([{:keys [indices client] :as search} fcoll {:keys [batch-size gc-between-batches? site-chunk-size]
-                                               :or {batch-size 20
-                                                    gc-between-batches? true
-                                                    site-chunk-size 20}}]
+  ([{:keys [indices] :as search} fcoll
+    {:keys [on-error]
+     :or {on-error (fn [m] (log/debug (:error m) "Error processing site"))}}]
    (let [idx-name (get-in indices [:analysis :diversity])
-         on-error (fn [e] (log/debug e "Error processing site"))
          buffer-dist-km 2
-         buffer-geom (gis/calc-buffer fcoll (* buffer-dist-km 1000))
-         buffer-fcoll (gis/->fcoll [(gis/->feature buffer-geom)])
+         buffer-fcoll (-> fcoll
+                          (gis/calc-buffer (* buffer-dist-km 1000))
+                          gis/->feature
+                          vector
+                          gis/->fcoll)
          grid-items (fetch-grid search buffer-fcoll buffer-dist-km)
-         total-items (count grid-items)
-         batch-count (int (Math/ceil (/ total-items batch-size)))]
-
-     (log/info (format "Processing %d grid items in %d batches of %d (site chunk size: %d)"
-                       total-items batch-count batch-size site-chunk-size))
-
-     ;; Process in batches to control memory usage
-     (doseq [[batch-idx batch] (map-indexed vector (partition-all batch-size grid-items))]
-       (let [batch-num (inc batch-idx)
-             start-time (System/currentTimeMillis)]
-
-         (log/info (format "Processing batch %d/%d" batch-num batch-count))
-
-         (try
-           ;; Process batch with site chunking
-           (let [processed (->> batch
-                                (map :_source)
-                                (mapv #(process-grid-item search buffer-dist-km % on-error
-                                                          :site-chunk-size site-chunk-size))
-                                (search/->bulk idx-name :grd_id))]
-             (search/bulk-index-sync! client processed))
-
-           (catch Exception e
-             (log/error e "Failed to process batch" batch-num)))
-
-         ;; Optional GC between batches
-         (when (and gc-between-batches? (< batch-num batch-count))
-           (System/gc)
-           (Thread/sleep 100))
-
-         (log/debug (format "Batch %d completed in %.1f seconds"
-                            batch-num (/ (- (System/currentTimeMillis) start-time) 1000.0)))))
-
-     (log/info "All batches completed"))))
+         ;; Covers every fetched cell buffered by cell-radius-m
+         site-area-fcoll (-> fcoll
+                             (gis/calc-buffer (+ (* buffer-dist-km 1000) cell-radius-m))
+                             gis/->feature
+                             vector
+                             gis/->fcoll)
+         start-ms (System/currentTimeMillis)
+         stats (process-cells! search idx-name (mapv :_source grid-items)
+                               site-area-fcoll on-error)]
+     (log/info (format "Diversity grid recalculated in %.1fs: %s"
+                       (/ (- (System/currentTimeMillis) start-ms) 1000.0)
+                       (pr-str stats)))
+     stats)))
 
 (defn seed-new-grid-from-csv!
-  [{:keys [indices client] :as search} csv-path]
+  [{:keys [client] :as search} csv-path]
   (let [idx-name (str "diversity-" (search/gen-idx-name))
-        on-error #(log/error %)
-        batch-size 100
-        dist-km 2]
+        on-error (fn [m] (log/error (:error m) "Error processing site"))
+        batch-size 500]
 
     (with-open [rdr (io/reader csv-path)]
       (log/info "Creating index" idx-name)
@@ -419,16 +567,15 @@
       (doseq [part (->> (csv/read-csv rdr)
                         utils/csv-data->maps
                         (map walk/keywordize-keys)
-                        (partition-all batch-size)
-                        (doall))]
-
-        (let [ms (reduce (fn [res m]
-                           (conj res (process-grid-item search dist-km m on-error :site-chunk-size 20)))
-                         []
-                         part)]
-
-          (log/info "Writing batch of" batch-size "to" idx-name)
-          (->> ms
-               (search/->bulk idx-name :grd_id)
-               (search/bulk-index-sync! client))
-          (log/info "Writing batch DONE"))))))
+                        (partition-all batch-size))]
+        (let [coords (mapv (comp gis/wkt-point->coords :WKT) part)
+              area-fcoll (-> {:type "MultiPoint" :coordinates coords}
+                             gis/->feature
+                             vector
+                             gis/->fcoll
+                             (gis/calc-buffer cell-radius-m)
+                             gis/->feature
+                             vector
+                             gis/->fcoll)
+              stats (process-cells! search idx-name (vec part) area-fcoll on-error)]
+          (log/info "Batch done:" (pr-str stats)))))))

--- a/webapp/src/clj/lipas/backend/gis.clj
+++ b/webapp/src/clj/lipas/backend/gis.clj
@@ -139,6 +139,30 @@
   (-> (.read (WKTReader. (gf srid)) ^String s)
       (transform-geom srid tm35fin-srid)))
 
+(defn fcoll->tm35fin-geom
+  "GeoJSON FeatureCollection (WGS84) -> JTS geometry in TM35FIN
+  (EPSG:3067), where distances are in meters."
+  ^Geometry [fcoll]
+  (transform-geom (->jts-geom fcoll) srid tm35fin-srid))
+
+(defn tm35fin-point
+  "JTS point from TM35FIN [easting northing]."
+  [[e n]]
+  (.createPoint (gf tm35fin-srid) (Coordinate. e n)))
+
+(defn within-distance?
+  "True when JTS geometry g2 lies within distance-m of g1. Both
+  geometries must be in a metric CRS (e.g. TM35FIN). An envelope
+  prefilter avoids the exact distance computation for far pairs."
+  [^Geometry g1 ^double distance-m ^Geometry g2]
+  (let [e1 (.getEnvelopeInternal g1)
+        e2 (.getEnvelopeInternal g2)]
+    (and (<= (- (.getMinX e1) distance-m) (.getMaxX e2))
+         (<= (.getMinX e2) (+ (.getMaxX e1) distance-m))
+         (<= (- (.getMinY e1) distance-m) (.getMaxY e2))
+         (<= (.getMinY e2) (+ (.getMaxY e1) distance-m))
+         (<= (.distance g1 g2) distance-m))))
+
 (defn transform-crs
   ([geom] (transform-geom geom srid tm35fin-srid))
   ([geom from-crs to-crs]

--- a/webapp/src/clj/lipas/backend/gis.clj
+++ b/webapp/src/clj/lipas/backend/gis.clj
@@ -160,19 +160,24 @@
   "Mean earth radius (meters), same constant spatial4j used."
   6371008.7714)
 
-(defn distance-point
-  "Geodesic (haversine) distance in meters between two points
-  (anything with getX/getY where x=lon, y=lat)."
-  [p1 p2]
-  (let [lat1 (Math/toRadians (.getY p1))
-        lat2 (Math/toRadians (.getY p2))
+(defn haversine
+  "Geodesic (haversine) distance in meters between [lon lat] pairs."
+  [[lon1 lat1] [lon2 lat2]]
+  (let [lat1 (Math/toRadians lat1)
+        lat2 (Math/toRadians lat2)
         sin-dlat (Math/sin (/ (- lat2 lat1) 2))
-        sin-dlon (Math/sin (/ (- (Math/toRadians (.getX p2))
-                                 (Math/toRadians (.getX p1)))
+        sin-dlon (Math/sin (/ (- (Math/toRadians lon2)
+                                 (Math/toRadians lon1))
                               2))
         a (+ (* sin-dlat sin-dlat)
              (* (Math/cos lat1) (Math/cos lat2) sin-dlon sin-dlon))]
     (* 2 earth-mean-radius-m (Math/asin (Math/sqrt (min 1.0 a))))))
+
+(defn distance-point
+  "Geodesic (haversine) distance in meters between two points
+  (anything with getX/getY where x=lon, y=lat)."
+  [p1 p2]
+  (haversine [(.getX p1) (.getY p1)] [(.getX p2) (.getY p2)]))
 
 (defn nearest-points [g1 g2]
   (DistanceOp/nearestPoints g1 g2))

--- a/webapp/src/clj/lipas/backend/osrm.clj
+++ b/webapp/src/clj/lipas/backend/osrm.clj
@@ -56,9 +56,14 @@
    :socket-timeout 30000 ; 30 seconds for response
    :connection-request-timeout 10000 ; 10 seconds to lease from the pool
    :connection-manager connection-manager
-   ;; OSRM GETs are idempotent - retry once on transient IO failures
-   ;; (e.g. a stale keep-alive connection that slipped past validation)
-   :retry-handler (fn [_ex try-count _ctx] (< try-count 2))
+   ;; OSRM GETs are idempotent - retry once on connection-establishment
+   ;; failures (e.g. a stale keep-alive connection that slipped past
+   ;; validation). Deliberately NOT on SocketTimeoutException: retrying
+   ;; a slow request doubles the load on a server that is still
+   ;; computing the abandoned response.
+   :retry-handler (fn [ex try-count _ctx]
+                    (and (< try-count 2)
+                         (not (instance? java.net.SocketTimeoutException ex))))
    ;; Standard options
    :decompress-body true ; OSRM typically uses gzip
    :accept :json
@@ -96,8 +101,13 @@
 
   `:cache?` (default true) controls the URL-keyed TTL cache. Batch
   callers issuing large one-off table requests should pass false so
-  multi-kB URLs don't churn the cache."
-  [{:keys [sources destinations cache?] :or {cache? true} :as m}]
+  multi-kB URLs don't churn the cache.
+
+  `:socket-timeout-ms` overrides the default 30s response timeout -
+  large table matrices (especially the foot profile) can legitimately
+  take longer to compute."
+  [{:keys [sources destinations cache? socket-timeout-ms]
+    :or {cache? true} :as m}]
   (when (and (seq sources) (seq destinations))
     (let [url (make-url m)]
       (if (and cache? (cache/has? @osrm-cache url))
@@ -112,8 +122,10 @@
           (when cache?
             (swap! cache-stats update :misses inc))
           (swap! request-stats update :requests inc)
-          (let [response (try
-                           (client/get url http-options)
+          (let [opts (cond-> http-options
+                       socket-timeout-ms (assoc :socket-timeout socket-timeout-ms))
+                response (try
+                           (client/get url opts)
                            ;; :throw-exceptions false only suppresses
                            ;; status exceptions - connection-level
                            ;; failures still throw

--- a/webapp/src/clj/lipas/backend/osrm.clj
+++ b/webapp/src/clj/lipas/backend/osrm.clj
@@ -2,6 +2,7 @@
   (:require
    [cemerick.url :as url]
    [clj-http.client :as client]
+   [clj-http.conn-mgr :as conn-mgr]
    [clojure.core.cache :as cache]
    [clojure.string :as str]
    [environ.core :refer [env]]
@@ -29,13 +30,21 @@
 (defonce cache-stats
   (atom {:hits 0 :misses 0}))
 
+(defonce ^{:doc "Reusable connection pool shared by all OSRM requests.
+  Keep-alive connections avoid a fresh TCP handshake per request, which
+  dominates latency when many table requests are made in sequence."}
+  connection-manager
+  (conn-mgr/make-reusable-conn-manager
+   {:timeout 30 ; Idle connection TTL (seconds)
+    :threads 12 ; Max connections total
+    :default-per-route 4})) ; Per profile server (car/bicycle/foot)
+
 (def http-options
   {:as :json ; Parse JSON directly, skipping string intermediate
    :throw-exceptions false ; Return error responses instead of throwing
    :connection-timeout 2000 ; 2 seconds to establish connection
    :socket-timeout 30000 ; 30 seconds for response
-   ;; Disable connection pooling - create fresh connection each time
-   :connection-manager false
+   :connection-manager connection-manager
    ;; Standard options
    :decompress-body true ; OSRM typically uses gzip
    :accept :json
@@ -67,12 +76,17 @@
                                                  (count destinations))))}))))
 
 (defn get-data
-  [{:keys [sources destinations] :as m}]
+  "Fetch a distance/duration table from OSRM.
+
+  `:cache?` (default true) controls the URL-keyed TTL cache. Batch
+  callers issuing large one-off table requests should pass false so
+  multi-kB URLs don't churn the cache."
+  [{:keys [sources destinations cache?] :or {cache? true} :as m}]
   (when (and (seq sources) (seq destinations))
     (let [url (make-url m)
-          cached-value (cache/lookup @osrm-cache url)]
+          cached-value (when cache? (cache/lookup @osrm-cache url))]
 
-      (if (cache/has? @osrm-cache url)
+      (if (and cache? (cache/has? @osrm-cache url))
         ;; Cache hit
         (do
           (swap! cache-stats update :hits inc)
@@ -88,7 +102,8 @@
               ;; Success - cache and return
               (= 200 (:status response))
               (let [result (:body response)]
-                (swap! osrm-cache cache/miss url result)
+                (when cache?
+                  (swap! osrm-cache cache/miss url result))
                 result)
 
               ;; Error response

--- a/webapp/src/clj/lipas/backend/osrm.clj
+++ b/webapp/src/clj/lipas/backend/osrm.clj
@@ -26,25 +26,39 @@
   This allows buffer for 3 profiles x socket-timeout."
   45000)
 
-;; Cache statistics
+;; Cache statistics (cached lookups only)
 (defonce cache-stats
   (atom {:hits 0 :misses 0}))
 
+;; Actual HTTP requests issued, cached or not
+(defonce request-stats
+  (atom {:requests 0}))
+
 (defonce ^{:doc "Reusable connection pool shared by all OSRM requests.
   Keep-alive connections avoid a fresh TCP handshake per request, which
-  dominates latency when many table requests are made in sequence."}
+  dominates latency when many table requests are made in sequence.
+  Sized so interactive analyses don't queue behind batch precompute
+  jobs (which hold at most one connection per profile host at a time)."}
   connection-manager
-  (conn-mgr/make-reusable-conn-manager
-   {:timeout 30 ; Idle connection TTL (seconds)
-    :threads 12 ; Max connections total
-    :default-per-route 4})) ; Per profile server (car/bicycle/foot)
+  (doto (conn-mgr/make-reusable-conn-manager
+         {:timeout 30 ; Idle connection TTL (seconds)
+          :threads 30 ; Max connections total
+          :default-per-route 10}) ; Per profile server (car/bicycle/foot)
+    ;; Health-check connections that sat idle >1s before reuse, so a
+    ;; keep-alive connection the server closed doesn't surface as an
+    ;; IOException mid-request
+    (.setValidateAfterInactivity 1000)))
 
 (def http-options
   {:as :json ; Parse JSON directly, skipping string intermediate
    :throw-exceptions false ; Return error responses instead of throwing
    :connection-timeout 2000 ; 2 seconds to establish connection
    :socket-timeout 30000 ; 30 seconds for response
+   :connection-request-timeout 10000 ; 10 seconds to lease from the pool
    :connection-manager connection-manager
+   ;; OSRM GETs are idempotent - retry once on transient IO failures
+   ;; (e.g. a stale keep-alive connection that slipped past validation)
+   :retry-handler (fn [_ex try-count _ctx] (< try-count 2))
    ;; Standard options
    :decompress-body true ; OSRM typically uses gzip
    :accept :json
@@ -76,29 +90,39 @@
                                                  (count destinations))))}))))
 
 (defn get-data
-  "Fetch a distance/duration table from OSRM.
+  "Fetch a distance/duration table from OSRM. Returns nil on any
+  failure (HTTP error status, connection failure, timeout) so callers
+  degrade by omitting the profile instead of blowing up mid-batch.
 
   `:cache?` (default true) controls the URL-keyed TTL cache. Batch
   callers issuing large one-off table requests should pass false so
   multi-kB URLs don't churn the cache."
   [{:keys [sources destinations cache?] :or {cache? true} :as m}]
   (when (and (seq sources) (seq destinations))
-    (let [url (make-url m)
-          cached-value (when cache? (cache/lookup @osrm-cache url))]
-
+    (let [url (make-url m)]
       (if (and cache? (cache/has? @osrm-cache url))
         ;; Cache hit
         (do
           (swap! cache-stats update :hits inc)
           (log/debug "OSRM cache hit for URL:" url)
-          cached-value)
+          (cache/lookup @osrm-cache url))
 
         ;; Cache miss - fetch and cache
         (do
-          (swap! cache-stats update :misses inc)
-          (log/debug "OSRM cache miss for URL:" url)
-          (let [response (client/get url http-options)]
+          (when cache?
+            (swap! cache-stats update :misses inc))
+          (swap! request-stats update :requests inc)
+          (let [response (try
+                           (client/get url http-options)
+                           ;; :throw-exceptions false only suppresses
+                           ;; status exceptions - connection-level
+                           ;; failures still throw
+                           (catch java.io.IOException e
+                             (log/error "OSRM connection error:" (ex-message e))
+                             nil))]
             (cond
+              (nil? response) nil
+
               ;; Success - cache and return
               (= 200 (:status response))
               (let [result (:body response)]
@@ -112,28 +136,27 @@
                 (log/error "OSRM error:" (:status response) (:body response))
                 nil)
 
-              ;; Connection error or timeout
-              (:error response)
-              (do
-                (log/error "OSRM connection error:" (:error response))
-                nil)
-
               :else nil)))))))
 
 (defn get-distances-and-travel-times
   "Fetch distances and travel times for multiple profiles in parallel.
-  Returns partial results if some profiles timeout (logs warning instead of throwing)."
-  [{:keys [profiles]
-    :or {profiles [:car :bicycle :foot]}
+  Returns partial results if some profiles fail or time out (logs a
+  warning instead of throwing)."
+  [{:keys [profiles timeout-ms]
+    :or {profiles [:car :bicycle :foot]
+         timeout-ms osrm-parallel-timeout-ms}
     :as m}]
   (let [futures (->> profiles
                      (mapv (fn [p] [p (future (get-data (assoc m :profile p)))])))]
     (reduce (fn [res [profile f]]
-              (let [result (deref f osrm-parallel-timeout-ms ::timeout)]
+              (let [result (deref f timeout-ms ::timeout)]
                 (cond
                   (= result ::timeout)
+                  ;; Deliberately no future-cancel: interrupting a
+                  ;; request that holds a pooled connection risks
+                  ;; leaking it, and the socket timeout bounds the
+                  ;; request anyway
                   (do
-                    (future-cancel f)
                     (log/warn "OSRM request timed out for profile" profile)
                     res)
 
@@ -164,6 +187,7 @@
   []
   (reset! osrm-cache (cache/ttl-cache-factory {} :ttl (* 5 60 1000)))
   (reset! cache-stats {:hits 0 :misses 0})
+  (reset! request-stats {:requests 0})
   (log/info "OSRM cache cleared"))
 
 (comment

--- a/webapp/src/clj/lipas/search_indexer.clj
+++ b/webapp/src/clj/lipas/search_indexer.clj
@@ -1,9 +1,6 @@
 (ns lipas.search-indexer
   (:require
-   [clojure.core.async :as async]
-   [clojure.data.csv :as csv]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [lipas.backend.api.v1.locations :as legacy-locations]
    [lipas.backend.api.v1.sports-place :as legacy-sports-place]
    [lipas.backend.analysis.diversity :as diversity]
@@ -17,7 +14,6 @@
    [lipas.backend.api.v1.transform :as legacy-transform]
    [lipas.utils :as utils]
    [next.jdbc :as jdbc]
-   [qbits.spandex :as es]
    [taoensso.timbre :as log]))
 
 (def cities (utils/index-by :city-code cities/all))
@@ -179,54 +175,6 @@
                              {:fetch-size 500}))]
         (flush-analytics-batch! client idx-name type-code tail)))))
 
-(defn read-csv->maps* [path]
-  (->> path
-       slurp
-       csv/read-csv
-       utils/csv-data->maps))
-
-(defn read-csv->maps [path]
-  (->> path
-       read-csv->maps*
-       (map walk/keywordize-keys)))
-
-(def dist-km 2)
-
-(def lol-atom (atom []))
-
-(defn index-diversity!
-  [search csv-path index-name]
-  (log/info "Starting to index diversity")
-
-  (log/info "Creating index" index-name)
-  #_(search/create-index! search index-name diversity/mappings)
-  (log/info "Index created!")
-
-  (log/info "Parsing grid data")
-  (let [grid-data (read-csv->maps csv-path)
-        on-error prn
-
-        {:keys [input-ch output-ch]}
-        (es/bulk-chan search {:flush-threshold 100
-                              :flush-interval 5000
-                              :max-concurrent-requests 3})]
-
-    (log/info "Grid data parsed. Starting to calculate and index")
-
-    (doseq [batch (partition-all 300 grid-data)]
-      (log/info "Processing new batch of 300")
-      (doseq [grid batch]
-        (->> (diversity/process-grid-item search dist-km grid on-error)
-             (search/wrap-es-bulk index-name nil :grd_id)
-             (async/put! input-ch)))
-
-      (log/info "Waiting for batch indexing to finish...")
-      (async/<!! output-ch)
-      (async/<!! output-ch)
-      (async/<!! output-ch))
-
-    (log/info "Diversity indexing DONE!")))
-
 (defn main
   ([db search mode]
    (main nil db search mode))
@@ -279,9 +227,7 @@
         search (:lipas/search system)]
     (try
       (if (= "diversity" mode)
-        (let [csv-path (second args)
-              idx-name (str "diversity-" (search/gen-idx-name))]
-          (index-diversity! (:client search) csv-path idx-name))
+        (diversity/seed-new-grid-from-csv! search (second args))
         (main system db search mode))
       (catch Exception ex
         (log/error ex "Something terrible happened while indexing" mode "!"))
@@ -303,9 +249,7 @@
 
   (def csv-path "/Users/tipo/lipas/aineistot/vaestoruutu_250m/vaestoruutu_250m_2020_kp.csv")
 
-  (index-diversity! search csv-path "poni705")
-  (count @lol-atom)
-  (second @lol-atom)
+  (diversity/seed-new-grid-from-csv! search csv-path)
 
   (def dada (core/get-sports-sites-by-type-code db 4401))
   (first dada)

--- a/webapp/test/clj/lipas/backend/analysis/diversity_simple_test.clj
+++ b/webapp/test/clj/lipas/backend/analysis/diversity_simple_test.clj
@@ -28,7 +28,7 @@
                             :durations [[800.0 450.0 1000.0]]}
                   :foot {:distances [[1900.0 1100.0 900.0]]
                          :durations [[1368.0 792.0 648.0]]}}
-          result (diversity/site-osrm-mins tables 0 [0 1 2])]
+          result (diversity/site-osrm-mins tables {} 0 [0 1 2])]
       (is (= 1234.5 (-> result :car :distance-m)))
       (is (= 180.2 (-> result :car :duration-s)))
       (is (= 1500.0 (-> result :bicycle :distance-m)))
@@ -39,66 +39,83 @@
   (testing "Only the site's own columns are considered"
     (let [tables {:car {:distances [[100.0 900.0 50.0]]
                         :durations [[10.0 90.0 5.0]]}}
-          result (diversity/site-osrm-mins tables 0 [0 1])]
+          result (diversity/site-osrm-mins tables {} 0 [0 1])]
       (is (= 100.0 (-> result :car :distance-m)))
       (is (= 10.0 (-> result :car :duration-s)))))
 
   (testing "Row selected by cell index"
     (let [tables {:car {:distances [[100.0] [200.0]]
                         :durations [[10.0] [20.0]]}}]
-      (is (= 200.0 (-> (diversity/site-osrm-mins tables 1 [0]) :car :distance-m)))))
+      (is (= 200.0 (-> (diversity/site-osrm-mins tables {} 1 [0]) :car :distance-m)))))
 
   (testing "Min distance and min duration are independent (old apply-mins semantics)"
     (let [tables {:car {:distances [[2000.0 1000.0]]
                         :durations [[100.0 500.0]]}}
-          result (diversity/site-osrm-mins tables 0 [0 1])]
+          result (diversity/site-osrm-mins tables {} 0 [0 1])]
       (is (= 1000.0 (-> result :car :distance-m)))
       (is (= 100.0 (-> result :car :duration-s)))))
 
   (testing "Unroutable destinations (nils) don't crash and yield nil mins"
     (let [tables {:car {:distances [[nil nil]]
                         :durations [[nil nil]]}}
-          result (diversity/site-osrm-mins tables 0 [0 1])]
+          result (diversity/site-osrm-mins tables {} 0 [0 1])]
       (is (= {:distance-m nil :duration-s nil} (:car result)))))
 
+  (testing "A profile whose failed columns touch the site is omitted for the site"
+    (let [tables {:car {:distances [[100.0 nil]] :durations [[10.0 nil]]}
+                  :foot {:distances [[120.0 nil]] :durations [[90.0 nil]]}}
+          failed-cols {:foot (sorted-set 1)}
+          result (diversity/site-osrm-mins tables failed-cols 0 [0 1])]
+      ;; car untouched by failures
+      (is (= 100.0 (-> result :car :distance-m)))
+      ;; foot's failed chunk covers col 1 -> foot omitted for this site
+      (is (not (contains? result :foot))))
+
+    (testing "but kept for sites whose columns avoid the failed chunk"
+      (let [tables {:foot {:distances [[120.0 nil]] :durations [[90.0 nil]]}}
+            failed-cols {:foot (sorted-set 1)}
+            result (diversity/site-osrm-mins tables failed-cols 0 [0])]
+        (is (= 120.0 (-> result :foot :distance-m))))))
+
   (testing "No profile data yields nil"
-    (is (nil? (diversity/site-osrm-mins {} 0 [0])))))
+    (is (nil? (diversity/site-osrm-mins {} {} 0 [0])))))
+
+(defn- point-site [id type-code coords]
+  {:_id id
+   :_source {:status "active"
+             :type {:type-code type-code}
+             :search-meta
+             {:location
+              {:simple-geoms
+               {:type "FeatureCollection"
+                :features
+                [{:type "Feature"
+                  :geometry {:type "Point"
+                             :coordinates coords}}]}}}}})
+
+(defn- linestring-site [id type-code coords]
+  (assoc-in (point-site id type-code nil)
+            [:_source :search-meta :location :simple-geoms :features 0 :geometry]
+            {:type "LineString" :coordinates coords}))
+
+(defn- ->cell-point [coords]
+  (gis/tm35fin-point (gis/wgs84->tm35fin-no-wrap coords)))
 
 (deftest prepare-site-entry-test
-  (testing "Point site yields dest strings and numeric coords"
-    (let [site {:_id "site-1"
-                :_source {:status "active"
-                          :type {:type-code 1520}
-                          :search-meta
-                          {:location
-                           {:simple-geoms
-                            {:type "FeatureCollection"
-                             :features
-                             [{:type "Feature"
-                               :geometry {:type "Point"
-                                          :coordinates [24.9 60.17]}}]}}}}}
-          entry (diversity/prepare-site-entry site prn)]
+  (testing "Point site yields dest strings and a metric geometry"
+    (let [entry (diversity/prepare-site-entry (point-site "site-1" 1520 [24.9 60.17]) prn)]
       (is (= "site-1" (:id entry)))
       (is (= 1520 (:type-code entry)))
       (is (= "active" (:status entry)))
       (is (= ["24.9,60.17"] (:dests entry)))
-      (is (= [[24.9 60.17]] (:coords entry)))))
+      (is (some? (:geom-3067 entry)))))
 
   (testing "Duplicate vertices are deduped"
-    (let [site {:_id "site-2"
-                :_source {:status "active"
-                          :type {:type-code 4401}
-                          :search-meta
-                          {:location
-                           {:simple-geoms
-                            {:type "FeatureCollection"
-                             :features
-                             [{:type "Feature"
-                               :geometry {:type "LineString"
-                                          :coordinates [[24.9 60.17]
-                                                        [24.91 60.18]
-                                                        [24.9 60.17]]}}]}}}}}
-          entry (diversity/prepare-site-entry site prn)]
+    (let [entry (diversity/prepare-site-entry
+                 (linestring-site "site-2" 4401 [[24.9 60.17]
+                                                 [24.91 60.18]
+                                                 [24.9 60.17]])
+                 prn)]
       (is (= ["24.9,60.17" "24.91,60.18"] (:dests entry)))))
 
   (testing "Site without usable geometry yields nil"
@@ -107,11 +124,10 @@
                                               #(swap! errors conj %)))))))
 
 (deftest assign-sites-test
-  (let [cell [24.94 60.16]
-        near-site {:coords [[24.945 60.161]]} ; ~300 m
-        far-site {:coords [[25.05 60.16]]} ; ~6 km
-        multi-vertex-site {:coords [[25.05 60.16] ; far vertex
-                                    [24.95 60.162]]}] ; near vertex
+  (let [cell (->cell-point [24.94 60.16])
+        entry #(diversity/prepare-site-entry % prn)
+        near-site (entry (point-site "near" 1520 [24.945 60.161]))   ; ~300 m
+        far-site (entry (point-site "far" 1520 [25.05 60.16]))]      ; ~6 km
 
     (testing "Site within radius is assigned"
       (is (= [[0]] (diversity/assign-sites [cell] [near-site] 2250))))
@@ -119,16 +135,21 @@
     (testing "Site outside radius is not assigned"
       (is (= [[]] (diversity/assign-sites [cell] [far-site] 2250))))
 
-    (testing "One near vertex suffices"
-      (is (= [[0]] (diversity/assign-sites [cell] [multi-vertex-site] 2250))))
-
     (testing "Assignments align with cell order"
-      (let [far-cell [26.0 61.0]]
+      (let [far-cell (->cell-point [26.0 61.0])]
         (is (= [[0] []]
                (diversity/assign-sites [cell far-cell] [near-site] 2250)))))
 
-    (testing "Radius boundary respects haversine distance"
-      (let [d (gis/haversine [24.94 60.16] [24.945 60.161])]
+    (testing "Distance is to the geometry, not just its vertices"
+      ;; Long straight linestring passing right by the cell; both
+      ;; vertices are ~3km away. The old per-cell ES geo query included
+      ;; such sites and so must the assignment prefilter.
+      (let [trail (entry (linestring-site "trail" 4401 [[24.88 60.16]
+                                                        [25.00 60.16]]))]
+        (is (= [[0]] (diversity/assign-sites [cell] [trail] 2250)))))
+
+    (testing "Radius boundary respects metric distance"
+      (let [d (.distance (:geom-3067 near-site) cell)]
         (is (= [[0]] (diversity/assign-sites [cell] [near-site] (+ d 1))))
         (is (= [[]] (diversity/assign-sites [cell] [near-site] (- d 1))))))))
 
@@ -152,27 +173,48 @@
 
 (deftest merge-table-chunks-test
   (testing "Columns of consecutive chunks are concatenated per row"
-    (let [merged (diversity/merge-table-chunks
-                  [{:car {:distances [[1 2] [3 4]] :durations [[10 20] [30 40]]}}
-                   {:car {:distances [[5] [6]] :durations [[50] [60]]}}])]
-      (is (= [[1 2 5] [3 4 6]] (-> merged :car :distances)))
-      (is (= [[10 20 50] [30 40 60]] (-> merged :car :durations)))))
+    (let [{:keys [tables failed-cols]}
+          (diversity/merge-table-chunks
+           [{:car {:distances [[1 2] [3 4]] :durations [[10 20] [30 40]]}}
+            {:car {:distances [[5] [6]] :durations [[50] [60]]}}]
+           [2 1] 2)]
+      (is (= [[1 2 5] [3 4 6]] (-> tables :car :distances)))
+      (is (= [[10 20 50] [30 40 60]] (-> tables :car :durations)))
+      (is (= {} failed-cols))))
 
   (testing "Single chunk passes through"
-    (let [merged (diversity/merge-table-chunks
-                  [{:foot {:distances [[1.0]] :durations [[2.0]]}}])]
-      (is (= [[1.0]] (-> merged :foot :distances)))
-      (is (= [[2.0]] (-> merged :foot :durations)))))
+    (let [{:keys [tables failed-cols]}
+          (diversity/merge-table-chunks
+           [{:foot {:distances [[1.0]] :durations [[2.0]]}}]
+           [1] 1)]
+      (is (= [[1.0]] (-> tables :foot :distances)))
+      (is (= [[2.0]] (-> tables :foot :durations)))
+      (is (= {} failed-cols))))
 
-  (testing "Profile missing from any chunk is dropped entirely"
-    (let [merged (diversity/merge-table-chunks
-                  [{:car {:distances [[1]] :durations [[10]]}
-                    :foot {:distances [[1]] :durations [[10]]}}
-                   {:car {:distances [[2]] :durations [[20]]}}])]
-      (is (= #{:car} (set (keys merged))))))
+  (testing "A chunk missing a profile is nil-filled and its columns reported"
+    (let [{:keys [tables failed-cols]}
+          (diversity/merge-table-chunks
+           [{:car {:distances [[1 2]] :durations [[10 20]]}
+             :foot {:distances [[1 2]] :durations [[10 20]]}}
+            {:car {:distances [[3]] :durations [[30]]}}]
+           [2 1] 1)]
+      (is (= [[1 2 3]] (-> tables :car :distances)))
+      ;; foot kept with nil-filled columns for the failed chunk
+      (is (= [[1 2 nil]] (-> tables :foot :distances)))
+      (is (= [[10 20 nil]] (-> tables :foot :durations)))
+      (is (= {:foot #{2}} (update-vals failed-cols set)))))
 
-  (testing "All profiles missing yields empty map"
-    (is (= {} (diversity/merge-table-chunks [{}])))))
+  (testing "Profile missing from every chunk is omitted entirely"
+    (let [{:keys [tables failed-cols]}
+          (diversity/merge-table-chunks
+           [{:car {:distances [[1]] :durations [[10]]}} {}]
+           [1 1] 1)]
+      (is (= #{:car} (set (keys tables))))
+      (is (= {:car #{1}} (update-vals failed-cols set)))))
+
+  (testing "All profiles missing yields empty maps"
+    (is (= {:tables {} :failed-cols {}}
+           (diversity/merge-table-chunks [{}] [1] 1)))))
 
 (deftest resolve-dests-test
   (testing "Resolve dests extracts coordinates correctly"

--- a/webapp/test/clj/lipas/backend/analysis/diversity_simple_test.clj
+++ b/webapp/test/clj/lipas/backend/analysis/diversity_simple_test.clj
@@ -2,8 +2,8 @@
   "Simple tests for diversity analysis that work without full system setup"
   (:require [clojure.test :refer [deftest testing is]]
             [lipas.backend.analysis.diversity :as diversity]
+            [lipas.backend.gis :as gis]
             [lipas.backend.search :as search]
-            [lipas.backend.osrm :as osrm]
             [lipas.schema.diversity :as diversity-schema]
             [malli.core :as m]
             [malli.error :as me]
@@ -11,35 +11,168 @@
 
 ;;; Pure function tests ;;;
 
-(deftest apply-mins-test
-  (testing "Apply mins correctly extracts minimum distances and durations"
-    ;; Test with single destination
-    (let [single-dest {:car {:distances [[1234.5]] :durations [[180.2]]}
-                       :bicycle {:distances [[1500.0]] :durations [[450.0]]}
-                       :foot {:distances [[1100.0]] :durations [[792.0]]}}
-          result (diversity/apply-mins single-dest)]
-      (is (= 1234.5 (-> result :car :distance-m)))
-      (is (= 180.2 (-> result :car :duration-s)))
-      (is (= 1500.0 (-> result :bicycle :distance-m)))
-      (is (= 450.0 (-> result :bicycle :duration-s)))
-      (is (= 1100.0 (-> result :foot :distance-m)))
-      (is (= 792.0 (-> result :foot :duration-s))))
+(deftest min-finite-test
+  (testing "Minimum over non-nil values"
+    (is (= 3 (diversity/min-finite [5 nil 3])))
+    (is (= 900.0 (diversity/min-finite [1900.0 1100.0 900.0])))
+    (is (= 1234.5 (diversity/min-finite [1234.5]))))
+  (testing "Nil when no finite values (unroutable destinations)"
+    (is (nil? (diversity/min-finite [nil nil])))
+    (is (nil? (diversity/min-finite [])))))
 
-    ;; Test with multiple destinations - should pick minimum for each mode
-    (let [multi-dest {:car {:distances [[2000.0 1234.5 3000.0]]
-                            :durations [[300.0 180.2 400.0]]}
-                      :bicycle {:distances [[2500.0 1500.0 3500.0]]
-                                :durations [[800.0 450.0 1000.0]]}
-                      :foot {:distances [[1900.0 1100.0 900.0]]
-                             :durations [[1368.0 792.0 648.0]]}}
-          result (diversity/apply-mins multi-dest)]
-      ;; Each mode takes its minimum value
+(deftest site-osrm-mins-test
+  (testing "Per-profile minimums over the site's matrix columns"
+    (let [tables {:car {:distances [[2000.0 1234.5 3000.0]]
+                        :durations [[300.0 180.2 400.0]]}
+                  :bicycle {:distances [[2500.0 1500.0 3500.0]]
+                            :durations [[800.0 450.0 1000.0]]}
+                  :foot {:distances [[1900.0 1100.0 900.0]]
+                         :durations [[1368.0 792.0 648.0]]}}
+          result (diversity/site-osrm-mins tables 0 [0 1 2])]
       (is (= 1234.5 (-> result :car :distance-m)))
       (is (= 180.2 (-> result :car :duration-s)))
       (is (= 1500.0 (-> result :bicycle :distance-m)))
       (is (= 450.0 (-> result :bicycle :duration-s)))
       (is (= 900.0 (-> result :foot :distance-m)))
-      (is (= 648.0 (-> result :foot :duration-s))))))
+      (is (= 648.0 (-> result :foot :duration-s)))))
+
+  (testing "Only the site's own columns are considered"
+    (let [tables {:car {:distances [[100.0 900.0 50.0]]
+                        :durations [[10.0 90.0 5.0]]}}
+          result (diversity/site-osrm-mins tables 0 [0 1])]
+      (is (= 100.0 (-> result :car :distance-m)))
+      (is (= 10.0 (-> result :car :duration-s)))))
+
+  (testing "Row selected by cell index"
+    (let [tables {:car {:distances [[100.0] [200.0]]
+                        :durations [[10.0] [20.0]]}}]
+      (is (= 200.0 (-> (diversity/site-osrm-mins tables 1 [0]) :car :distance-m)))))
+
+  (testing "Min distance and min duration are independent (old apply-mins semantics)"
+    (let [tables {:car {:distances [[2000.0 1000.0]]
+                        :durations [[100.0 500.0]]}}
+          result (diversity/site-osrm-mins tables 0 [0 1])]
+      (is (= 1000.0 (-> result :car :distance-m)))
+      (is (= 100.0 (-> result :car :duration-s)))))
+
+  (testing "Unroutable destinations (nils) don't crash and yield nil mins"
+    (let [tables {:car {:distances [[nil nil]]
+                        :durations [[nil nil]]}}
+          result (diversity/site-osrm-mins tables 0 [0 1])]
+      (is (= {:distance-m nil :duration-s nil} (:car result)))))
+
+  (testing "No profile data yields nil"
+    (is (nil? (diversity/site-osrm-mins {} 0 [0])))))
+
+(deftest prepare-site-entry-test
+  (testing "Point site yields dest strings and numeric coords"
+    (let [site {:_id "site-1"
+                :_source {:status "active"
+                          :type {:type-code 1520}
+                          :search-meta
+                          {:location
+                           {:simple-geoms
+                            {:type "FeatureCollection"
+                             :features
+                             [{:type "Feature"
+                               :geometry {:type "Point"
+                                          :coordinates [24.9 60.17]}}]}}}}}
+          entry (diversity/prepare-site-entry site prn)]
+      (is (= "site-1" (:id entry)))
+      (is (= 1520 (:type-code entry)))
+      (is (= "active" (:status entry)))
+      (is (= ["24.9,60.17"] (:dests entry)))
+      (is (= [[24.9 60.17]] (:coords entry)))))
+
+  (testing "Duplicate vertices are deduped"
+    (let [site {:_id "site-2"
+                :_source {:status "active"
+                          :type {:type-code 4401}
+                          :search-meta
+                          {:location
+                           {:simple-geoms
+                            {:type "FeatureCollection"
+                             :features
+                             [{:type "Feature"
+                               :geometry {:type "LineString"
+                                          :coordinates [[24.9 60.17]
+                                                        [24.91 60.18]
+                                                        [24.9 60.17]]}}]}}}}}
+          entry (diversity/prepare-site-entry site prn)]
+      (is (= ["24.9,60.17" "24.91,60.18"] (:dests entry)))))
+
+  (testing "Site without usable geometry yields nil"
+    (let [errors (atom [])]
+      (is (nil? (diversity/prepare-site-entry {:_id "broken" :_source {}}
+                                              #(swap! errors conj %)))))))
+
+(deftest assign-sites-test
+  (let [cell [24.94 60.16]
+        near-site {:coords [[24.945 60.161]]} ; ~300 m
+        far-site {:coords [[25.05 60.16]]} ; ~6 km
+        multi-vertex-site {:coords [[25.05 60.16] ; far vertex
+                                    [24.95 60.162]]}] ; near vertex
+
+    (testing "Site within radius is assigned"
+      (is (= [[0]] (diversity/assign-sites [cell] [near-site] 2250))))
+
+    (testing "Site outside radius is not assigned"
+      (is (= [[]] (diversity/assign-sites [cell] [far-site] 2250))))
+
+    (testing "One near vertex suffices"
+      (is (= [[0]] (diversity/assign-sites [cell] [multi-vertex-site] 2250))))
+
+    (testing "Assignments align with cell order"
+      (let [far-cell [26.0 61.0]]
+        (is (= [[0] []]
+               (diversity/assign-sites [cell far-cell] [near-site] 2250)))))
+
+    (testing "Radius boundary respects haversine distance"
+      (let [d (gis/haversine [24.94 60.16] [24.945 60.161])]
+        (is (= [[0]] (diversity/assign-sites [cell] [near-site] (+ d 1))))
+        (is (= [[]] (diversity/assign-sites [cell] [near-site] (- d 1))))))))
+
+(deftest index-dests-test
+  (let [entries [{:dests ["1,1" "2,2"]}
+                 {:dests ["2,2" "3,3"]}
+                 {:dests ["4,4"]}]]
+
+    (testing "Shared destinations get a single column"
+      (let [[dests site->cols] (diversity/index-dests entries [0 1 2])]
+        (is (= ["1,1" "2,2" "3,3" "4,4"] dests))
+        (is (= {0 [0 1] 1 [1 2] 2 [3]} site->cols))))
+
+    (testing "Only requested sites are indexed"
+      (let [[dests site->cols] (diversity/index-dests entries [2])]
+        (is (= ["4,4"] dests))
+        (is (= {2 [0]} site->cols))))
+
+    (testing "Empty input"
+      (is (= [[] {}] (diversity/index-dests entries []))))))
+
+(deftest merge-table-chunks-test
+  (testing "Columns of consecutive chunks are concatenated per row"
+    (let [merged (diversity/merge-table-chunks
+                  [{:car {:distances [[1 2] [3 4]] :durations [[10 20] [30 40]]}}
+                   {:car {:distances [[5] [6]] :durations [[50] [60]]}}])]
+      (is (= [[1 2 5] [3 4 6]] (-> merged :car :distances)))
+      (is (= [[10 20 50] [30 40 60]] (-> merged :car :durations)))))
+
+  (testing "Single chunk passes through"
+    (let [merged (diversity/merge-table-chunks
+                  [{:foot {:distances [[1.0]] :durations [[2.0]]}}])]
+      (is (= [[1.0]] (-> merged :foot :distances)))
+      (is (= [[2.0]] (-> merged :foot :durations)))))
+
+  (testing "Profile missing from any chunk is dropped entirely"
+    (let [merged (diversity/merge-table-chunks
+                  [{:car {:distances [[1]] :durations [[10]]}
+                    :foot {:distances [[1]] :durations [[10]]}}
+                   {:car {:distances [[2]] :durations [[20]]}}])]
+      (is (= #{:car} (set (keys merged))))))
+
+  (testing "All profiles missing yields empty map"
+    (is (= {} (diversity/merge-table-chunks [{}])))))
 
 (deftest resolve-dests-test
   (testing "Resolve dests extracts coordinates correctly"
@@ -83,53 +216,6 @@
       (is (= 60 (:population-age-65- result)))
       (is (number? (:diversity-idx-mean result)))
       (is (number? (:diversity-idx-median result))))))
-
-(deftest process-grid-item-structure-test
-  (testing "Process grid item maintains data structure"
-    (with-redefs [lipas.backend.analysis.common/get-sports-site-data
-                  (fn [_ _ _ _ _]
-                    {:hits [{:_id "site-1"
-                             :_source {:name "Test Site"
-                                       :status "active"
-                                       :type {:type-code 1520}
-                                       :search-meta
-                                       {:location
-                                        {:simple-geoms
-                                         {:features
-                                          [{:geometry {:coordinates [24.95 60.17]
-                                                       :type "Point"}
-                                            :type "Feature"}]}}}}}]})
-                  osrm/get-data
-                  (fn [{:keys [profile]}]
-                    (case profile
-                      :car {:distances [[1000.0]] :durations [[120.0]]}
-                      :bicycle {:distances [[1200.0]] :durations [[360.0]]}
-                      :foot {:distances [[950.0]] :durations [[684.0]]}
-                      nil))]
-
-      (let [grid-item {:grd_id "test-123"
-                       :WKT "POINT (24.9477 60.1678)"
-                       :vaesto "100"
-                       :extra-field "preserved"}
-            mock-search {:client nil :indices {}}
-            result (diversity/process-grid-item mock-search 2 grid-item prn)]
-
-        ;; Original fields preserved
-        (is (= "test-123" (:grd_id result)))
-        (is (= "100" (:vaesto result)))
-        (is (= "preserved" (:extra-field result)))
-
-        ;; Sports sites added
-        (is (sequential? (:sports-sites result)))
-        (is (= 1 (count (:sports-sites result))))
-
-        ;; Check site structure
-        (let [site (first (:sports-sites result))]
-          (is (= "site-1" (:id site)))
-          (is (= 1520 (:type-code site)))
-          (is (= "active" (:status site)))
-          (is (= 1000.0 (-> site :osrm :car :distance-m)))
-          (is (= 120.0 (-> site :osrm :car :duration-s))))))))
 
 (deftest bulk-data-transformation-test
   (testing "Grid items are correctly transformed for bulk indexing"

--- a/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
+++ b/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
@@ -1,13 +1,13 @@
 (ns lipas.backend.analysis.diversity-test
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is use-fixtures]]
             [integrant.core :as ig]
             [lipas.backend.analysis.diversity :as diversity]
             [lipas.backend.config :as config]
             [lipas.backend.gis :as gis]
-            [lipas.backend.search :as search]
             [lipas.backend.osrm :as osrm]
-            [lipas.test-utils :as test-utils]
-            [taoensso.timbre :as log]))
+            [lipas.backend.search :as search]
+            [lipas.test-utils :as test-utils]))
 
 ;;; Test system setup ;;;
 ;; Note: This test only needs :lipas/search component, not the full system
@@ -116,18 +116,6 @@
                 {:type "Point"
                  :coordinates [24.950 60.169]}}}}}])
 
-(def test-osrm-responses
-  "Realistic OSRM API responses"
-  {:car {:code "Ok"
-         :distances [[2036.6 2050.3 2500.1]]
-         :durations [[338.4 340.2 380.5]]}
-   :bicycle {:code "Ok"
-             :distances [[2350.0 2360.5 2800.2]]
-             :durations [[763.0 765.1 820.3]]}
-   :foot {:code "Ok"
-          :distances [[1987.2 2000.1 2400.3]]
-          :durations [[1432.6 1440.2 1600.1]]}})
-
 ;;; Helper functions for seeding test data ;;;
 
 (defn- seed-test-data! [search]
@@ -148,20 +136,79 @@
 
 ;;; Mock OSRM for deterministic tests ;;;
 
-(defn mock-osrm-call
-  "Mock for osrm/get-data that returns profile-specific data"
-  [{:keys [profile] :as _params}]
-  (get test-osrm-responses profile))
+(def profile-factors
+  "Route distance = haversine distance * factor in the mock, so expected
+  minimums can be computed independently in assertions."
+  {:car 1.0 :bicycle 1.1 :foot 1.25})
+
+(def profile-speeds-m-s
+  {:car 10.0 :bicycle 5.0 :foot 1.4})
+
+(defn- parse-coord [s]
+  (mapv #(Double/parseDouble %) (str/split s #",")))
+
+(defn mock-osrm-matrix
+  "Matrix-shaped mock for osrm/get-data: distances[i][j] is the haversine
+  distance from source i to destination j scaled by a per-profile factor."
+  [{:keys [profile sources destinations] :as _params}]
+  (let [factor (profile-factors profile)
+        speed (profile-speeds-m-s profile)]
+    {:code "Ok"
+     :distances (mapv (fn [src]
+                        (mapv (fn [dest]
+                                (* factor (gis/haversine (parse-coord src)
+                                                         (parse-coord dest))))
+                              destinations))
+                      sources)
+     :durations (mapv (fn [src]
+                        (mapv (fn [dest]
+                                (/ (* factor (gis/haversine (parse-coord src)
+                                                            (parse-coord dest)))
+                                   speed))
+                              destinations))
+                      sources)}))
+
+(def test-point-fcoll
+  (gis/->fcoll
+   [(gis/->feature {:type "Point"
+                    :coordinates [24.9477 60.1678]})]))
+
+(defn- run-recalc-capturing-bulk!
+  "Run recalc-grid! with bulk indexing captured instead of written.
+  Returns the indexed grid docs keyed by grd_id."
+  ([] (run-recalc-capturing-bulk! mock-osrm-matrix))
+  ([osrm-mock]
+   (let [bulk-calls (atom [])]
+     (with-redefs [osrm/get-data osrm-mock
+                   search/bulk-index-sync! (fn [_ data]
+                                             (swap! bulk-calls conj data)
+                                             {:created (count data)})]
+       (diversity/recalc-grid! (test-search) test-point-fcoll))
+     (->> @bulk-calls
+          (mapcat identity)
+          (filter :grd_id)
+          (reduce (fn [m doc] (assoc m (:grd_id doc) doc)) {})))))
+
+(defn- site-coords [site-id]
+  (->> test-sports-sites
+       (filter #(= site-id (:_id %)))
+       first
+       :_source :search-meta :location :geometries :coordinates))
+
+(defn- expected-distance [grid-item site-id profile]
+  (let [cell-coords (gis/wkt-point->coords (:WKT grid-item))]
+    (* (profile-factors profile)
+       (gis/haversine cell-coords (site-coords site-id)))))
+
+(defn- approx= [a b]
+  (and (number? a) (number? b) (< (Math/abs (- (double a) (double b))) 0.001)))
 
 ;;; Tests ;;;
 
 (deftest fetch-grid-test
   (testing "Fetching grid items within radius"
     (seed-test-data! (test-search))
-    (let [test-fcoll (gis/->fcoll
-                      [(gis/->feature {:type "Point"
-                                       :coordinates [24.9477 60.1678]})])
-          result (diversity/fetch-grid (test-search) test-fcoll 1)]
+    (let [result (diversity/fetch-grid (test-search) test-point-fcoll 1)]
       (is (seq result))
       (is (every? #(contains? % :_source) result))
       ;; fetch-grid applies no sort, so ES returns the matching cells in
@@ -170,129 +217,113 @@
       (is (= #{"250mN667175E38600" "250mN667150E38600"}
              (set (map #(-> % :_source :grd_id) result)))))))
 
-(deftest process-grid-item-test
-  (testing "Processing single grid item calculates sports site distances"
+(deftest recalc-grid-structure-test
+  (testing "Recalculated docs preserve cell fields and carry full site entries"
     (seed-test-data! (test-search))
-    (with-redefs [osrm/get-data mock-osrm-call]
-      (let [grid-item (first test-grid-items)
-            result (diversity/process-grid-item (test-search) 2 grid-item prn)]
+    (let [docs (run-recalc-capturing-bulk!)]
+      (is (= #{"250mN667175E38600" "250mN667150E38600"} (set (keys docs))))
 
-        ;; Check structure
-        (is (contains? result :sports-sites))
-        (is (coll? (:sports-sites result)))
-        (is (pos? (count (:sports-sites result))))
+      (doseq [[_ doc] docs]
+        ;; Original grid cell fields preserved
+        (is (string? (:WKT doc)))
+        (is (string? (:vaesto doc)))
+        (is (= "Helsinki" (:kunta doc)))
 
-        ;; Check each sports site has required fields
-        (doseq [site (:sports-sites result)]
-          (is (contains? site :id))
+        ;; All 3 test sites are within 2km of both test cells
+        (is (= #{"site-1" "site-2" "site-3"}
+               (set (map :id (:sports-sites doc)))))
+
+        (doseq [site (:sports-sites doc)]
           (is (contains? site :type-code))
           (is (contains? site :status))
-          (is (contains? site :osrm)))
+          (is (= #{:car :bicycle :foot} (set (keys (:osrm site)))))
+          (doseq [[_ mins] (:osrm site)]
+            (is (number? (:distance-m mins)))
+            (is (number? (:duration-s mins)))))))))
 
-        ;; Check OSRM data structure
-        (when (seq (:sports-sites result))
-          (let [first-site (first (:sports-sites result))]
-            (is (= #{:car :bicycle :foot} (set (keys (:osrm first-site)))))
-            (is (number? (-> first-site :osrm :car :distance-m)))
-            (is (number? (-> first-site :osrm :car :duration-s)))))))))
-
-(deftest apply-mins-test
-  (testing "Apply mins correctly extracts minimum distances and durations"
-    ;; Test with single destination
-    (let [single-dest {:car {:distances [[1234.5]] :durations [[180.2]]}
-                       :bicycle {:distances [[1500.0]] :durations [[450.0]]}
-                       :foot {:distances [[1100.0]] :durations [[792.0]]}}
-          result (diversity/apply-mins single-dest)]
-      (is (= 1234.5 (-> result :car :distance-m)))
-      (is (= 180.2 (-> result :car :duration-s)))
-      (is (= 1500.0 (-> result :bicycle :distance-m)))
-      (is (= 450.0 (-> result :bicycle :duration-s)))
-      (is (= 1100.0 (-> result :foot :distance-m)))
-      (is (= 792.0 (-> result :foot :duration-s))))
-
-    ;; Test with multiple destinations - should pick minimum for each mode
-    (let [multi-dest {:car {:distances [[2000.0 1234.5 3000.0]]
-                            :durations [[300.0 180.2 400.0]]}
-                      :bicycle {:distances [[2500.0 1500.0 3500.0]]
-                                :durations [[800.0 450.0 1000.0]]}
-                      :foot {:distances [[1900.0 1100.0 900.0]]
-                             :durations [[1368.0 792.0 648.0]]}}
-          result (diversity/apply-mins multi-dest)]
-      ;; Each mode takes its minimum value
-      (is (= 1234.5 (-> result :car :distance-m)))
-      (is (= 180.2 (-> result :car :duration-s)))
-      (is (= 1500.0 (-> result :bicycle :distance-m)))
-      (is (= 450.0 (-> result :bicycle :duration-s)))
-      (is (= 900.0 (-> result :foot :distance-m)))
-      (is (= 648.0 (-> result :foot :duration-s))))))
-
-(deftest recalc-grid-test
-  (testing "Full grid recalculation workflow"
+(deftest recalc-grid-distance-correctness-test
+  (testing "Stored minimums match independently computed expected distances"
     (seed-test-data! (test-search))
-    (with-redefs [osrm/get-data mock-osrm-call]
-      (let [test-fcoll (gis/->fcoll
-                        [(gis/->feature {:type "Point"
-                                         :coordinates [24.9477 60.1678]})])
-            ;; Capture bulk index calls
-            bulk-calls (atom [])
-            mock-bulk-index (fn [client data]
-                              (swap! bulk-calls conj data)
-                              {:created (count data)})]
+    (let [docs (run-recalc-capturing-bulk!)]
+      (doseq [grid-item test-grid-items
+              site-id ["site-1" "site-2" "site-3"]
+              profile [:car :bicycle :foot]]
+        (let [doc (get docs (:grd_id grid-item))
+              site (->> doc :sports-sites (filter #(= site-id (:id %))) first)
+              expected (expected-distance grid-item site-id profile)
+              actual (get-in site [:osrm profile :distance-m])]
+          (is (approx= expected actual)
+              (format "cell %s site %s profile %s: expected %.3f, got %s"
+                      (:grd_id grid-item) site-id (name profile)
+                      (double expected) (pr-str actual)))))
 
-        (with-redefs [search/bulk-index-sync! mock-bulk-index]
-          (diversity/recalc-grid! (test-search) test-fcoll)
+      (testing "durations are scaled by profile speed"
+        (let [doc (get docs "250mN667175E38600")
+              site (->> doc :sports-sites (filter #(= "site-1" (:id %))) first)]
+          (is (approx= (/ (expected-distance (first test-grid-items) "site-1" :foot)
+                          (profile-speeds-m-s :foot))
+                       (get-in site [:osrm :foot :duration-s]))))))))
 
-          ;; Verify bulk indexing was called
-          (is (seq @bulk-calls))
-
-          ;; Verify data structure
-          (let [indexed-data (first @bulk-calls)]
-            (is (every? #(or (contains? % :index) (contains? % :grd_id)) indexed-data))
-            (is (= (count indexed-data) (* 2 (count test-grid-items)))) ; 2 entries per item
-            (is (every? #(= "diversity_test" (-> % :index :_index))
-                        (filter #(contains? % :index) indexed-data)))))))))
-
-(deftest memory-usage-test
-  (testing "Processing doesn't accumulate excessive memory"
+(deftest recalc-grid-chunking-invariance-test
+  (testing "Tiny max-table-locations forces chunked requests with identical results"
     (seed-test-data! (test-search))
-    (let [test-fcoll (gis/->fcoll
-                      [(gis/->feature {:type "Point"
-                                       :coordinates [24.9477 60.1678]})])
-          runtime (Runtime/getRuntime)
-          ;; Force GC and measure baseline
-          _ (.gc runtime)
-          _ (Thread/sleep 100)
-          baseline-memory (.totalMemory runtime)]
+    (let [request-sizes (atom [])
+          counting-mock (fn [{:keys [sources destinations] :as params}]
+                          (swap! request-sizes conj (+ (count sources)
+                                                       (count destinations)))
+                          (mock-osrm-matrix params))
+          baseline (run-recalc-capturing-bulk!)
+          chunked (with-redefs [diversity/max-table-locations 3]
+                    (run-recalc-capturing-bulk! counting-mock))]
+      ;; Chunking actually happened: more than one request per profile
+      (is (> (count @request-sizes) 3))
+      ;; Results are unaffected by chunking
+      (is (= baseline chunked)))))
 
-      (with-redefs [osrm/get-data mock-osrm-call
-                    ;; Limit grid items for memory test
-                    diversity/fetch-grid (fn [_ _ _]
-                                           (take 5 (map #(hash-map :_source %) test-grid-items)))]
+(deftest recalc-grid-profile-failure-test
+  (testing "A failing profile is omitted; other profiles keep their data"
+    (seed-test-data! (test-search))
+    (let [failing-mock (fn [{:keys [profile] :as params}]
+                         (when-not (= :bicycle profile)
+                           (mock-osrm-matrix params)))
+          docs (run-recalc-capturing-bulk! failing-mock)]
+      (is (seq docs))
+      (doseq [[_ doc] docs
+              site (:sports-sites doc)]
+        (is (= #{:car :foot} (set (keys (:osrm site)))))))))
 
-        ;; Run multiple iterations
-        (dotimes [_ 3]
-          (diversity/recalc-grid! (test-search) test-fcoll))
+(deftest recalc-grid-all-profiles-fail-test
+  (testing "Total OSRM failure still indexes docs, with nil osrm per site"
+    (seed-test-data! (test-search))
+    (let [docs (run-recalc-capturing-bulk! (constantly nil))]
+      (is (= #{"250mN667175E38600" "250mN667150E38600"} (set (keys docs))))
+      (doseq [[_ doc] docs
+              site (:sports-sites doc)]
+        (is (nil? (:osrm site)))))))
 
-        ;; Force GC and measure
-        (.gc runtime)
-        (Thread/sleep 100)
-        (let [final-memory (.totalMemory runtime)
-              memory-increase (- final-memory baseline-memory)
-              ;; Allow up to 100MB increase (reasonable for test data)
-              max-allowed-increase (* 100 1024 1024)]
-
-          (is (< memory-increase max-allowed-increase)
-              (str "Memory increased by " (/ memory-increase 1024 1024) "MB")))))))
+(deftest recalc-grid-timeout-test
+  (testing "Slow OSRM requests time out and are treated as failed profiles"
+    (seed-test-data! (test-search))
+    (let [slow-mock (fn [params]
+                      (Thread/sleep 200)
+                      (mock-osrm-matrix params))
+          docs (with-redefs [diversity/osrm-table-timeout-ms 50]
+                 (run-recalc-capturing-bulk! slow-mock))]
+      ;; Docs are still indexed, but without OSRM data
+      (is (= #{"250mN667175E38600" "250mN667150E38600"} (set (keys docs))))
+      (doseq [[_ doc] docs
+              site (:sports-sites doc)]
+        (is (nil? (:osrm site)))))))
 
 (deftest concurrent-processing-test
-  (testing "Concurrent processing doesn't corrupt data"
+  (testing "Concurrent recalculations don't corrupt data"
     (seed-test-data! (test-search))
     (let [test-points [[24.9477 60.1678]
                        [24.9500 60.1700]
                        [24.9400 60.1650]]
           results (atom [])]
 
-      (with-redefs [osrm/get-data mock-osrm-call
+      (with-redefs [osrm/get-data mock-osrm-matrix
                     search/bulk-index-sync! (fn [_ data]
                                               (swap! results conj data)
                                               {:created (count data)})]
@@ -309,52 +340,16 @@
           ;; Wait for all to complete
           (doseq [f futures] @f)
 
-          ;; Verify all results were captured
-          (is (= (count test-points) (count @results)))
+          ;; Every recalc produced at least one bulk call (per tile)
+          (is (>= (count @results) (count test-points)))
 
           ;; Verify no data corruption
           (doseq [result @results]
             (is (seq result))
-            (is (every? #(or (contains? % :index) (contains? % :grd_id)) result))))))))
-
-;;; Timeout handling tests ;;;
-
-(deftest osrm-site-timeout-test
-  (testing "site timeout constant is defined and positive"
-    (is (pos? diversity/osrm-site-timeout-ms))
-    ;; Should be at least 30 seconds
-    (is (>= diversity/osrm-site-timeout-ms 30000))))
-
-(deftest process-sites-chunk-timeout-handling-test
-  (testing "handles OSRM timeout gracefully by returning nil for osrm field"
-    (let [;; Mock that simulates a timeout by sleeping longer than the timeout
-          slow-mock (fn [_params]
-                      (Thread/sleep 200) ; Simulate slow response
-                      {:distances [[100]] :durations [[10]]})]
-
-      (with-redefs [osrm/get-data slow-mock
-                    ;; Use very short timeout to trigger timeout behavior
-                    diversity/osrm-site-timeout-ms 50]
-        (let [test-site {:_id "test-site"
-                         :_source {:status "active"
-                                   :type {:type-code 1520}
-                                   :search-meta
-                                   {:location
-                                    {:simple-geoms
-                                     {:features
-                                      [{:geometry {:coordinates [24.948 60.168]
-                                                   :type "Point"}}]}}}}}
-              coords [24.9477 60.1678]
-              result (diversity/process-sites-chunk [test-site] coords prn)]
-          ;; Should return a result even if OSRM times out
-          (is (seq result))
-          (is (= "test-site" (:id (first result))))
-          ;; OSRM field should be nil due to timeout
-          (is (nil? (:osrm (first result)))))))))
+            (is (every? #(or (contains? % :index) (contains? % :grd_id)) result))
+            (doseq [doc (filter :grd_id result)]
+              (is (vector? (:sports-sites doc))))))))))
 
 (comment
-  (setup-test-system!)
-  (clojure.test/run-test-var #'process-grid-item-test)
-  (clojure.test/run-test-var #'osrm-site-timeout-test)
-  (clojure.test/run-test-var #'process-sites-chunk-timeout-handling-test)
+  (clojure.test/run-test-var #'recalc-grid-distance-correctness-test)
   (seed-test-data! (:lipas/search @test-system)))

--- a/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
+++ b/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
@@ -175,7 +175,9 @@
 
 (defn- run-recalc-capturing-bulk!
   "Run recalc-grid! with bulk indexing captured instead of written.
-  Returns the indexed grid docs keyed by grd_id."
+  Returns the indexed grid docs keyed by grd_id. The :sports-sites
+  vector is sorted by :id because its order follows the unsorted ES
+  site query, so it varies between runs."
   ([] (run-recalc-capturing-bulk! mock-osrm-matrix))
   ([osrm-mock]
    (let [bulk-calls (atom [])]
@@ -187,7 +189,10 @@
      (->> @bulk-calls
           (mapcat identity)
           (filter :grd_id)
-          (reduce (fn [m doc] (assoc m (:grd_id doc) doc)) {})))))
+          (reduce (fn [m doc]
+                    (assoc m (:grd_id doc)
+                           (update doc :sports-sites #(vec (sort-by :id %)))))
+                  {})))))
 
 (defn- site-coords [site-id]
   (->> test-sports-sites

--- a/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
+++ b/webapp/test/clj/lipas/backend/analysis/diversity_test.clj
@@ -292,6 +292,28 @@
               site (:sports-sites doc)]
         (is (= #{:car :foot} (set (keys (:osrm site)))))))))
 
+(deftest recalc-grid-chunk-failure-partial-degradation-test
+  (testing "A failed destination chunk only degrades sites in that chunk"
+    (seed-test-data! (test-search))
+    ;; max-table-locations 2 forces single-destination chunks whatever
+    ;; the tile layout (chunk-size = max 1 (- 2 n-sources)), so each
+    ;; site is its own chunk
+    (let [site-2-dest "24.945,60.167"
+          failing-mock (fn [{:keys [profile destinations] :as params}]
+                         (when-not (and (= :foot profile)
+                                        (some #{site-2-dest} destinations))
+                           (mock-osrm-matrix params)))
+          docs (with-redefs [diversity/max-table-locations 2]
+                 (run-recalc-capturing-bulk! failing-mock))]
+      (is (seq docs))
+      (doseq [[_ doc] docs
+              site (:sports-sites doc)]
+        (if (= "site-2" (:id site))
+          (is (= #{:car :bicycle} (set (keys (:osrm site))))
+              "site-2's foot chunk failed -> foot omitted for site-2 only")
+          (is (= #{:car :bicycle :foot} (set (keys (:osrm site))))
+              (str (:id site) " must keep all profiles")))))))
+
 (deftest recalc-grid-all-profiles-fail-test
   (testing "Total OSRM failure still indexes docs, with nil osrm per site"
     (seed-test-data! (test-search))


### PR DESCRIPTION
## Summary

The precomputed diversity grid made **3 OSRM requests per site per grid cell** (plus one ES geo query per cell) — on the order of 100k HTTP calls for an urban point-site analysis job, with `System/gc` calls and site-chunking machinery to cope with the fallout.

`recalc-grid!` and CSV seeding now share `process-cells!`, which:

- fetches all candidate sports sites with **one scrolled ES query** over the buffered area (no 10k clipping)
- assigns sites to cells with an exact **JTS metric distance** prefilter against `simple-geoms` in TM35FIN — same semantics as the old per-cell ES radius query, to within simplification tolerance (250m margin)
- groups cells into **2km tiles**, each issuing one multi-source OSRM `/table` request per profile over the deduplicated union of site vertices, chunked under `--max-table-size`, tiles processed in bounded-concurrency waves
- slices per-cell/per-site minimums from the matrices (min distance and min duration independently, as before) and bulk-indexes per tile

**Stored document shape is unchanged**; all three profiles (car/bicycle/foot) are kept.

## Measured impact

Helsinki-center point-site job (49 cells / 827 real sites, real local OSRM, 4-core host):

| | Old | New |
|---|---|---|
| OSRM HTTP requests | 50,193 | **15** (3,346x fewer) |
| ES queries | 49 | 1 |
| Wall time | 324s | **148s** |

Wall time is bound by foot-profile table computation. Measured `/table` (MLD) cost is ~20ms per destination + ~1ms per source×dest pair — the tile size balances amortizing destination searches against pair count (see `tile-size-m` docstring). The full-country seed documented as "8 hours" in ops.md should shrink accordingly (re-measure on first run).

## Correctness

- Old-vs-new equivalence over **100,428** cell/site/profile values: no sites lost; 3,179 additions in the 2.0–2.25km assignment-margin band (all beyond the 2km read cutoff); exactly 2 differing values, traced to OSRM itself — off-network coordinates (a park facility) can snap differently depending on the other coordinates in the request (documented in `docs/analysis-diversity.md`)
- Fixes a latent crash: all-`null` OSRM rows (unroutable destinations) threw `ArityException` in `resolve-min` and killed the whole batch; now they yield nil minimums
- **E2E verified with real data**: real site through jobs enqueue → dispatcher → `recalc-grid!` → dev diversity index (50 cells × 294–475 sites) → `POST /api/actions/calc-diversity-indices` returns sensible indices (3–5, mode 4)

## Resilience (from a high-effort review pass)

- `osrm/get-data` returns nil on connection-level IOExceptions (previously they rethrew through futures and aborted a whole tile); failed profile requests retry once
- A failed destination chunk degrades only the sites whose matrix columns it covers (`:failed-cols`), not the profile tile-wide — same blast radius as the old per-site requests
- Keep-alive connection pool with per-route caps, lease timeout, idle validation, and idempotent retry on connection-establishment failures — but **never** on `SocketTimeoutException` (retrying a slow request doubles load on a server still computing the abandoned response; observed cascading into cross-profile timeout storms)
- Timed-out profile futures are no longer `future-cancel`led (interrupting a thread holding a pooled connection risks leaking it; the socket timeout bounds the request)
- Large batch tables get a 120s socket timeout via `:socket-timeout-ms` — big foot-profile matrices legitimately exceed the default 30s

## Other

- `search-indexer --diversity` now delegates to `seed-new-grid-from-csv!`; the old `index-diversity!` path was bit-rotted (passed a bare ES client where the search component map was expected)
- Test suite rewritten around the new pure batching primitives + integration tests with a haversine-derived matrix mock so stored minimums are asserted against independently computed values; chunking-invariance, chunk-failure, profile-failure, timeout, and concurrency coverage (48 tests / 427 assertions green across diversity, osrm, dispatcher, heatmap)
- Docs updated: `docs/analysis-diversity.md` (architecture + measured numbers), `docs/ops.md` seeding note

🤖 Generated with [Claude Code](https://claude.com/claude-code)