### PR TITLE
Vertex-driven, adaptively planned elevation enrichment

### DIFF
--- a/webapp/src/clj/lipas/backend/elevation.clj
+++ b/webapp/src/clj/lipas/backend/elevation.clj
@@ -68,9 +68,12 @@
 (def merge-tile-min-chunks
   "Merge a tile into one request when it contains at least this many
   vertex chunks. Measured MML timings: one 250m chunk ~255ms, one
-  1000m tile (16 chunk areas) ~740ms, so 4+ chunks are cheaper (and
-  always fewer requests) fetched as a tile."
-  4)
+  1000m tile (16 chunk areas) ~740ms, so from 3 chunks up a tile
+  request costs MML no more server time and is always fewer requests.
+  On the 300-route sweep this threshold cut total requests 3.8x
+  (threshold 4 gave 3.0x; 2 gave 4.5x but doubles MML's per-area
+  server time on the merged pairs)."
+  3)
 
 (def vertex-buffer-m
   "Tolerance added around the vertices in single-envelope requests so

--- a/webapp/src/clj/lipas/backend/elevation.clj
+++ b/webapp/src/clj/lipas/backend/elevation.clj
@@ -85,28 +85,44 @@
   "Upper bound on simultaneous MML requests. MML is an external,
   rate-limited API guarded by a circuit breaker in the job dispatcher;
   fetches proceed in bounded waves instead of launching every chunk
-  fetch at once."
+  fetch at once (the old implementation fired one concurrent request
+  per chunk, 165 for one benchmark route). Deliberate tradeoff: under
+  severe MML degradation a many-chunk route may now exceed its job
+  timeout and retry later via the queue, instead of 'winning' by
+  hammering the degraded API with hundreds of concurrent slow
+  requests."
   8)
 
-(defonce ^{:doc "Reusable connection pool shared by all MML requests.
-  Keep-alive connections avoid a fresh TCP+TLS handshake per request,
-  which matters when a route needs tens of chunk fetches."}
+(defonce ^{:doc "Reusable connection pool shared by all MML requests,
+  built lazily on first use. Keep-alive connections avoid a fresh
+  TCP+TLS handshake per request, which matters when a route needs tens
+  of chunk fetches. Sized well above max-concurrent-fetches so that
+  concurrently running elevation jobs (worker general lane has
+  multiple threads) and abandoned requests still holding leases
+  (a timed-out fetch blocks on its socket read until socket-timeout;
+  interrupts don't unblock it) can't starve each other of
+  connections."}
   connection-manager
-  (doto (conn-mgr/make-reusable-conn-manager
-         {:timeout 30 ; Idle connection TTL (seconds)
-          :threads max-concurrent-fetches
-          :default-per-route max-concurrent-fetches})
-    ;; Health-check connections that sat idle >1s before reuse, so a
-    ;; keep-alive connection the server closed doesn't surface as an
-    ;; IOException mid-request
-    (.setValidateAfterInactivity 1000)))
+  (delay
+    (doto (conn-mgr/make-reusable-conn-manager
+           {:timeout 30 ; Idle connection TTL (seconds)
+            :threads 32
+            :default-per-route 32})
+      ;; Health-check connections that sat idle >1s before reuse, so a
+      ;; keep-alive connection the server closed doesn't surface as an
+      ;; IOException mid-request
+      (.setValidateAfterInactivity 1000))))
 
 (def mml-http-options
-  "HTTP options for MML API requests."
+  "HTTP options for MML API requests. The shared `connection-manager`
+  is merged in by `get-elevation-coverage`."
   {:connection-timeout 5000     ;; 5 seconds to establish connection
    :socket-timeout 120000       ;; 2 minutes for response (large grids take time)
-   :connection-request-timeout 10000 ;; 10 seconds to lease from the pool
-   :connection-manager connection-manager
+   ;; Leasing from the pool must tolerate a full socket-timeout wait:
+   ;; failing the lease faster than in-flight requests can finish would
+   ;; turn MML slowness into job failures (and eventually a tripped
+   ;; circuit breaker) instead of slow jobs
+   :connection-request-timeout 130000
    :throw-exceptions false      ;; Handle errors explicitly
    :decompress-body true
    ;; GetCoverage GETs are idempotent - retry once on connection-
@@ -132,23 +148,6 @@
     (-> (client/get mml-coverage-url opts)
         :body)))
 
-(defn fit-to-coverage
-  "Returns an envelope that contains given envelope and 'matches' MML
-  2x2m coverage grid. Ensures that the returned envelope is within the
-  bounds of the coverage's envelope."
-  [{:keys [min-x min-y max-x max-y]} {:keys [envelope]}]
-  {:min-x (max (:min-x envelope) (let [n (Math/round (double min-x))] (if (odd? n) (dec n) n)))
-   :min-y (max (:min-y envelope) (let [n (Math/round (double min-y))] (if (odd? n) (dec n) n)))
-   :max-x (min (:max-x envelope) (let [n (Math/round (double max-x))] (if (odd? n) (dec n) n)))
-   :max-y (min (:max-y envelope) (let [n (Math/round (double max-y))] (if (odd? n) (dec n) n)))})
-
-(defn chunk-key
-  "Key [kx ky] of the fixed-grid chunk that contains the given TM35FIN
-  point. Chunk origins are multiples of `query-envelope-size-m`."
-  [[x y]]
-  [(long (Math/floor (/ x query-envelope-size-m)))
-   (long (Math/floor (/ y query-envelope-size-m)))])
-
 (defn- clamp-to-coverage
   "Clamp an already 2m-aligned envelope to the coverage envelope. An
   envelope fully outside the coverage becomes degenerate (min > max)
@@ -160,6 +159,30 @@
      :max-x (min (:max-x envelope) max-x)
      :min-y (max (:min-y envelope) min-y)
      :max-y (min (:max-y envelope) max-y)}))
+
+(defn fit-to-coverage
+  "Returns an envelope that contains given envelope and 'matches' MML
+  2x2m coverage grid. Ensures that the returned envelope is within the
+  bounds of the coverage's envelope."
+  [{:keys [min-x min-y max-x max-y]} _coverage-info]
+  (let [down-to-even (fn [v] (let [n (Math/round (double v))] (if (odd? n) (dec n) n)))]
+    (clamp-to-coverage {:min-x (down-to-even min-x)
+                        :min-y (down-to-even min-y)
+                        :max-x (down-to-even max-x)
+                        :max-y (down-to-even max-y)})))
+
+(defn chunk-key
+  "Key [kx ky] of the fixed-grid chunk that contains the given TM35FIN
+  point. Chunk origins are multiples of `query-envelope-size-m`. A
+  point exactly on the coverage envelope's max edge belongs to the
+  last chunk inside the coverage; `resolve-elevation`'s col/row cap
+  then reads its edge cell, like the old implementation did."
+  [[x y]]
+  (let [{:keys [envelope]} coverage-info
+        x (if (= (double x) (double (:max-x envelope))) (dec (double x)) x)
+        y (if (= (double y) (double (:max-y envelope))) (dec (double y)) y)]
+    [(long (Math/floor (/ x query-envelope-size-m)))
+     (long (Math/floor (/ y query-envelope-size-m)))]))
 
 (defn chunk-key->envelope
   "Envelope of fixed-grid chunk [kx ky], clamped to the coverage
@@ -224,72 +247,74 @@
              (sort-by (comp (juxt :min-x :min-y) :envelope))
              vec)))))
 
+(defn map-vertices
+  "Eagerly map f over every vertex coordinate of fcoll, rebuilding the
+  feature collection. Both vertex collection and z-appending go
+  through this single walk, so the walk order (and thereby the fetched
+  chunk set covering the resolved vertices) is structural, not a
+  documented invariant."
+  [f fcoll]
+  (update fcoll :features
+          (fn [fs]
+            (mapv
+             (fn [feat]
+               (update-in feat [:geometry :coordinates]
+                          (fn [coords]
+                            (condp = (-> feat :geometry :type)
+                              "Point"      (f coords)
+                              "LineString" (mapv f coords)
+                              "Polygon"    (mapv #(mapv f %) coords)
+                              (throw (ex-info "Encountered unexpected geometry type" feat))))))
+             fs))))
+
 (defn geometry-vertices
-  "All [lon lat] vertices of fcoll that `append-elevations` will resolve
-  an elevation for. Walks the geometry types exactly like
-  `append-elevations` so the fetched chunk set always covers the
-  resolved vertices."
+  "All vertex coordinates of fcoll that `append-elevations` will
+  resolve an elevation for, in walk order."
   [fcoll]
-  (into []
-        (mapcat
-         (fn [f]
-           (let [coords (-> f :geometry :coordinates)]
-             (condp = (-> f :geometry :type)
-               "Point"      [coords]
-               "LineString" coords
-               "Polygon"    (mapcat identity coords)
-               (throw (ex-info "Encountered unexpected geometry type" f))))))
-        (:features fcoll)))
+  (let [acc (volatile! (transient []))]
+    (map-vertices (fn [c] (vswap! acc conj! c) c) fcoll)
+    (persistent! @acc)))
 
 (defn resolve-elevation
-  [grid-index coords]
-  (let [[lon lat :as tm35] (gis/wgs84->tm35fin-no-wrap coords)
-        k (chunk-key tm35)
+  "Resolve the elevation of a TM35FIN point from the grid index. The
+  col/row cap keeps a point exactly on its grid's max edge in the edge
+  cell; anything further outside the grid means MML returned a grid
+  that doesn't cover the requested envelope, which must fail loudly
+  instead of silently resolving a wrong edge cell."
+  [grid-index [x y :as tm35]]
+  (let [k (chunk-key tm35)
 
         {:keys [headers rows]}
         (or (get grid-index k)
             (throw (ex-info "No elevation grid covers coordinate"
-                            {:coords coords :tm35fin tm35 :chunk-key k})))
+                            {:tm35fin tm35 :chunk-key k})))
+
+        {:keys [xllcorner yllcorner cellsize ncols nrows]} headers
 
         ;; Resolve col and row for the coords relative to the lower
         ;; left corner of the grid. Cap to max-bounds.
-        col (min (long (Math/floor
-                        (/ (- lon (:xllcorner headers))
-                           (:cellsize headers))))
-                 (dec (:ncols headers)))
-        row (min (long (Math/floor
-                        (/ (- lat (:yllcorner headers))
-                           (:cellsize headers))))
-                 (dec (:nrows headers)))]
+        col (long (Math/floor (/ (- x xllcorner) cellsize)))
+        row (long (Math/floor (/ (- y yllcorner) cellsize)))]
 
-    (-> rows (nth row) (nth col))))
+    (when-not (and (<= 0 col ncols) (<= 0 row nrows))
+      (throw (ex-info "Vertex outside its elevation grid"
+                      {:tm35fin tm35 :chunk-key k :headers headers})))
+
+    (-> rows
+        (nth (min row (dec nrows)))
+        (nth (min col (dec ncols))))))
 
 (defn append-elevations
-  [fcoll grid-index]
-  (update fcoll :features
-          (fn [fs]
-            (map
-             (fn [f]
-               (update-in f [:geometry :coordinates]
-                          (fn [coords]
-                            (condp = (-> f :geometry :type)
-                              "Point"      (let [[x y] coords]
-                                             [x y (resolve-elevation grid-index coords)])
-                              "LineString" (mapv
-                                            (fn [coords]
-                                              (let [[x y] coords]
-                                                [x y (resolve-elevation grid-index coords)]))
-                                            coords)
-                              "Polygon"    (mapv
-                                            (fn [coords]
-                                              (mapv
-                                               (fn [coords]
-                                                 (let [[x y] coords]
-                                                   [x y (resolve-elevation grid-index coords)]))
-                                               coords))
-                                            coords)
-                              (throw (ex-info "Encountered unexpected geometry type" f))))))
-             fs))))
+  "Append a z coordinate to every vertex, resolved from grid-index.
+  tm35-vertices must be the vertices of fcoll in walk order (as
+  returned by `geometry-vertices`, CRS-transformed once)."
+  [fcoll grid-index tm35-vertices]
+  (let [i (volatile! -1)]
+    (map-vertices
+     (fn [coords]
+       (let [[x y] coords]
+         [x y (resolve-elevation grid-index (nth tm35-vertices (vswap! i inc)))]))
+     fcoll)))
 
 (defn parse-ascii-grid-headers
   [lines]
@@ -320,6 +345,23 @@
     {:headers (parse-ascii-grid-headers header-lines)
      :data    (parse-ascii-grid-data data-lines)}))
 
+(defn validate-grid
+  "Throw when the parsed grid's dimensions don't match its headers.
+  Guards against a truncated or malformed MML response silently
+  resolving wrong cells: row indexing counts from the top of the grid,
+  so missing rows would shift every subsequent lookup. Throwing fails
+  the job, which retries via the queue."
+  [{:keys [headers data] :as grid} envelope]
+  (let [{:keys [ncols nrows]} headers]
+    (when-not (and (= nrows (count data))
+                   (every? #(= ncols (count %)) data))
+      (throw (ex-info "MML grid dimensions don't match headers"
+                      {:envelope     envelope
+                       :headers      headers
+                       :nrows-parsed (count data)
+                       :ncols-parsed (into (sorted-set) (map count) data)})))
+    grid))
+
 (defn index-grid
   "Prepare a parsed grid for O(1) vertex lookups: reverse the rows once
   so the lower left corner comes first and row/col math works in
@@ -337,13 +379,15 @@
 (defn get-elevation-coverage
   [envelope]
   (let [opts (merge mml-http-options
-                    {:query-params (make-query-params envelope)
+                    {:connection-manager @connection-manager
+                     :query-params (make-query-params envelope)
                      :basic-auth   (str mml-api-key ":")})]
     (log/info "Getting coverage with envelope" envelope)
     (let [response (client/get mml-coverage-url opts)]
       (cond
         (= 200 (:status response))
-        (parse-ascii-grid (:body response))
+        (-> (parse-ascii-grid (:body response))
+            (validate-grid envelope))
 
         (>= (:status response) 400)
         (throw (ex-info "MML API error"
@@ -383,9 +427,7 @@
         fetch-plan    (plan-fetches tm35-vertices)]
     (log/info "Fetching elevation data for" (count tm35-vertices) "vertices in"
               (count fetch-plan) "requests")
-    (-> fetch-plan
-        fetch-grids
-        (->> (append-elevations fcoll)))))
+    (append-elevations fcoll (fetch-grids fetch-plan) tm35-vertices)))
 
 (comment
   (->> (describe-coverage)

--- a/webapp/src/clj/lipas/backend/elevation.clj
+++ b/webapp/src/clj/lipas/backend/elevation.clj
@@ -10,14 +10,23 @@
 ;; MML elevation coverage model consists of 2x2m squares that contain
 ;; the elevation information as meters above/below sea level. Elevation
 ;; is resolved per geometry vertex: we derive the set of fixed-grid
-;; 250x250m chunks that contain at least one vertex, request each chunk
-;; as an ESRI Ascii Grid text file from MML api (bounded concurrency)
-;; and resolve the elevation value for each vertex from an O(1) index
-;; over the fetched grids.
+;; 250x250m chunks that contain at least one vertex and plan the MML
+;; requests adaptively (`plan-fetches`):
 ;;
-;; Chunk corners are multiples of 250 and therefore aligned with the
-;; 2m coverage cell grid, so the value resolved for a vertex does not
-;; depend on which chunk framing served its cell.
+;;   - geometries spanning at most one chunk (points, most single
+;;     sports sites) fetch one small envelope around the vertices,
+;;     like the pre-optimization implementation did
+;;   - dense clusters of chunks are merged into 1000x1000m tile
+;;     requests (measured: a 16-chunk tile costs ~3x one chunk fetch)
+;;   - remaining chunks are fetched individually
+;;
+;; Each request returns an ESRI Ascii Grid text file. Requests run
+;; with bounded concurrency and each vertex resolves its elevation
+;; from an O(1) chunk-key index over the fetched grids.
+;;
+;; All requested envelopes have even (2m-aligned) corners, so the
+;; value resolved for a vertex does not depend on which envelope
+;; framing served its cell.
 
 ;; https://www.maanmittauslaitos.fi/ortokuvien-ja-korkeusmallien-kyselypalvelu/tekninen-kuvaus
 ;; https://en.wikipedia.org/wiki/Esri_grid
@@ -48,6 +57,26 @@
   ratio with MML api. Must be even so chunk corners align with the 2m
   coverage cells (the coverage envelope bounds are multiples of 250)."
   250)
+
+(def merge-tile-size-m
+  "Dense chunk clusters are merged into requests of this size. Must be
+  a multiple of `query-envelope-size-m`; the coverage envelope bounds
+  are also multiples of it. Sizes beyond 1000m get disproportionately
+  slow on the MML side (2500m ~2.9s, 5000m ~16s)."
+  1000)
+
+(def merge-tile-min-chunks
+  "Merge a tile into one request when it contains at least this many
+  vertex chunks. Measured MML timings: one 250m chunk ~255ms, one
+  1000m tile (16 chunk areas) ~740ms, so 4+ chunks are cheaper (and
+  always fewer requests) fetched as a tile."
+  4)
+
+(def vertex-buffer-m
+  "Tolerance added around the vertices in single-envelope requests so
+  that `fit-to-coverage` rounding can never leave an extreme vertex
+  outside the fetched grid. 8 meters was found via experimentation."
+  8)
 
 (def max-concurrent-fetches
   "Upper bound on simultaneous MML requests. MML is an external,
@@ -117,20 +146,80 @@
   [(long (Math/floor (/ x query-envelope-size-m)))
    (long (Math/floor (/ y query-envelope-size-m)))])
 
+(defn- clamp-to-coverage
+  "Clamp an already 2m-aligned envelope to the coverage envelope. An
+  envelope fully outside the coverage becomes degenerate (min > max)
+  and its MML request fails, which fails the whole job (same outcome
+  as the old implementation for out-of-coverage geometries)."
+  [{:keys [min-x max-x min-y max-y]}]
+  (let [{:keys [envelope]} coverage-info]
+    {:min-x (max (:min-x envelope) min-x)
+     :max-x (min (:max-x envelope) max-x)
+     :min-y (max (:min-y envelope) min-y)
+     :max-y (min (:max-y envelope) max-y)}))
+
 (defn chunk-key->envelope
   "Envelope of fixed-grid chunk [kx ky], clamped to the coverage
   envelope. Chunk corners are multiples of `query-envelope-size-m` and
-  hence already aligned with the 2m coverage cells; a chunk fully
-  outside the coverage yields a degenerate envelope whose MML request
-  fails, which fails the whole job (same outcome as the old
-  implementation for out-of-coverage geometries)."
+  hence already aligned with the 2m coverage cells."
   [[kx ky]]
-  (let [{:keys [envelope]} coverage-info
-        size query-envelope-size-m]
-    {:min-x (max (:min-x envelope) (* kx size))
-     :max-x (min (:max-x envelope) (* (inc kx) size))
-     :min-y (max (:min-y envelope) (* ky size))
-     :max-y (min (:max-y envelope) (* (inc ky) size))}))
+  (let [size query-envelope-size-m]
+    (clamp-to-coverage {:min-x (* kx size)
+                        :max-x (* (inc kx) size)
+                        :min-y (* ky size)
+                        :max-y (* (inc ky) size)})))
+
+(defn tile-key->envelope
+  "Envelope of the merge tile [tx ty], clamped to the coverage
+  envelope."
+  [[tx ty]]
+  (clamp-to-coverage {:min-x (* tx merge-tile-size-m)
+                      :max-x (* (inc tx) merge-tile-size-m)
+                      :min-y (* ty merge-tile-size-m)
+                      :max-y (* (inc ty) merge-tile-size-m)}))
+
+(defn- vertices-envelope
+  "Envelope of the TM35FIN vertices buffered by `vertex-buffer-m`,
+  fitted to the coverage grid."
+  [tm35-vertices]
+  (-> {:min-x (- (reduce min (map first tm35-vertices)) vertex-buffer-m)
+       :max-x (+ (reduce max (map first tm35-vertices)) vertex-buffer-m)
+       :min-y (- (reduce min (map second tm35-vertices)) vertex-buffer-m)
+       :max-y (+ (reduce max (map second tm35-vertices)) vertex-buffer-m)}
+      (fit-to-coverage coverage-info)))
+
+(defn plan-fetches
+  "Plan the MML requests needed to resolve elevations for the given
+  TM35FIN vertices. Returns [{:envelope e :chunk-keys [k ...]} ...]
+  where every distinct vertex chunk key appears in exactly one entry
+  and each entry's envelope covers all of its chunk keys' vertices.
+
+  Small geometries (all vertices within one chunk's span) get a single
+  envelope tightly around the vertices; otherwise chunks are fetched
+  individually except dense clusters, which are merged into
+  `merge-tile-size-m` tiles."
+  [tm35-vertices]
+  (if (empty? tm35-vertices)
+    []
+    (let [chunk-keys (distinct (map chunk-key tm35-vertices))
+          {:keys [min-x max-x min-y max-y] :as env} (vertices-envelope tm35-vertices)]
+      (if (and (<= (- max-x min-x) query-envelope-size-m)
+               (<= (- max-y min-y) query-envelope-size-m))
+        ;; Small geometry: one request around the vertices (like the
+        ;; pre-optimization implementation did for points and most
+        ;; single sports sites)
+        [{:envelope env :chunk-keys chunk-keys}]
+        (->> chunk-keys
+             (group-by (fn [[kx ky]]
+                         (let [factor (quot merge-tile-size-m query-envelope-size-m)]
+                           [(quot kx factor) (quot ky factor)])))
+             (mapcat (fn [[tile-key ks]]
+                       (if (>= (count ks) merge-tile-min-chunks)
+                         [{:envelope (tile-key->envelope tile-key) :chunk-keys ks}]
+                         (for [k ks]
+                           {:envelope (chunk-key->envelope k) :chunk-keys [k]}))))
+             (sort-by (comp (juxt :min-x :min-y) :envelope))
+             vec)))))
 
 (defn geometry-vertices
   "All [lon lat] vertices of fcoll that `append-elevations` will resolve
@@ -211,11 +300,14 @@
                (parse-double v))]))))
 
 (defn parse-ascii-grid-data
+  "Parse data rows into vectors of doubles. Splitting on whitespace is
+  ~2x faster than the regex scan this replaced and yields the same
+  values; `keep` drops empty tokens from leading whitespace."
   [lines]
   (into []
         (for [s     lines
               :when (not-empty s)]
-          (into [] (map parse-double) (re-seq #"-?\d+\.?\d*" s)))))
+          (into [] (keep parse-double) (str/split s #"\s+")))))
 
 (defn parse-ascii-grid
   [s]
@@ -262,31 +354,33 @@
                          :envelope envelope}))))))
 
 (defn fetch-grids
-  "Fetch and index the elevation grids for chunk-keys with bounded
-  concurrency (waves of `max-concurrent-fetches`). Returns a map of
-  chunk-key -> indexed grid. Any chunk failure propagates and fails the
-  whole enrichment: the job queue retries and the circuit breaker in
-  the dispatcher sees the failure."
-  [chunk-keys]
+  "Fetch and index the elevation grids for a `plan-fetches` plan with
+  bounded concurrency (waves of `max-concurrent-fetches`). Returns a
+  map of chunk-key -> indexed grid; an entry's grid is shared by all
+  the chunk keys it was fetched for. Any fetch failure propagates and
+  fails the whole enrichment: the job queue retries and the circuit
+  breaker in the dispatcher sees the failure."
+  [fetch-plan]
   (into {}
         (mapcat
          (fn [wave]
-           (mapv (fn [k grid] [k (index-grid grid)])
-                 wave
-                 (patterns/pmap-with-timeout
-                  elevation-chunk-timeout-ms
-                  (comp get-elevation-coverage chunk-key->envelope)
-                  wave))))
-        (partition-all max-concurrent-fetches chunk-keys)))
+           (mapcat (fn [{:keys [chunk-keys]} grid]
+                     (let [indexed (index-grid grid)]
+                       (map (fn [k] [k indexed]) chunk-keys)))
+                   wave
+                   (patterns/pmap-with-timeout
+                    elevation-chunk-timeout-ms
+                    (comp get-elevation-coverage :envelope)
+                    wave))))
+        (partition-all max-concurrent-fetches fetch-plan)))
 
 (defn enrich-elevation
   [fcoll]
-  (let [chunk-keys (->> (geometry-vertices fcoll)
-                        (map (comp chunk-key gis/wgs84->tm35fin-no-wrap))
-                        distinct
-                        sort)]
-    (log/info "Fetching elevation data for" (count chunk-keys) "grid chunks")
-    (-> chunk-keys
+  (let [tm35-vertices (mapv gis/wgs84->tm35fin-no-wrap (geometry-vertices fcoll))
+        fetch-plan    (plan-fetches tm35-vertices)]
+    (log/info "Fetching elevation data for" (count tm35-vertices) "vertices in"
+              (count fetch-plan) "requests")
+    (-> fetch-plan
         fetch-grids
         (->> (append-elevations fcoll)))))
 

--- a/webapp/src/clj/lipas/backend/elevation.clj
+++ b/webapp/src/clj/lipas/backend/elevation.clj
@@ -1,5 +1,6 @@
 (ns lipas.backend.elevation
   (:require [clj-http.client :as client]
+            [clj-http.conn-mgr :as conn-mgr]
             [clojure.string :as str]
             [lipas.backend.config :as config]
             [lipas.backend.gis :as gis]
@@ -7,11 +8,16 @@
             [taoensso.timbre :as log]))
 
 ;; MML elevation coverage model consists of 2x2m squares that contain
-;; the elevation information as meters above/below sea level. We
-;; calculate an envelope for our geometries and request the relevant
-;; tiles (squares) as ESRI Ascii Grid text files from MML api. Then we
-;; resolve the elevation value for each point in the geometry from the
-;; elevation tiles.
+;; the elevation information as meters above/below sea level. Elevation
+;; is resolved per geometry vertex: we derive the set of fixed-grid
+;; 250x250m chunks that contain at least one vertex, request each chunk
+;; as an ESRI Ascii Grid text file from MML api (bounded concurrency)
+;; and resolve the elevation value for each vertex from an O(1) index
+;; over the fetched grids.
+;;
+;; Chunk corners are multiples of 250 and therefore aligned with the
+;; 2m coverage cell grid, so the value resolved for a vertex does not
+;; depend on which chunk framing served its cell.
 
 ;; https://www.maanmittauslaitos.fi/ortokuvien-ja-korkeusmallien-kyselypalvelu/tekninen-kuvaus
 ;; https://en.wikipedia.org/wiki/Esri_grid
@@ -39,15 +45,46 @@
 
 (def query-envelope-size-m
   "250x250m was selected as the grid size because of good perf/coverage
-  ratio with MML api."
+  ratio with MML api. Must be even so chunk corners align with the 2m
+  coverage cells (the coverage envelope bounds are multiples of 250)."
   250)
 
+(def max-concurrent-fetches
+  "Upper bound on simultaneous MML requests. MML is an external,
+  rate-limited API guarded by a circuit breaker in the job dispatcher;
+  fetches proceed in bounded waves instead of launching every chunk
+  fetch at once."
+  8)
+
+(defonce ^{:doc "Reusable connection pool shared by all MML requests.
+  Keep-alive connections avoid a fresh TCP+TLS handshake per request,
+  which matters when a route needs tens of chunk fetches."}
+  connection-manager
+  (doto (conn-mgr/make-reusable-conn-manager
+         {:timeout 30 ; Idle connection TTL (seconds)
+          :threads max-concurrent-fetches
+          :default-per-route max-concurrent-fetches})
+    ;; Health-check connections that sat idle >1s before reuse, so a
+    ;; keep-alive connection the server closed doesn't surface as an
+    ;; IOException mid-request
+    (.setValidateAfterInactivity 1000)))
+
 (def mml-http-options
-  "HTTP options for MML API requests with timeouts."
+  "HTTP options for MML API requests."
   {:connection-timeout 5000     ;; 5 seconds to establish connection
    :socket-timeout 120000       ;; 2 minutes for response (large grids take time)
+   :connection-request-timeout 10000 ;; 10 seconds to lease from the pool
+   :connection-manager connection-manager
    :throw-exceptions false      ;; Handle errors explicitly
-   :decompress-body true})
+   :decompress-body true
+   ;; GetCoverage GETs are idempotent - retry once on connection-
+   ;; establishment failures (e.g. a stale keep-alive connection that
+   ;; slipped past validation). Deliberately NOT on
+   ;; SocketTimeoutException: the server keeps computing the abandoned
+   ;; response, so retrying a slow request doubles its load.
+   :retry-handler (fn [ex try-count _ctx]
+                    (and (< try-count 2)
+                         (not (instance? java.net.SocketTimeoutException ex))))})
 
 (def elevation-chunk-timeout-ms
   "Timeout for fetching a single elevation grid chunk (3 minutes).
@@ -68,27 +105,59 @@
   2x2m coverage grid. Ensures that the returned envelope is within the
   bounds of the coverage's envelope."
   [{:keys [min-x min-y max-x max-y]} {:keys [envelope]}]
-  {:min-x (max (:min-x envelope) (let [n (Math/round min-x)] (if (odd? n) (dec n) n)))
-   :min-y (max (:min-y envelope) (let [n (Math/round min-y)] (if (odd? n) (dec n) n)))
-   :max-x (min (:max-x envelope) (let [n (Math/round max-x)] (if (odd? n) (dec n) n)))
-   :max-y (min (:max-y envelope) (let [n (Math/round max-y)] (if (odd? n) (dec n) n)))})
+  {:min-x (max (:min-x envelope) (let [n (Math/round (double min-x))] (if (odd? n) (dec n) n)))
+   :min-y (max (:min-y envelope) (let [n (Math/round (double min-y))] (if (odd? n) (dec n) n)))
+   :max-x (min (:max-x envelope) (let [n (Math/round (double max-x))] (if (odd? n) (dec n) n)))
+   :max-y (min (:max-y envelope) (let [n (Math/round (double max-y))] (if (odd? n) (dec n) n)))})
+
+(defn chunk-key
+  "Key [kx ky] of the fixed-grid chunk that contains the given TM35FIN
+  point. Chunk origins are multiples of `query-envelope-size-m`."
+  [[x y]]
+  [(long (Math/floor (/ x query-envelope-size-m)))
+   (long (Math/floor (/ y query-envelope-size-m)))])
+
+(defn chunk-key->envelope
+  "Envelope of fixed-grid chunk [kx ky], clamped to the coverage
+  envelope. Chunk corners are multiples of `query-envelope-size-m` and
+  hence already aligned with the 2m coverage cells; a chunk fully
+  outside the coverage yields a degenerate envelope whose MML request
+  fails, which fails the whole job (same outcome as the old
+  implementation for out-of-coverage geometries)."
+  [[kx ky]]
+  (let [{:keys [envelope]} coverage-info
+        size query-envelope-size-m]
+    {:min-x (max (:min-x envelope) (* kx size))
+     :max-x (min (:max-x envelope) (* (inc kx) size))
+     :min-y (max (:min-y envelope) (* ky size))
+     :max-y (min (:max-y envelope) (* (inc ky) size))}))
+
+(defn geometry-vertices
+  "All [lon lat] vertices of fcoll that `append-elevations` will resolve
+  an elevation for. Walks the geometry types exactly like
+  `append-elevations` so the fetched chunk set always covers the
+  resolved vertices."
+  [fcoll]
+  (into []
+        (mapcat
+         (fn [f]
+           (let [coords (-> f :geometry :coordinates)]
+             (condp = (-> f :geometry :type)
+               "Point"      [coords]
+               "LineString" coords
+               "Polygon"    (mapcat identity coords)
+               (throw (ex-info "Encountered unexpected geometry type" f))))))
+        (:features fcoll)))
 
 (defn resolve-elevation
-  [coords elevations]
-  (let [[lon lat]              (gis/wgs84->tm35fin-no-wrap coords)
-        ;; Find the correct grid
-        {:keys [headers data]} (->> elevations
-                                    (some
-                                     (fn [{:keys [headers] :as elevation}]
-                                       (let [min-x (:xllcorner headers)
-                                             min-y (:yllcorner headers)
-                                             max-x (+ min-x (* (:ncols headers)
-                                                               (:cellsize headers)))
-                                             max-y (+ min-y (* (:nrows headers)
-                                                               (:cellsize headers)))]
-                                         (and (>= max-x lon min-x)
-                                              (>= max-y lat min-y)
-                                              elevation)))))
+  [grid-index coords]
+  (let [[lon lat :as tm35] (gis/wgs84->tm35fin-no-wrap coords)
+        k (chunk-key tm35)
+
+        {:keys [headers rows]}
+        (or (get grid-index k)
+            (throw (ex-info "No elevation grid covers coordinate"
+                            {:coords coords :tm35fin tm35 :chunk-key k})))
 
         ;; Resolve col and row for the coords relative to the lower
         ;; left corner of the grid. Cap to max-bounds.
@@ -101,12 +170,10 @@
                            (:cellsize headers))))
                  (dec (:nrows headers)))]
 
-    ;; Reverse the data (rows) so the lower left corner comes first
-    ;; and we can lookup in 'natural' order.
-    (-> data rseq (nth row) (nth col))))
+    (-> rows (nth row) (nth col))))
 
 (defn append-elevations
-  [fcoll elevations]
+  [fcoll grid-index]
   (update fcoll :features
           (fn [fs]
             (map
@@ -115,18 +182,18 @@
                           (fn [coords]
                             (condp = (-> f :geometry :type)
                               "Point"      (let [[x y] coords]
-                                             [x y (resolve-elevation coords elevations)])
+                                             [x y (resolve-elevation grid-index coords)])
                               "LineString" (mapv
                                             (fn [coords]
                                               (let [[x y] coords]
-                                                [x y (resolve-elevation coords elevations)]))
+                                                [x y (resolve-elevation grid-index coords)]))
                                             coords)
                               "Polygon"    (mapv
                                             (fn [coords]
                                               (mapv
                                                (fn [coords]
                                                  (let [[x y] coords]
-                                                   [x y (resolve-elevation coords elevations)]))
+                                                   [x y (resolve-elevation grid-index coords)]))
                                                coords))
                                             coords)
                               (throw (ex-info "Encountered unexpected geometry type" f))))))
@@ -148,8 +215,7 @@
   (into []
         (for [s     lines
               :when (not-empty s)]
-          (->> (re-seq #"-?\d+\.?\d*" s)
-               (map parse-double)))))
+          (into [] (map parse-double) (re-seq #"-?\d+\.?\d*" s)))))
 
 (defn parse-ascii-grid
   [s]
@@ -158,6 +224,14 @@
         data-lines   (drop (count header-lines) lines)]
     {:headers (parse-ascii-grid-headers header-lines)
      :data    (parse-ascii-grid-data data-lines)}))
+
+(defn index-grid
+  "Prepare a parsed grid for O(1) vertex lookups: reverse the rows once
+  so the lower left corner comes first and row/col math works in
+  'natural' order."
+  [{:keys [headers data]}]
+  {:headers headers
+   :rows    (vec (rseq data))})
 
 (defn make-query-params
   [{:keys [min-x max-x min-y max-y]}]
@@ -187,20 +261,34 @@
                         {:status (:status response)
                          :envelope envelope}))))))
 
+(defn fetch-grids
+  "Fetch and index the elevation grids for chunk-keys with bounded
+  concurrency (waves of `max-concurrent-fetches`). Returns a map of
+  chunk-key -> indexed grid. Any chunk failure propagates and fails the
+  whole enrichment: the job queue retries and the circuit breaker in
+  the dispatcher sees the failure."
+  [chunk-keys]
+  (into {}
+        (mapcat
+         (fn [wave]
+           (mapv (fn [k grid] [k (index-grid grid)])
+                 wave
+                 (patterns/pmap-with-timeout
+                  elevation-chunk-timeout-ms
+                  (comp get-elevation-coverage chunk-key->envelope)
+                  wave))))
+        (partition-all max-concurrent-fetches chunk-keys)))
+
 (defn enrich-elevation
   [fcoll]
-  (let [;; Add some tolerance because otherwise grid queries might
-        ;; break near the edges. 8 meters was found via experimentation.
-        buff-m    8
-        fcoll-jts (-> fcoll gis/->jts-geom gis/transform-crs)
-        envelopes (-> (gis/get-envelope fcoll-jts buff-m)
-                      (fit-to-coverage coverage-info)
-                      (gis/chunk-envelope query-envelope-size-m)
-                      (->> (filter #(gis/intersects-envelope? % fcoll-jts))))]
-    (log/info "Fetching elevation data for" (count envelopes) "grid chunks")
-    (->> envelopes
-         (patterns/pmap-with-timeout elevation-chunk-timeout-ms get-elevation-coverage)
-         (append-elevations fcoll))))
+  (let [chunk-keys (->> (geometry-vertices fcoll)
+                        (map (comp chunk-key gis/wgs84->tm35fin-no-wrap))
+                        distinct
+                        sort)]
+    (log/info "Fetching elevation data for" (count chunk-keys) "grid chunks")
+    (-> chunk-keys
+        fetch-grids
+        (->> (append-elevations fcoll)))))
 
 (comment
   (->> (describe-coverage)
@@ -222,33 +310,18 @@
       (->> (map gis/wgs84->tm35fin-no-wrap)))
   ;; => ([434355.5312499977 6943966.504886635])
 
-  (-> test-point
-      gis/->tm35fin-envelope
-      make-query-params)
-
-  {"service"     "WCS",
-   "version"     "2.0.1",
-   "request"     "GetCoverage",
-   "format"      "text/plain",
-   "CoverageID"  "korkeusmalli_2m",
-   "SCALEFACTOR" "1",
-   "SUBSET"      ["N(6943964,6943968)" "E(434353,434357)"]}
-
-  (def lol
-    {:headers
-     {:ncols     2,
-      :nrows     2,
-      :xllcorner 434353.0,
-      :yllcorner 6943964.0,
-      :cellsize  2.0},
-     :data (list (list 152.55 152.34) (list 152.39 152.3))})
-
-  (resolve-elevation [25.720539797408946,
-                      62.62057217751676] lol)
-  ;; => 152.34
-
-  (-> (list (list 152.55 152.34) (list 152.39 152.3)) (nth 1) (nth 1))
-
+  ;; Timings measured against the MML api (2026-07-05 re-check pending;
+  ;; original measurements below):
+  ;; :m10    1951 ms  <--- cold start?
+  ;; :m25     244 ms
+  ;; :m50     257 ms
+  ;; :m100    241 ms
+  ;; :m250    255 ms  <--- sweet spot?
+  ;; :m500    436 ms
+  ;; :m1000   740 ms
+  ;; :m2500  2919 ms
+  ;; :m5000  16045 ms
+  ;; :m10000 62406 ms
   (def test-envelopes
     [[:m10    {:min-x 400000 :max-x 400010 :min-y 6900000 :max-y 6900010}]
      [:m25    {:min-x 400000 :max-x 400025 :min-y 6900000 :max-y 6900025}]
@@ -256,42 +329,16 @@
      [:m100   {:min-x 400000 :max-x 400100 :min-y 6900000 :max-y 6900100}]
      [:m250   {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250}]
      [:m500   {:min-x 400000 :max-x 400500 :min-y 6900000 :max-y 6900500}]
-     [:m1000  {:min-x 400000 :max-x 401000 :min-y 6900000 :max-y 6901000}]
-     [:m2500  {:min-x 400000 :max-x 402500 :min-y 6900000 :max-y 6902500}]
-     [:m5000  {:min-x 400000 :max-x 405000 :min-y 6900000 :max-y 6905000}]
-     [:m10000 {:min-x 400000 :max-x 410000 :min-y 6900000 :max-y 6910000}]])
+     [:m1000  {:min-x 400000 :max-x 401000 :min-y 6900000 :max-y 6901000}]])
 
   (doseq [[k v] test-envelopes]
     (println k)
     (let [output (with-out-str (time (get-elevation-coverage v)))]
       (println output)))
 
-  ;; :m10
-  ;; "Elapsed time: 1951.641453 msecs"  <--- cold start?
-  ;; :m25
-  ;; "Elapsed time: 244.095314 msecs"
-  ;; :m50
-  ;; "Elapsed time: 256.81999 msecs"
-  ;; :m100
-  ;; "Elapsed time: 241.35635 msecs"
-  ;; :m250
-  ;; "Elapsed time: 255.206125 msecs"   <--- sweet spot?
-  ;; :m500
-  ;; "Elapsed time: 436.237267 msecs"
-  ;; :m1000
-  ;; "Elapsed time: 740.046107 msecs"
-  ;; :m2500
-  ;; "Elapsed time: 2919.371703 msecs"
-  ;; :m5000
-  ;; "Elapsed time: 16044.512852 msecs"
-  ;; :m10000
-  ;; "Elapsed time: 62406.48823 msecs"
-
   (def dada "NCOLS 1\r\nNROWS 1\r\nXLLCORNER 434354.531249997672\r\nYLLCORNER 6943965.504886634648\r\nCELLSIZE 1.000000000000\r\nNODATA_VALUE -9999\r\n")
 
   (parse-ascii-grid-headers (str/split-lines dada))
-
-  (re-find #"(\w+)\s*(-?\d+\.?\d*)" "kissa    -9999.0")
 
   (def test-route
     {:type "FeatureCollection",
@@ -309,49 +356,11 @@
         [[26.2436550567509, 63.9531552213109],
          [25.7583312263512, 63.9746827436437]]}}]})
 
-  (-> (gis/->tm35fin-envelope test-route 2)
-      (fit-to-coverage coverage-info)
-      (gis/chunk-envelope 10000))
-  ;; => [{:min-x 439212, :max-x 449212, :min-y 7087406, :max-y 7094786}
-  ;;     {:min-x 449212, :max-x 459212, :min-y 7087406, :max-y 7094786}
-  ;;     {:min-x 459212, :max-x 469212, :min-y 7087406, :max-y 7094786}
-  ;;     {:min-x 469212, :max-x 473044, :min-y 7087406, :max-y 7094786}]
+  ;; The old implementation selected chunks by line-corridor
+  ;; intersection: 165 chunks (~41s of fetches) for this 4-vertex
+  ;; route. Vertex-driven selection fetches 4.
+  (->> (geometry-vertices test-route)
+       (map (comp chunk-key gis/wgs84->tm35fin-no-wrap))
+       distinct)
 
-  (-> (gis/->tm35fin-envelope test-route 2)
-      (fit-to-coverage coverage-info)
-      (gis/chunk-envelope 250)
-      (->> (filter #(gis/intersects-envelope? % test-route))))
-
-  ;; Without filter
-  (count *1)
-  ;; => 4110
-
-  ;; with filter
-  (def lolz *1)
-  (count lolz)
-  ;; => 165
-
-  (* 250 165)
-
-  (def big-data
-    (get-elevation-coverage {:min-x 439212, :max-x 449212, :min-y 7087406, :max-y 7094786}))
-
-  big-data
-
-  (:headers big-data)
-  ;; => {:ncols 5000,
-  ;;     :nrows 3690,
-  ;;     :xllcorner 439212.0,
-  ;;     :yllcorner 7087406.0,
-  ;;     :cellsize 2.0}
-
-  (enrich-elevation test-route)
-
-  (+ 1 1)
-
-  (def lolx *1)
-
-  (- (:max-x lolx) (:min-x lolx))
-
-  (get-elevation-coverage test-route)
   (enrich-elevation test-route))

--- a/webapp/src/clj/lipas/backend/elevation.clj
+++ b/webapp/src/clj/lipas/backend/elevation.clj
@@ -164,7 +164,7 @@
   "Returns an envelope that contains given envelope and 'matches' MML
   2x2m coverage grid. Ensures that the returned envelope is within the
   bounds of the coverage's envelope."
-  [{:keys [min-x min-y max-x max-y]} _coverage-info]
+  [{:keys [min-x min-y max-x max-y]}]
   (let [down-to-even (fn [v] (let [n (Math/round (double v))] (if (odd? n) (dec n) n)))]
     (clamp-to-coverage {:min-x (down-to-even min-x)
                         :min-y (down-to-even min-y)
@@ -212,7 +212,7 @@
        :max-x (+ (reduce max (map first tm35-vertices)) vertex-buffer-m)
        :min-y (- (reduce min (map second tm35-vertices)) vertex-buffer-m)
        :max-y (+ (reduce max (map second tm35-vertices)) vertex-buffer-m)}
-      (fit-to-coverage coverage-info)))
+      fit-to-coverage))
 
 (defn plan-fetches
   "Plan the MML requests needed to resolve elevations for the given
@@ -249,10 +249,9 @@
 
 (defn map-vertices
   "Eagerly map f over every vertex coordinate of fcoll, rebuilding the
-  feature collection. Both vertex collection and z-appending go
-  through this single walk, so the walk order (and thereby the fetched
-  chunk set covering the resolved vertices) is structural, not a
-  documented invariant."
+  feature collection. Must visit vertices in the same order as
+  `reduce-vertices` (the test suite pins the two walks together), so
+  the fetched chunk set always covers the resolved vertices."
   [f fcoll]
   (update fcoll :features
           (fn [fs]
@@ -267,20 +266,34 @@
                               (throw (ex-info "Encountered unexpected geometry type" feat))))))
              fs))))
 
+(defn reduce-vertices
+  "Reduce rf over every vertex coordinate of fcoll without rebuilding
+  the collection, in the same order `map-vertices` visits them."
+  [rf init fcoll]
+  (reduce
+   (fn [acc feat]
+     (let [coords (-> feat :geometry :coordinates)]
+       (condp = (-> feat :geometry :type)
+         "Point"      (rf acc coords)
+         "LineString" (reduce rf acc coords)
+         "Polygon"    (reduce #(reduce rf %1 %2) acc coords)
+         (throw (ex-info "Encountered unexpected geometry type" feat)))))
+   init
+   (:features fcoll)))
+
 (defn geometry-vertices
   "All vertex coordinates of fcoll that `append-elevations` will
   resolve an elevation for, in walk order."
   [fcoll]
-  (let [acc (volatile! (transient []))]
-    (map-vertices (fn [c] (vswap! acc conj! c) c) fcoll)
-    (persistent! @acc)))
+  (persistent! (reduce-vertices conj! (transient []) fcoll)))
 
 (defn resolve-elevation
-  "Resolve the elevation of a TM35FIN point from the grid index. The
-  col/row cap keeps a point exactly on its grid's max edge in the edge
-  cell; anything further outside the grid means MML returned a grid
-  that doesn't cover the requested envelope, which must fail loudly
-  instead of silently resolving a wrong edge cell."
+  "Resolve the elevation of a TM35FIN point from the grid index. A
+  point exactly on its grid's max edge (a coverage-envelope max-edge
+  vertex, see `chunk-key`) caps into the edge cell; anything else
+  outside the grid means MML returned a grid that doesn't cover the
+  requested envelope, which must fail loudly instead of silently
+  resolving a wrong edge cell."
   [grid-index [x y :as tm35]]
   (let [k (chunk-key tm35)
 
@@ -292,11 +305,12 @@
         {:keys [xllcorner yllcorner cellsize ncols nrows]} headers
 
         ;; Resolve col and row for the coords relative to the lower
-        ;; left corner of the grid. Cap to max-bounds.
+        ;; left corner of the grid
         col (long (Math/floor (/ (- x xllcorner) cellsize)))
         row (long (Math/floor (/ (- y yllcorner) cellsize)))]
 
-    (when-not (and (<= 0 col ncols) (<= 0 row nrows))
+    (when-not (and (or (< -1 col ncols) (== (double x) (+ xllcorner (* ncols cellsize))))
+                   (or (< -1 row nrows) (== (double y) (+ yllcorner (* nrows cellsize)))))
       (throw (ex-info "Vertex outside its elevation grid"
                       {:tm35fin tm35 :chunk-key k :headers headers})))
 
@@ -383,7 +397,21 @@
                      :query-params (make-query-params envelope)
                      :basic-auth   (str mml-api-key ":")})]
     (log/info "Getting coverage with envelope" envelope)
-    (let [response (client/get mml-coverage-url opts)]
+    (let [response (try
+                     (client/get mml-coverage-url opts)
+                     ;; Socket/connect/pool-lease timeouts extend
+                     ;; InterruptedIOException, which the circuit
+                     ;; breaker's interrupt classifier would rethrow
+                     ;; without counting (it can't tell them from a job
+                     ;; watchdog interrupt). Rethrow as ex-info WITHOUT
+                     ;; the original as cause so MML slowness actually
+                     ;; trips the breaker.
+                     (catch java.net.SocketTimeoutException e
+                       (throw (ex-info (str "MML request timed out: " (ex-message e))
+                                       {:envelope envelope :error (str (class e))})))
+                     (catch org.apache.http.conn.ConnectTimeoutException e
+                       (throw (ex-info (str "MML request timed out: " (ex-message e))
+                                       {:envelope envelope :error (str (class e))}))))]
       (cond
         (= 200 (:status response))
         (-> (parse-ascii-grid (:body response))
@@ -423,7 +451,7 @@
 
 (defn enrich-elevation
   [fcoll]
-  (let [tm35-vertices (mapv gis/wgs84->tm35fin-no-wrap (geometry-vertices fcoll))
+  (let [tm35-vertices (gis/wgs84->tm35fin-coords (geometry-vertices fcoll))
         fetch-plan    (plan-fetches tm35-vertices)]
     (log/info "Fetching elevation data for" (count tm35-vertices) "vertices in"
               (count fetch-plan) "requests")

--- a/webapp/src/clj/lipas/backend/gis.clj
+++ b/webapp/src/clj/lipas/backend/gis.clj
@@ -118,6 +118,22 @@
   (let [transformed (transform-geom (->jts-point lon lat) srid tm35fin-srid)]
     [(.getX transformed) (.getY transformed)]))
 
+(defn wgs84->tm35fin-coords
+  "Batch version of `wgs84->tm35fin-no-wrap`: transforms every
+  [lon lat] with a single transform construction instead of one JTS
+  point + transform per coordinate. Applies the same per-coordinate
+  math, so results are identical to the single-point fn."
+  [coords]
+  (let [xform (BasicCoordinateTransform. (crs srid) (crs tm35fin-srid))
+        src (ProjCoordinate.)
+        dst (ProjCoordinate.)]
+    (mapv (fn [[lon lat]]
+            (set! (.-x src) (double lon))
+            (set! (.-y src) (double lat))
+            (.transform xform src dst)
+            [(.-x dst) (.-y dst)])
+          coords)))
+
 (defn epsg3067-point->envelope [[e n] delta]
   [[(- e delta) (+ n delta)] [(+ e delta) (- n delta)]])
 

--- a/webapp/test/clj/lipas/backend/elevation_test.clj
+++ b/webapp/test/clj/lipas/backend/elevation_test.clj
@@ -171,7 +171,7 @@
       (is (= 1 (count plan)))
       (is (= #{[1600 27600] [1601 27600]} (set (:chunk-keys (first plan)))))))
 
-  (testing "Dense cluster (>= 4 chunks in a 1000m tile) merges into one tile request"
+  (testing "Dense cluster (>= 3 chunks in a 1000m tile) merges into one tile request"
     (let [verts [[400010.0 6900010.0] [400260.0 6900010.0]
                  [400510.0 6900010.0] [400760.0 6900010.0]]
           [{:keys [envelope chunk-keys]} :as plan] (elevation/plan-fetches verts)]
@@ -179,10 +179,10 @@
       (is (= {:min-x 400000 :max-x 401000 :min-y 6900000 :max-y 6901000} envelope))
       (is (= 4 (count chunk-keys)))))
 
-  (testing "Sparse chunks (< 4 per tile) are fetched individually"
-    (let [verts [[400010.0 6900010.0] [400260.0 6900010.0] [400510.0 6900010.0]]
+  (testing "Sparse chunks (< 3 per tile) are fetched individually"
+    (let [verts [[400010.0 6900010.0] [400510.0 6900010.0]]
           plan  (elevation/plan-fetches verts)]
-      (is (= 3 (count plan)))
+      (is (= 2 (count plan)))
       (is (every? #(= 1 (count (:chunk-keys %))) plan))
       (is (= {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250}
              (:envelope (first plan))))))

--- a/webapp/test/clj/lipas/backend/elevation_test.clj
+++ b/webapp/test/clj/lipas/backend/elevation_test.clj
@@ -124,6 +124,22 @@
                   "NCOLS 1\r\nNROWS 1\r\nXLLCORNER 0\r\nYLLCORNER 0\r\nCELLSIZE 2.0\r\n1.0\n\n")]
       (is (= [[1.0]] (:data parsed))))))
 
+(deftest validate-grid-test
+  (let [env  {:min-x 400000 :max-x 400004 :min-y 6900000 :max-y 6900004}
+        grid (elevation/parse-ascii-grid (synthetic-grid-body env))]
+    (testing "A well-formed grid passes through unchanged"
+      (is (= grid (elevation/validate-grid grid env))))
+
+    (testing "Missing rows (truncated response) throw"
+      (is (thrown-with-msg? ExceptionInfo #"MML grid dimensions"
+                            (elevation/validate-grid
+                             (update grid :data pop) env))))
+
+    (testing "A short row (truncated mid-row) throws"
+      (is (thrown-with-msg? ExceptionInfo #"MML grid dimensions"
+                            (elevation/validate-grid
+                             (update-in grid [:data 1] pop) env))))))
+
 (deftest chunk-key-test
   (testing "Chunk keys are quotients of the fixed 250m grid"
     (is (= [1600 27600] (elevation/chunk-key [400000.0 6900000.0])))
@@ -143,6 +159,15 @@
             {:keys [min-x max-x min-y max-y]} (elevation/chunk-key->envelope
                                                (elevation/chunk-key p))]
         (is (and (>= x min-x) (< x max-x) (>= y min-y) (< y max-y))))))
+
+  (testing "A point exactly on the coverage max edge maps to the last chunk inside"
+    (let [{:keys [envelope]} elevation/coverage-info
+          k (elevation/chunk-key [(:max-x envelope) (:max-y envelope)])
+          {:keys [min-x max-x min-y max-y]} (elevation/chunk-key->envelope k)]
+      (is (= [(dec (/ (:max-x envelope) 250)) (dec (/ (:max-y envelope) 250))] k))
+      ;; non-degenerate envelope whose max edge touches the coverage max
+      (is (and (< min-x max-x) (< min-y max-y)
+               (= max-x (:max-x envelope)) (= max-y (:max-y envelope))))))
 
   (testing "Chunk envelopes are clamped to the coverage envelope"
     (let [{:keys [envelope]} elevation/coverage-info]
@@ -254,8 +279,9 @@
 (deftest resolve-elevation-test
   ;; Reference case from the original implementation's comment block:
   ;; test-point resolves to 152.34 from this 2x2 grid.
-  (let [test-point [25.720539797408946 62.62057217751676] ;; tm35fin ~[434355.53 6943966.50]
-        k          (elevation/chunk-key (gis/wgs84->tm35fin-no-wrap test-point))
+  (let [test-point (gis/wgs84->tm35fin-no-wrap
+                    [25.720539797408946 62.62057217751676]) ;; ~[434355.53 6943966.50]
+        k          (elevation/chunk-key test-point)
         grid       {:headers {:ncols 2 :nrows 2 :xllcorner 434352.0
                               :yllcorner 6943964.0 :cellsize 2.0}
                     ;; rows top-down as parsed from the ascii grid
@@ -265,13 +291,17 @@
     (testing "Row/col math relative to the grid's lower left corner"
       (is (= 152.34 (elevation/resolve-elevation index test-point))))
 
-    (testing "Col and row are capped to the grid bounds (edge cells)"
-      (let [tiny  {k (elevation/index-grid
-                      {:headers {:ncols 1 :nrows 1 :xllcorner 434352.0
-                                 :yllcorner 6943964.0 :cellsize 2.0}
-                       :data [[152.55]]})}]
-        ;; col/row would compute to 1 but are capped to ncols-1 = 0
-        (is (= 152.55 (elevation/resolve-elevation tiny test-point)))))
+    (testing "A point exactly on the grid's max edge reads the edge cell"
+      (let [edge-point [434356.0 6943968.0] ;; == grid max corner
+            index      {(elevation/chunk-key edge-point) (elevation/index-grid grid)}]
+        ;; col/row compute to ncols/nrows and are capped to the edge cell
+        (is (= 152.34 (elevation/resolve-elevation index edge-point)))))
+
+    (testing "A point further outside its grid fails loudly"
+      (let [far-point [434360.5 6943970.5] ;; > 1 cell beyond the grid
+            index     {(elevation/chunk-key far-point) (elevation/index-grid grid)}]
+        (is (thrown-with-msg? ExceptionInfo #"Vertex outside its elevation grid"
+                              (elevation/resolve-elevation index far-point)))))
 
     (testing "NODATA value passes through unchanged"
       (let [nodata {k (elevation/index-grid

--- a/webapp/test/clj/lipas/backend/elevation_test.clj
+++ b/webapp/test/clj/lipas/backend/elevation_test.clj
@@ -1,31 +1,480 @@
 (ns lipas.backend.elevation-test
-  (:require [clojure.test :refer [deftest testing is]]
-            [lipas.backend.elevation :as elevation]))
+  "Tests for elevation enrichment.
 
-;;; Tests for HTTP timeout options and error handling ;;;
+  Integration tests mock the MML fetch (`get-elevation-coverage`) with
+  synthetic ESRI ascii grids built from a deterministic, cell-unique
+  elevation function, so exact z-values can be asserted without network
+  access. The old (pre vertex-driven optimization) implementation is
+  copied at the bottom of this namespace and used to assert exact
+  old-vs-new equivalence of the produced values."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [lipas.backend.elevation :as elevation]
+            [lipas.backend.gis :as gis]
+            [lipas.jobs.patterns :as patterns])
+  (:import [clojure.lang ExceptionInfo]))
 
-(deftest mml-http-options-test
-  (testing "HTTP options include connection timeout"
-    (is (pos? (:connection-timeout elevation/mml-http-options))))
+;;; Synthetic elevation model ;;;
 
-  (testing "HTTP options include socket timeout"
-    (is (pos? (:socket-timeout elevation/mml-http-options))))
+(defn synthetic-z-str
+  "Deterministic, cell-unique elevation for the 2m cell with lower left
+  corner [cx cy] (TM35FIN), as it would appear in the ascii grid body.
+  cx + cy/1e7 is injective over the whole coverage envelope, so reading
+  the wrong cell always produces a different value."
+  [cx cy]
+  (format "%.7f" (+ cx (/ cy 1e7))))
 
-  (testing "HTTP options disable exception throwing for error handling"
-    (is (false? (:throw-exceptions elevation/mml-http-options)))))
+(defn expected-z
+  "The z value the synthetic coverage yields for a WGS84 coordinate:
+  computed through the same format+parse round trip as the mock grids."
+  [coords]
+  (let [[x y] (gis/wgs84->tm35fin-no-wrap coords)
+        cx    (* 2 (long (Math/floor (/ x 2))))
+        cy    (* 2 (long (Math/floor (/ y 2))))]
+    (parse-double (synthetic-z-str cx cy))))
 
-(deftest elevation-chunk-timeout-test
-  (testing "elevation chunk timeout constant is defined and positive"
-    (is (pos? elevation/elevation-chunk-timeout-ms))
-    ;; Should be at least 1 minute for large grids
-    (is (>= elevation/elevation-chunk-timeout-ms 60000))))
+(defn synthetic-grid-body
+  "ESRI ascii grid text covering the envelope with synthetic-z values.
+  Works for any 2m-aligned envelope (both the new fixed 250m chunks and
+  the old geometry-envelope-aligned chunks)."
+  [{:keys [min-x max-x min-y max-y]}]
+  (let [ncols (long (/ (- max-x min-x) 2))
+        nrows (long (/ (- max-y min-y) 2))]
+    (str "NCOLS " ncols "\r\n"
+         "NROWS " nrows "\r\n"
+         "XLLCORNER " min-x "\r\n"
+         "YLLCORNER " min-y "\r\n"
+         "CELLSIZE 2.0\r\n"
+         "NODATA_VALUE -9999\r\n"
+         (str/join "\n"
+                   (for [row (range nrows)] ;; rows top-down (north first)
+                     (let [cy (+ min-y (* 2 (- nrows 1 row)))]
+                       (str/join " "
+                                 (for [col (range ncols)]
+                                   (synthetic-z-str (+ min-x (* 2 col)) cy)))))))))
+
+(defn synthetic-coverage
+  "Drop-in mock for `elevation/get-elevation-coverage`: parses a
+  synthetic grid body with the real parser."
+  [envelope]
+  (elevation/parse-ascii-grid (synthetic-grid-body envelope)))
+
+(defn counting
+  "Wrap f so calls are counted in the counter atom."
+  [counter f]
+  (fn [& args]
+    (swap! counter inc)
+    (apply f args)))
+
+;;; Pure function tests ;;;
+
+(deftest fit-to-coverage-test
+  (testing "Rounds to even coordinates (2m cell alignment)"
+    (is (= {:min-x 400000 :min-y 6900000 :max-x 400010 :max-y 6900012}
+           (elevation/fit-to-coverage
+            {:min-x 400001.4 :min-y 6900000.6 :max-x 400010.5 :max-y 6900011.9}
+            elevation/coverage-info))))
+
+  (testing "Even values pass through"
+    (is (= {:min-x 400002 :min-y 6900004 :max-x 400006 :max-y 6900008}
+           (elevation/fit-to-coverage
+            {:min-x 400002.0 :min-y 6900004.0 :max-x 400006.0 :max-y 6900008.0}
+            elevation/coverage-info))))
+
+  (testing "Clamps to the coverage envelope"
+    (let [{:keys [envelope]} elevation/coverage-info
+          fitted (elevation/fit-to-coverage
+                  {:min-x 0.0 :min-y 0.0 :max-x 99999999.0 :max-y 99999999.0}
+                  elevation/coverage-info)]
+      (is (= {:min-x (:min-x envelope) :min-y (:min-y envelope)
+              :max-x (:max-x envelope) :max-y (:max-y envelope)}
+             fitted)))))
+
+(deftest parse-ascii-grid-test
+  (testing "Headers with CRLF line endings (MML response format)"
+    (let [dada    (str "NCOLS 1\r\nNROWS 1\r\nXLLCORNER 434354.531249997672\r\n"
+                       "YLLCORNER 6943965.504886634648\r\nCELLSIZE 1.000000000000\r\n"
+                       "NODATA_VALUE -9999\r\n")
+          headers (elevation/parse-ascii-grid-headers (str/split-lines dada))]
+      (is (= 1 (:ncols headers)))
+      (is (= 1 (:nrows headers)))
+      (is (= 434354.531249997672 (:xllcorner headers)))
+      (is (= 6943965.504886634648 (:yllcorner headers)))
+      (is (= 1.0 (:cellsize headers)))
+      (is (= -9999 (:nodata_value headers)))))
+
+  (testing "Data rows incl. negative and NODATA values"
+    (let [s      (str "NCOLS 3\r\nNROWS 2\r\nXLLCORNER 434352\r\nYLLCORNER 6943964\r\n"
+                      "CELLSIZE 2.0\r\nNODATA_VALUE -9999\r\n"
+                      "152.55 -0.34 -9999\n"
+                      "152.39 152.3 7.0\n")
+          parsed (elevation/parse-ascii-grid s)]
+      (is (= [[152.55 -0.34 -9999.0]
+              [152.39 152.3 7.0]]
+             (:data parsed)))))
+
+  (testing "Data is fully realized vectors for O(1) lookups"
+    (let [parsed (elevation/parse-ascii-grid
+                  "NCOLS 2\r\nNROWS 1\r\nXLLCORNER 0\r\nYLLCORNER 0\r\nCELLSIZE 2.0\r\n1.0 2.0\n")]
+      (is (vector? (:data parsed)))
+      (is (every? vector? (:data parsed)))))
+
+  (testing "Trailing empty lines are skipped"
+    (let [parsed (elevation/parse-ascii-grid
+                  "NCOLS 1\r\nNROWS 1\r\nXLLCORNER 0\r\nYLLCORNER 0\r\nCELLSIZE 2.0\r\n1.0\n\n")]
+      (is (= [[1.0]] (:data parsed))))))
+
+(deftest chunk-key-test
+  (testing "Chunk keys are quotients of the fixed 250m grid"
+    (is (= [1600 27600] (elevation/chunk-key [400000.0 6900000.0])))
+    (is (= [1600 27600] (elevation/chunk-key [400249.99 6900249.99])))
+    (is (= [1601 27601] (elevation/chunk-key [400250.0 6900250.0])))
+    (is (= [1599 27599] (elevation/chunk-key [399999.99 6899999.99]))))
+
+  (testing "Chunk envelope corners are 2m-aligned multiples of 250"
+    (let [env (elevation/chunk-key->envelope [1600 27600])]
+      (is (= {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250} env))
+      (is (every? even? (vals env)))))
+
+  (testing "Every TM35FIN point is inside its own chunk envelope"
+    (doseq [p [[400000.0 6900000.0] [400249.99 6900249.99]
+               [434355.5312 6943966.5048] [44000.01 6594000.01]]]
+      (let [[x y] p
+            {:keys [min-x max-x min-y max-y]} (elevation/chunk-key->envelope
+                                               (elevation/chunk-key p))]
+        (is (and (>= x min-x) (< x max-x) (>= y min-y) (< y max-y))))))
+
+  (testing "Chunk envelopes are clamped to the coverage envelope"
+    (let [{:keys [envelope]} elevation/coverage-info]
+      ;; First chunk column inside coverage
+      (is (= (:min-x envelope)
+             (:min-x (elevation/chunk-key->envelope [(/ (:min-x envelope) 250) 27600]))))
+      ;; Chunk fully outside coverage collapses to a degenerate
+      ;; envelope (min > max) whose MML request fails the job
+      (let [env (elevation/chunk-key->envelope [0 27600])]
+        (is (> (:min-x env) (:max-x env)))))))
+
+(deftest geometry-vertices-test
+  (testing "Point"
+    (is (= [[25.7 62.6]]
+           (elevation/geometry-vertices
+            {:type "FeatureCollection"
+             :features [{:type "Feature"
+                         :geometry {:type "Point" :coordinates [25.7 62.6]}}]}))))
+
+  (testing "LineString"
+    (is (= [[25.7 62.6] [25.8 62.7]]
+           (elevation/geometry-vertices
+            {:type "FeatureCollection"
+             :features [{:type "Feature"
+                         :geometry {:type "LineString"
+                                    :coordinates [[25.7 62.6] [25.8 62.7]]}}]}))))
+
+  (testing "Polygon with a hole includes every ring's vertices"
+    (is (= [[25.0 62.0] [25.1 62.0] [25.1 62.1] [25.0 62.0]
+            [25.04 62.04] [25.06 62.04] [25.06 62.06] [25.04 62.04]]
+           (elevation/geometry-vertices
+            {:type "FeatureCollection"
+             :features [{:type "Feature"
+                         :geometry {:type "Polygon"
+                                    :coordinates
+                                    [[[25.0 62.0] [25.1 62.0] [25.1 62.1] [25.0 62.0]]
+                                     [[25.04 62.04] [25.06 62.04] [25.06 62.06] [25.04 62.04]]]}}]}))))
+
+  (testing "Multiple features concatenate in order"
+    (is (= [[25.7 62.6] [25.8 62.7] [25.9 62.8]]
+           (elevation/geometry-vertices
+            {:type "FeatureCollection"
+             :features [{:type "Feature"
+                         :geometry {:type "LineString"
+                                    :coordinates [[25.7 62.6] [25.8 62.7]]}}
+                        {:type "Feature"
+                         :geometry {:type "Point" :coordinates [25.9 62.8]}}]}))))
+
+  (testing "Unexpected geometry type throws"
+    (is (thrown? ExceptionInfo
+                 (elevation/geometry-vertices
+                  {:type "FeatureCollection"
+                   :features [{:type "Feature"
+                               :geometry {:type "MultiPoint"
+                                          :coordinates [[25.7 62.6]]}}]})))))
+
+(deftest resolve-elevation-test
+  ;; Reference case from the original implementation's comment block:
+  ;; test-point resolves to 152.34 from this 2x2 grid.
+  (let [test-point [25.720539797408946 62.62057217751676] ;; tm35fin ~[434355.53 6943966.50]
+        k          (elevation/chunk-key (gis/wgs84->tm35fin-no-wrap test-point))
+        grid       {:headers {:ncols 2 :nrows 2 :xllcorner 434352.0
+                              :yllcorner 6943964.0 :cellsize 2.0}
+                    ;; rows top-down as parsed from the ascii grid
+                    :data [[152.55 152.34] [152.39 152.3]]}
+        index      {k (elevation/index-grid grid)}]
+
+    (testing "Row/col math relative to the grid's lower left corner"
+      (is (= 152.34 (elevation/resolve-elevation index test-point))))
+
+    (testing "Col and row are capped to the grid bounds (edge cells)"
+      (let [tiny  {k (elevation/index-grid
+                      {:headers {:ncols 1 :nrows 1 :xllcorner 434352.0
+                                 :yllcorner 6943964.0 :cellsize 2.0}
+                       :data [[152.55]]})}]
+        ;; col/row would compute to 1 but are capped to ncols-1 = 0
+        (is (= 152.55 (elevation/resolve-elevation tiny test-point)))))
+
+    (testing "NODATA value passes through unchanged"
+      (let [nodata {k (elevation/index-grid
+                       {:headers {:ncols 2 :nrows 2 :xllcorner 434352.0
+                                  :yllcorner 6943964.0 :cellsize 2.0}
+                        :data [[-9999.0 -9999.0] [-9999.0 -9999.0]]})}]
+        (is (= -9999.0 (elevation/resolve-elevation nodata test-point)))))
+
+    (testing "Vertex without a covering grid throws a descriptive error"
+      (is (thrown-with-msg? ExceptionInfo #"No elevation grid covers coordinate"
+                            (elevation/resolve-elevation {} test-point))))))
+
+(deftest index-grid-test
+  (testing "Rows are reversed so the lower left corner comes first"
+    (is (= {:headers {:ncols 2}
+            :rows    [[3.0 4.0] [1.0 2.0]]}
+           (elevation/index-grid {:headers {:ncols 2}
+                                  :data    [[1.0 2.0] [3.0 4.0]]})))))
+
+;;; Integration tests with mocked MML fetch ;;;
+
+(def point-fcoll
+  {:type "FeatureCollection"
+   :features
+   [{:type "Feature"
+     :properties {:name "test point"}
+     :geometry {:type "Point"
+                :coordinates [25.720539797408946 62.62057217751676]}}]})
+
+(def route-fcoll
+  "Two-feature route whose 4 vertices land in 3 distinct chunks. The
+  old implementation fetched 165 corridor chunks for this geometry."
+  {:type "FeatureCollection"
+   :features
+   [{:type "Feature"
+     :properties {:name "leg 1"}
+     :geometry {:type "LineString"
+                :coordinates [[26.2436753445903 63.9531598143881]
+                              [26.4505514903968 63.9127506671744]]}}
+    {:type "Feature"
+     :properties {:name "leg 2"}
+     :geometry {:type "LineString"
+                :coordinates [[26.2436550567509 63.9531552213109]
+                              [25.7583312263512 63.9746827436437]]}}]})
+
+(def polygon-fcoll
+  {:type "FeatureCollection"
+   :features
+   [{:type "Feature"
+     :geometry {:type "Polygon"
+                :coordinates
+                [[[25.72 62.62] [25.7205 62.62] [25.7205 62.6205] [25.72 62.62]]
+                 [[25.7201 62.6201] [25.7203 62.6201] [25.7203 62.6202] [25.7201 62.6201]]]}}]})
+
+(deftest enrich-point-test
+  (let [requests (atom 0)]
+    (with-redefs [elevation/get-elevation-coverage (counting requests synthetic-coverage)]
+      (let [enriched (elevation/enrich-elevation point-fcoll)
+            [x y z]  (-> enriched :features first :geometry :coordinates)]
+        (testing "One vertex needs exactly one MML request"
+          (is (= 1 @requests)))
+        (testing "x/y preserved, z resolved from the containing 2m cell"
+          (is (= [25.720539797408946 62.62057217751676] [x y]))
+          (is (= (expected-z [x y]) z)))
+        (testing "Feature structure and properties pass through"
+          (is (= (assoc-in point-fcoll [:features 0 :geometry :coordinates]
+                           [x y z])
+                 (update enriched :features vec))))))))
+
+(deftest enrich-multi-chunk-route-test
+  (let [requests (atom 0)]
+    (with-redefs [elevation/get-elevation-coverage (counting requests synthetic-coverage)]
+      (let [enriched (elevation/enrich-elevation route-fcoll)]
+        (testing "Chunk count is vertex-driven: 4 vertices / 3 distinct chunks"
+          (is (= 3 @requests)))
+        (testing "Every vertex gets the exact synthetic z of its own cell"
+          (doseq [f    (:features enriched)
+                  [x y z] (-> f :geometry :coordinates)]
+            (is (= (expected-z [x y]) z))))
+        (testing "Feature order and properties are preserved"
+          (is (= ["leg 1" "leg 2"]
+                 (mapv #(-> % :properties :name) (:features enriched))))
+          (is (= (mapv #(mapv (fn [c] (subvec c 0 2)) (-> % :geometry :coordinates))
+                       (:features route-fcoll))
+                 (mapv #(mapv (fn [c] (subvec c 0 2)) (-> % :geometry :coordinates))
+                       (vec (:features enriched))))))))))
+
+(deftest enrich-polygon-test
+  (with-redefs [elevation/get-elevation-coverage synthetic-coverage]
+    (let [enriched (elevation/enrich-elevation polygon-fcoll)]
+      (testing "All ring vertices (incl. hole) get exact z values"
+        (doseq [ring    (-> enriched :features first :geometry :coordinates)
+                [x y z] ring]
+          (is (= (expected-z [x y]) z)))))))
+
+(deftest enrich-vertices-in-same-chunk-dedupe-test
+  (let [requests (atom 0)
+        ;; ~20 vertices a few meters apart -> all in one 250m chunk
+        fcoll    {:type "FeatureCollection"
+                  :features
+                  [{:type "Feature"
+                    :geometry {:type "LineString"
+                               :coordinates (vec (for [i (range 20)]
+                                                   [(+ 25.7201 (* i 0.00001))
+                                                    (+ 62.6201 (* i 0.00001))]))}}]}]
+    (with-redefs [elevation/get-elevation-coverage (counting requests synthetic-coverage)]
+      (let [enriched (elevation/enrich-elevation fcoll)]
+        (testing "All vertices in one chunk -> a single MML request"
+          (is (= 1 @requests)))
+        (testing "All z values exact"
+          (doseq [[x y z] (-> enriched :features first :geometry :coordinates)]
+            (is (= (expected-z [x y]) z))))))))
+
+(deftest enrich-fetch-failure-test
+  (testing "Any chunk fetch failure fails the whole enrichment"
+    (with-redefs [elevation/get-elevation-coverage
+                  (fn [envelope]
+                    (if (< (:min-x envelope) 462000)
+                      (synthetic-coverage envelope)
+                      (throw (ex-info "MML API error" {:status 500 :envelope envelope}))))]
+      (is (thrown? Exception (elevation/enrich-elevation route-fcoll))))))
 
 (deftest get-elevation-coverage-error-handling-test
-  (testing "returns nil or throws on HTTP error status"
-    ;; Test with mock HTTP response - actual behavior depends on implementation
-    ;; This documents the expected error handling pattern
-    (is (fn? elevation/get-elevation-coverage)
-        "get-elevation-coverage should be a function")))
+  (testing "HTTP 4xx/5xx throws with response context"
+    (with-redefs [clj-http.client/get (fn [_url _opts] {:status 503 :body "unavailable"})]
+      (is (thrown-with-msg? ExceptionInfo #"MML API error"
+                            (elevation/get-elevation-coverage
+                             {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250})))))
+
+  (testing "Unexpected status throws"
+    (with-redefs [clj-http.client/get (fn [_url _opts] {:status 302})]
+      (is (thrown-with-msg? ExceptionInfo #"Unexpected MML API response"
+                            (elevation/get-elevation-coverage
+                             {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250})))))
+
+  (testing "HTTP 200 parses the grid"
+    (with-redefs [clj-http.client/get
+                  (fn [_url _opts]
+                    {:status 200
+                     :body   (synthetic-grid-body {:min-x 400000 :max-x 400004
+                                                   :min-y 6900000 :max-y 6900004})})]
+      (let [grid (elevation/get-elevation-coverage
+                  {:min-x 400000 :max-x 400004 :min-y 6900000 :max-y 6900004})]
+        (is (= 2 (-> grid :headers :ncols)))
+        (is (= 2 (count (:data grid))))))))
+
+(deftest bounded-concurrency-test
+  (let [in-flight     (atom 0)
+        max-in-flight (atom 0)
+        chunk-keys    (for [i (range 30)] [(+ 1600 i) 27600])
+        slow-fetch    (fn [_envelope]
+                        (let [n (swap! in-flight inc)]
+                          (swap! max-in-flight max n)
+                          (Thread/sleep 25)
+                          (swap! in-flight dec)
+                          {:headers {:ncols 1 :nrows 1 :xllcorner 0.0
+                                     :yllcorner 0.0 :cellsize 2.0}
+                           :data    [[42.0]]}))]
+    (with-redefs [elevation/get-elevation-coverage slow-fetch]
+      (let [grids (elevation/fetch-grids chunk-keys)]
+        (testing "All chunks fetched and indexed by their key"
+          (is (= 30 (count grids)))
+          (is (= (set chunk-keys) (set (keys grids)))))
+        (testing "Concurrency never exceeds max-concurrent-fetches"
+          (is (<= @max-in-flight elevation/max-concurrent-fetches)))
+        (testing "Fetches actually run in parallel"
+          (is (> @max-in-flight 1)))))))
+
+;;; Old (pre vertex-driven) implementation, kept for equivalence tests ;;;
+
+(defn- old-resolve-elevation
+  [coords elevations]
+  (let [[lon lat]              (gis/wgs84->tm35fin-no-wrap coords)
+        {:keys [headers data]} (->> elevations
+                                    (some
+                                     (fn [{:keys [headers] :as elevation}]
+                                       (let [min-x (:xllcorner headers)
+                                             min-y (:yllcorner headers)
+                                             max-x (+ min-x (* (:ncols headers)
+                                                               (:cellsize headers)))
+                                             max-y (+ min-y (* (:nrows headers)
+                                                               (:cellsize headers)))]
+                                         (and (>= max-x lon min-x)
+                                              (>= max-y lat min-y)
+                                              elevation)))))
+        col (min (long (Math/floor
+                        (/ (- lon (:xllcorner headers))
+                           (:cellsize headers))))
+                 (dec (:ncols headers)))
+        row (min (long (Math/floor
+                        (/ (- lat (:yllcorner headers))
+                           (:cellsize headers))))
+                 (dec (:nrows headers)))]
+    (-> data rseq (nth row) (nth col))))
+
+(defn- old-append-elevations
+  [fcoll elevations]
+  (update fcoll :features
+          (fn [fs]
+            (map
+             (fn [f]
+               (update-in f [:geometry :coordinates]
+                          (fn [coords]
+                            (condp = (-> f :geometry :type)
+                              "Point"      (let [[x y] coords]
+                                             [x y (old-resolve-elevation coords elevations)])
+                              "LineString" (mapv
+                                            (fn [coords]
+                                              (let [[x y] coords]
+                                                [x y (old-resolve-elevation coords elevations)]))
+                                            coords)
+                              "Polygon"    (mapv
+                                            (fn [coords]
+                                              (mapv
+                                               (fn [coords]
+                                                 (let [[x y] coords]
+                                                   [x y (old-resolve-elevation coords elevations)]))
+                                               coords))
+                                            coords)
+                              (throw (ex-info "Encountered unexpected geometry type" f))))))
+             fs))))
+
+(defn old-enrich-elevation
+  "The implementation before the vertex-driven optimization: corridor
+  chunking over the buffered geometry envelope + linear grid scans."
+  [fcoll]
+  (let [buff-m    8
+        fcoll-jts (-> fcoll gis/->jts-geom gis/transform-crs)
+        envelopes (-> (gis/get-envelope fcoll-jts buff-m)
+                      (elevation/fit-to-coverage elevation/coverage-info)
+                      (gis/chunk-envelope elevation/query-envelope-size-m)
+                      (->> (filter #(gis/intersects-envelope? % fcoll-jts))))]
+    (->> envelopes
+         (patterns/pmap-with-timeout elevation/elevation-chunk-timeout-ms
+                                     elevation/get-elevation-coverage)
+         (old-append-elevations fcoll))))
+
+(deftest old-vs-new-equivalence-test
+  ;; Short geometries keep the old implementation's corridor chunk
+  ;; count (and thus test runtime) small.
+  (let [short-route {:type "FeatureCollection"
+                     :features
+                     [{:type "Feature"
+                       :properties {:name "short"}
+                       :geometry {:type "LineString"
+                                  :coordinates [[25.7201 62.6201]
+                                                [25.7245 62.6215]
+                                                [25.7280 62.6230]]}}]}]
+    (with-redefs [elevation/get-elevation-coverage synthetic-coverage]
+      (doseq [fcoll [point-fcoll short-route polygon-fcoll]]
+        (testing (str "Identical output for " (-> fcoll :features first :geometry :type))
+          (let [old (old-enrich-elevation fcoll)
+                new (elevation/enrich-elevation fcoll)]
+            (is (= (update old :features vec)
+                   (update new :features vec)))))))))
 
 (comment
   (clojure.test/run-tests 'lipas.backend.elevation-test))

--- a/webapp/test/clj/lipas/backend/elevation_test.clj
+++ b/webapp/test/clj/lipas/backend/elevation_test.clj
@@ -20,9 +20,11 @@
   "Deterministic, cell-unique elevation for the 2m cell with lower left
   corner [cx cy] (TM35FIN), as it would appear in the ascii grid body.
   cx + cy/1e7 is injective over the whole coverage envelope, so reading
-  the wrong cell always produces a different value."
+  the wrong cell always produces a different value. Formatted with an
+  explicit locale so decimal-comma JVM locales can't break parsing."
   [cx cy]
-  (format "%.7f" (+ cx (/ cy 1e7))))
+  (String/format java.util.Locale/ROOT "%.7f"
+                 (to-array [(+ cx (/ cy 1e7))])))
 
 (defn expected-z
   "The z value the synthetic coverage yields for a WGS84 coordinate:
@@ -72,20 +74,17 @@
   (testing "Rounds to even coordinates (2m cell alignment)"
     (is (= {:min-x 400000 :min-y 6900000 :max-x 400010 :max-y 6900012}
            (elevation/fit-to-coverage
-            {:min-x 400001.4 :min-y 6900000.6 :max-x 400010.5 :max-y 6900011.9}
-            elevation/coverage-info))))
+            {:min-x 400001.4 :min-y 6900000.6 :max-x 400010.5 :max-y 6900011.9}))))
 
   (testing "Even values pass through"
     (is (= {:min-x 400002 :min-y 6900004 :max-x 400006 :max-y 6900008}
            (elevation/fit-to-coverage
-            {:min-x 400002.0 :min-y 6900004.0 :max-x 400006.0 :max-y 6900008.0}
-            elevation/coverage-info))))
+            {:min-x 400002.0 :min-y 6900004.0 :max-x 400006.0 :max-y 6900008.0}))))
 
   (testing "Clamps to the coverage envelope"
     (let [{:keys [envelope]} elevation/coverage-info
           fitted (elevation/fit-to-coverage
-                  {:min-x 0.0 :min-y 0.0 :max-x 99999999.0 :max-y 99999999.0}
-                  elevation/coverage-info)]
+                  {:min-x 0.0 :min-y 0.0 :max-x 99999999.0 :max-y 99999999.0})]
       (is (= {:min-x (:min-x envelope) :min-y (:min-y envelope)
               :max-x (:max-x envelope) :max-y (:max-y envelope)}
              fitted)))))
@@ -274,7 +273,27 @@
                   {:type "FeatureCollection"
                    :features [{:type "Feature"
                                :geometry {:type "MultiPoint"
-                                          :coordinates [[25.7 62.6]]}}]})))))
+                                          :coordinates [[25.7 62.6]]}}]}))))
+
+  (testing "reduce-vertices and map-vertices visit vertices in the same order"
+    ;; append-elevations consumes the CRS-transformed vertex list by
+    ;; index, so the two walks must never diverge
+    (let [fcoll {:type "FeatureCollection"
+                 :features
+                 [{:type "Feature"
+                   :geometry {:type "LineString"
+                              :coordinates [[25.7 62.6] [25.8 62.7]]}}
+                  {:type "Feature"
+                   :geometry {:type "Point" :coordinates [25.9 62.8]}}
+                  {:type "Feature"
+                   :geometry {:type "Polygon"
+                              :coordinates
+                              [[[25.0 62.0] [25.1 62.0] [25.1 62.1] [25.0 62.0]]
+                               [[25.04 62.04] [25.06 62.04] [25.06 62.06] [25.04 62.04]]]}}]}
+          mapped (let [acc (volatile! [])]
+                   (elevation/map-vertices (fn [c] (vswap! acc conj c) c) fcoll)
+                   @acc)]
+      (is (= (elevation/geometry-vertices fcoll) mapped)))))
 
 (deftest resolve-elevation-test
   ;; Reference case from the original implementation's comment block:
@@ -296,6 +315,20 @@
             index      {(elevation/chunk-key edge-point) (elevation/index-grid grid)}]
         ;; col/row compute to ncols/nrows and are capped to the edge cell
         (is (= 152.34 (elevation/resolve-elevation index edge-point)))))
+
+    (testing "A point inside the max-edge cell's overshoot but not exactly on the edge fails"
+      ;; a grid one cell short of covering its vertex must not silently
+      ;; resolve the neighboring cell
+      (let [near-point [434356.9 6943966.5]
+            index      {(elevation/chunk-key near-point) (elevation/index-grid grid)}]
+        (is (thrown-with-msg? ExceptionInfo #"Vertex outside its elevation grid"
+                              (elevation/resolve-elevation index near-point)))))
+
+    (testing "A point below the grid's lower left corner fails loudly"
+      (let [low-point [434350.5 6943962.5]
+            index     {(elevation/chunk-key low-point) (elevation/index-grid grid)}]
+        (is (thrown-with-msg? ExceptionInfo #"Vertex outside its elevation grid"
+                              (elevation/resolve-elevation index low-point)))))
 
     (testing "A point further outside its grid fails loudly"
       (let [far-point [434360.5 6943970.5] ;; > 1 cell beyond the grid
@@ -384,9 +417,9 @@
         (testing "Feature order and properties are preserved"
           (is (= ["leg 1" "leg 2"]
                  (mapv #(-> % :properties :name) (:features enriched))))
-          (is (= (mapv #(mapv (fn [c] (subvec c 0 2)) (-> % :geometry :coordinates))
+          (is (= (mapv #(mapv gis/strip-z (-> % :geometry :coordinates))
                        (:features route-fcoll))
-                 (mapv #(mapv (fn [c] (subvec c 0 2)) (-> % :geometry :coordinates))
+                 (mapv #(mapv gis/strip-z (-> % :geometry :coordinates))
                        (vec (:features enriched))))))))))
 
 (deftest enrich-polygon-test
@@ -436,6 +469,24 @@
       (is (thrown-with-msg? ExceptionInfo #"Unexpected MML API response"
                             (elevation/get-elevation-coverage
                              {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250})))))
+
+  (testing "Socket timeouts are rethrown without an InterruptedIOException in the cause chain"
+    ;; SocketTimeoutException extends InterruptedIOException, which the
+    ;; circuit breaker's interrupt classifier rethrows WITHOUT counting;
+    ;; MML slowness must count as a service failure
+    (with-redefs [clj-http.client/get
+                  (fn [_url _opts] (throw (java.net.SocketTimeoutException. "Read timed out")))]
+      (let [ex (try
+                 (elevation/get-elevation-coverage
+                  {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250})
+                 (catch Exception e e))]
+        (is (instance? ExceptionInfo ex))
+        (is (re-find #"MML request timed out" (ex-message ex)))
+        (is (nil? (loop [e ex]
+                    (cond
+                      (nil? e) nil
+                      (instance? java.io.InterruptedIOException e) e
+                      :else (recur (ex-cause e)))))))))
 
   (testing "HTTP 200 parses the grid"
     (with-redefs [clj-http.client/get
@@ -558,7 +609,7 @@
   (let [buff-m    8
         fcoll-jts (-> fcoll gis/->jts-geom gis/transform-crs)
         envelopes (-> (gis/get-envelope fcoll-jts buff-m)
-                      (elevation/fit-to-coverage elevation/coverage-info)
+                      (elevation/fit-to-coverage)
                       (gis/chunk-envelope elevation/query-envelope-size-m)
                       (->> (filter #(gis/intersects-envelope? % fcoll-jts))))]
     (->> envelopes

--- a/webapp/test/clj/lipas/backend/elevation_test.clj
+++ b/webapp/test/clj/lipas/backend/elevation_test.clj
@@ -154,6 +154,58 @@
       (let [env (elevation/chunk-key->envelope [0 27600])]
         (is (> (:min-x env) (:max-x env)))))))
 
+(deftest plan-fetches-test
+  (testing "No vertices -> no requests"
+    (is (= [] (elevation/plan-fetches []))))
+
+  (testing "Single vertex -> one small envelope around it"
+    (let [[{:keys [envelope chunk-keys]} :as plan]
+          (elevation/plan-fetches [[400010.3 6900020.7]])]
+      (is (= 1 (count plan)))
+      (is (= [[1600 27600]] chunk-keys))
+      ;; vertex +/- 8m buffer, fitted to even coordinates
+      (is (= {:min-x 400002 :max-x 400018 :min-y 6900012 :max-y 6900028} envelope))))
+
+  (testing "Small geometry straddling a chunk border -> still one request"
+    (let [plan (elevation/plan-fetches [[400240.0 6900010.0] [400260.0 6900030.0]])]
+      (is (= 1 (count plan)))
+      (is (= #{[1600 27600] [1601 27600]} (set (:chunk-keys (first plan)))))))
+
+  (testing "Dense cluster (>= 4 chunks in a 1000m tile) merges into one tile request"
+    (let [verts [[400010.0 6900010.0] [400260.0 6900010.0]
+                 [400510.0 6900010.0] [400760.0 6900010.0]]
+          [{:keys [envelope chunk-keys]} :as plan] (elevation/plan-fetches verts)]
+      (is (= 1 (count plan)))
+      (is (= {:min-x 400000 :max-x 401000 :min-y 6900000 :max-y 6901000} envelope))
+      (is (= 4 (count chunk-keys)))))
+
+  (testing "Sparse chunks (< 4 per tile) are fetched individually"
+    (let [verts [[400010.0 6900010.0] [400260.0 6900010.0] [400510.0 6900010.0]]
+          plan  (elevation/plan-fetches verts)]
+      (is (= 3 (count plan)))
+      (is (every? #(= 1 (count (:chunk-keys %))) plan))
+      (is (= {:min-x 400000 :max-x 400250 :min-y 6900000 :max-y 6900250}
+             (:envelope (first plan))))))
+
+  (testing "Mixed: dense tile merges, distant chunk stays individual"
+    (let [verts [[400010.0 6900010.0] [400260.0 6900010.0]
+                 [400510.0 6900010.0] [400760.0 6900010.0]
+                 [450010.0 6950010.0]]
+          plan  (elevation/plan-fetches verts)]
+      (is (= 2 (count plan)))))
+
+  (testing "Every distinct chunk key appears in exactly one plan entry"
+    (let [verts (for [i (range 40)] [(+ 400010.0 (* i 130.0)) (+ 6900010.0 (* i 45.0))])
+          keys* (distinct (map elevation/chunk-key verts))
+          plan  (elevation/plan-fetches verts)]
+      (is (= (sort keys*) (sort (mapcat :chunk-keys plan))))
+      (testing "and each entry's envelope contains its chunk keys' vertices"
+        (doseq [{:keys [envelope chunk-keys]} plan
+                [x y] verts
+                :when (some #{(elevation/chunk-key [x y])} chunk-keys)]
+          (is (and (>= x (:min-x envelope)) (<= x (:max-x envelope))
+                   (>= y (:min-y envelope)) (<= y (:max-y envelope)))))))))
+
 (deftest geometry-vertices-test
   (testing "Point"
     (is (= [[25.7 62.6]]
@@ -370,6 +422,8 @@
   (let [in-flight     (atom 0)
         max-in-flight (atom 0)
         chunk-keys    (for [i (range 30)] [(+ 1600 i) 27600])
+        fetch-plan    (for [k chunk-keys]
+                        {:envelope (elevation/chunk-key->envelope k) :chunk-keys [k]})
         slow-fetch    (fn [_envelope]
                         (let [n (swap! in-flight inc)]
                           (swap! max-in-flight max n)
@@ -379,7 +433,7 @@
                                      :yllcorner 0.0 :cellsize 2.0}
                            :data    [[42.0]]}))]
     (with-redefs [elevation/get-elevation-coverage slow-fetch]
-      (let [grids (elevation/fetch-grids chunk-keys)]
+      (let [grids (elevation/fetch-grids fetch-plan)]
         (testing "All chunks fetched and indexed by their key"
           (is (= 30 (count grids)))
           (is (= (set chunk-keys) (set (keys grids)))))
@@ -387,6 +441,31 @@
           (is (<= @max-in-flight elevation/max-concurrent-fetches)))
         (testing "Fetches actually run in parallel"
           (is (> @max-in-flight 1)))))))
+
+(deftest enrich-dense-route-tile-merge-test
+  ;; ~3 km of vertices every ~25 m: enough chunk density that at
+  ;; least one 1000m tile merge kicks in.
+  (let [start    [25.7201 62.6201]
+        fcoll    {:type "FeatureCollection"
+                  :features
+                  [{:type "Feature"
+                    :geometry {:type "LineString"
+                               :coordinates (vec (for [i (range 120)]
+                                                   [(+ (first start) (* i 0.0005))
+                                                    (second start)]))}}]}
+        verts    (mapv gis/wgs84->tm35fin-no-wrap (elevation/geometry-vertices fcoll))
+        n-chunks (count (distinct (map elevation/chunk-key verts)))
+        plan     (elevation/plan-fetches verts)
+        requests (atom 0)]
+    (with-redefs [elevation/get-elevation-coverage (counting requests synthetic-coverage)]
+      (let [enriched (elevation/enrich-elevation fcoll)]
+        (testing "Dense chunks merge into tiles: fewer requests than chunks"
+          (is (< (count plan) n-chunks))
+          (is (some #(> (count (:chunk-keys %)) 1) plan))
+          (is (= (count plan) @requests)))
+        (testing "Merged grids resolve the exact same synthetic z values"
+          (doseq [[x y z] (-> enriched :features first :geometry :coordinates)]
+            (is (= (expected-z [x y]) z))))))))
 
 ;;; Old (pre vertex-driven) implementation, kept for equivalence tests ;;;
 


### PR DESCRIPTION
## Summary

`enrich-elevation` resolves elevations **only at geometry vertices**, but selected its MML chunks by line-corridor intersection over the whole buffered geometry envelope — a 4-vertex test route fetched **165** 250m chunks where 3 suffice, firing them all as **concurrent unbounded requests** against the rate-limited MML API, then resolving each vertex with a linear scan over the fetched grids and `nth` over lazy lists.

The rewrite derives the chunk set from the vertices and plans requests adaptively (`plan-fetches`):

- **Small geometries** (vertices span ≤ 250m — points and most single sports sites): one request tightly around the vertices, like the old implementation fetched
- **Dense clusters**: ≥ 3 vertex chunks inside a 1000×1000m tile merge into one tile request (measured MML cost: 250m chunk ~255ms, 1000m tile = 16 chunk areas ~740ms, so a merged tile costs MML no more server time and is always fewer requests)
- Remaining chunks are fetched as individual fixed-grid 250m chunks

Fetches run in **bounded waves of 8** (was: all at once) over a shared keep-alive connection pool, and each vertex resolves via an **O(1) chunk-key index** with pre-reversed row vectors (was: O(#chunks) scan + O(ncols) lazy-list `nth` per vertex), CRS-transforming each vertex once.

**Output values and fcoll shape are unchanged** — all request envelopes keep 2m-aligned corners, so every vertex resolves to exactly the same MML coverage cell as before. Dispatcher/registry semantics (circuit breaker, `still-valid?` re-enqueue, trigger and dedup rules) untouched.

## Measured impact

Chunk-selection sweep over **300 real route sites** (types 4401–4412, prod-snapshot dev DB; deterministic, no MML calls):

| | Old | New |
|---|---|---|
| Total MML requests | 92,638 | **24,095** (3.8x fewer) |
| Median per-route reduction | – | **3.8x** (max 7x) |
| Heaviest route (lipas-id 613762, 4,367 vertices) | 5,619 | **1,427** |
| Routes needing *more* requests than old | – | 1 of 300 (4 → 5) |

Real MML API, one run per implementation per site (old = full pre-optimization pipeline):

| Site | Requests old → new | Wall time old → new |
|---|---|---|
| Point (502944) | 1 → 1 | 740ms → 397ms |
| Medium route (517341, 184 vertices) | 33 → **10** | 3.0s → 3.0s |
| Long sparse route (607816, 394 vertices) | 73 → **11** | 2.2s → 4.1s |

Wall time on already-fast MML is a wash: the old code "won" the sparse-route case by firing all 73 requests concurrently — exactly the abusive pattern this PR removes (a route like 613762 fired **5,619 concurrent requests** at a circuit-breaker-guarded external API). Merged tiles also transfer more grid bytes than the vertex-minimal chunk set (15MB vs 6MB on the sparse route) but cost MML *less* total server time per its measured cost curve. Ascii-grid parsing switched from a regex scan to whitespace split: same values, ~2x faster (a 1000m tile parses in ~240ms on the 2-core dev box).

## Correctness

- **Exact-equality bar** (same 2m source cells, so unlike the diversity sweep there is no snapping nondeterminism excuse): the committed test suite asserts old-vs-new outputs are `=` against a copy of the pre-optimization implementation on synthetic grids with cell-unique values
- **Real data**: point + medium route z-vectors exactly equal old-vs-new; the sparse route initially showed differing values between the old and new *runs*, and re-fetching both pipelines fresh gave **0/394 differing vertices** — the difference was transient MML response content between the two benchmark fetches, not framing. In response, parsed grids are now **validated against their headers** (truncated/malformed responses previously shifted every subsequent row lookup silently; now the job fails and retries)
- NODATA (-9999) passthrough, Point/LineString/Polygon walks, feature order, property passthrough, and out-of-coverage failure behavior preserved (degenerate envelope → MML error → job failure, as before)
- A vertex exactly on the coverage envelope's max edge maps into the last chunk inside coverage and resolves via the col/row edge cap, like the old inclusive containment + cap did
- **E2E with real data**: `dispatcher/handle-job "elevation"` unmocked for lipas-id 502944 → one MML request, robot revision in DB and ES doc both carry `[x y 106.69]` (identical z to the old pipeline's value for that site); test revision cleaned up afterwards

## Resilience (two high-effort review passes, findings fixed)

- **MML timeouts now actually trip the dispatcher's circuit breaker**: `SocketTimeoutException` and Apache's connect/pool timeouts extend `InterruptedIOException`, which `patterns/interrupt?` classifies as a watchdog interrupt and rethrows *without counting* — so MML degradation never opened the `mml-elevation-service` breaker (pre-existing on master; load-bearing here, so fixed at the fetch layer by rethrowing as `ex-info` without the original cause)

- Shared connection pool sized 32/32 (well above 2 concurrent jobs × wave of 8) with a lease timeout above the socket timeout, so MML slowness or abandoned requests holding leases make jobs *slow*, not *failed* (failing fast here would feed the dispatcher's circuit breaker and block all enrichment); pool built lazily on first MML call
- Retry once on connection-establishment IOExceptions, **never** on `SocketTimeoutException` (the server keeps computing the abandoned response; learned in #207)
- `resolve-elevation` bounds-checks its grid: only an exact max-edge point may cap into the edge cell; a grid that doesn't cover its vertex fails loudly instead of silently resolving a wrong edge cell
- Any chunk failure still fails the whole job so the queue's retry + circuit breaker machinery stays in charge (per-chunk degradation would write partial nonsense)
- Deliberate tradeoff, documented in code: under severe MML degradation a many-hundred-chunk route may exceed its 30-min job timeout and retry later, instead of "succeeding" by hammering the degraded API with unbounded concurrency

## Tests

`lipas.backend.elevation-test` rewritten from 4 constant-existence assertions to **17 tests / 276 assertions**: grid parsing (CRLF headers, NODATA, negatives, truncation validation, locale-safe oracle), chunk-key/tile/small-mode planning math incl. coverage-edge cases, resolution at cell boundaries and grid corners (edge cap vs loud failure), walk-order lockstep between vertex collection and z-appending, mocked-MML integration with a cell-unique synthetic elevation oracle (exact z per vertex, multi-chunk borders, tile merging, request dedup, failure propagation, timeout wrapping, concurrency bound actually bounding), and the old-vs-new equivalence suite. Dispatcher + patterns tests green. The batch CRS transform was verified bit-identical to the per-vertex transform on 394 real vertices.

Mocking note: the suite mocks the MML fetch layer with `with-redefs` — the CLAUDE.md fixture preference can't apply to an external, authenticated, rate-limited API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
