### PR TITLE
Fix npm audit vulnerabilities: xmldom, js-cookie, ws

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -47,7 +47,7 @@
       "devDependencies": {
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "shadow-cljs": "^3.3.6",
+        "shadow-cljs": "^3.4.11",
         "stream-browserify": "^3.0.0",
         "util": "^0.12.5"
       }
@@ -1118,9 +1118,9 @@
       "license": "MIT"
     },
     "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
@@ -2213,9 +2213,9 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -2306,6 +2306,16 @@
       "license": "GPL v3",
       "dependencies": {
         "xmldom": "^0.1.21"
+      }
+    },
+    "node_modules/jxon/node_modules/xmldom": {
+      "name": "@xmldom/xmldom",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/lerc": {
@@ -2779,17 +2789,17 @@
       }
     },
     "node_modules/react-use": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
-      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.1.tgz",
+      "integrity": "sha512-uibb3pgzV4LFsYPHyXYGu7dD2+pyk/ZJlPH+AizBR3zolqPWyCleKcWWbUQaKSKfydwgnQ3ymGm1Ab3/saGHCA==",
       "license": "Unlicense",
       "dependencies": {
-        "@types/js-cookie": "^2.2.6",
+        "@types/js-cookie": "^3.0.0",
         "@xobotyi/scrollbar-width": "^1.9.5",
         "copy-to-clipboard": "^3.3.1",
         "fast-deep-equal": "^3.1.3",
         "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
+        "js-cookie": "^3.0.0",
         "nano-css": "^5.6.2",
         "react-universal-interface": "^0.6.2",
         "resize-observer-polyfill": "^1.5.1",
@@ -3038,9 +3048,9 @@
       "license": "MIT"
     },
     "node_modules/shadow-cljs": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.3.6.tgz",
-      "integrity": "sha512-t5TBJmy77abwlkAY7UOXa1s9H/28nTHeDVckgzEVS8ONYtDvbNCHEuBYfS7wwV9wVZVybRNb7dILWNXISJL1Nw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.4.11.tgz",
+      "integrity": "sha512-996uqtadZItXdD80Vtoh9IoE8oUOKoXOXd48gOxkZWUAHcxgcBlcRqMmPYiy4A1QqvSUQkdNGpv9AIWOgLx9Vg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3259,6 +3269,16 @@
         "bops": "0.0.6"
       }
     },
+    "node_modules/togpx/node_modules/xmldom": {
+      "name": "@xmldom/xmldom",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/ts-easing": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
@@ -3418,9 +3438,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3444,16 +3464,6 @@
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
       "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
       "license": "CC0-1.0"
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "license": "(LGPL-2.0 or MIT)",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/yaml": {
       "version": "1.10.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -54,8 +54,11 @@
   "devDependencies": {
     "buffer": "^6.0.3",
     "events": "^3.3.0",
-    "shadow-cljs": "^3.3.6",
+    "shadow-cljs": "^3.4.11",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5"
+  },
+  "overrides": {
+    "xmldom": "npm:@xmldom/xmldom@^0.9.10"
   }
 }


### PR DESCRIPTION
## Summary
- Override `xmldom` -> `@xmldom/xmldom` (maintained fork) in `webapp/package.json`. The unscoped `xmldom` package is abandoned and GitHub flags it vulnerable at *all* versions (XML injection via CDATA/comment/DOCTYPE/PI serialization, DoS via uncontrolled recursion, multi-root-node parsing). It's pulled in transitively via `togpx` -> `jxon`, used client-side to serialize sports-site data into downloadable GPX files.
- Bump `shadow-cljs` 3.3.6 -> 3.4.11 (dev-only), which pulls a patched `ws` (was flagged for memory disclosure / DoS).
- `npm audit fix` bumps `react-use` 17.6.0 -> 17.6.1 / `js-cookie` 2.2.1 -> 3.0.8 (cookie-attribute injection, CVE-2026-46625) — same fix as Dependabot PR #201, closed as superseded.

`npm audit` in `webapp/`: 6 vulnerabilities (1 critical, 3 high, 2 moderate) -> 0. Covers all 9 open Dependabot alerts on `webapp/package-lock.json` (GitHub splits the xmldom advisories individually).

## Test plan
- [x] `npm audit` reports 0 vulnerabilities after the change
- [x] `shadow-cljs` CLI still resolves/runs post-bump
- [x] Manually verified GPX export end-to-end against a live dev system: dispatched the real `:lipas.ui.map.events/download-gpx` re-frame event through the compiled bundle against a real site (lipas-id 91920, 5 tracks / 141 trackpoints), captured the blob, and round-tripped it through the patched `@xmldom/xmldom` parser — valid GPX 1.1, correct UTF-8 (Finnish characters) escaping, zero parse errors, zero console errors
- [x] CI green (`build`, `backend-tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)