### PR TITLE
Add AI assistant, knowledge base, and help center v2

### DIFF
--- a/webapp/.claude/skills/help-video-ingest/SKILL.md
+++ b/webapp/.claude/skills/help-video-ingest/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: help-video-ingest
+description: Extract help-center (ohjeet) articles from LIPAS YouTube tutorial videos using Gemini's native video understanding, consolidate them into task-sized help pages, translate to sv/en, and publish to the help CMS (which feeds the AI-assistant knowledge base). Use when turning tutorial videos or guide PDFs into ohjeet content.
+---
+
+# Help video ingest
+
+Turn LIPAS tutorial videos (and guide PDFs) into published, translated
+help-center pages. The help CMS is the canonical target: published pages
+become both human-readable ohjeet and AI-assistant KB docs
+(`lipas.backend.kb/help-cms->docs` — one KB doc per page per language).
+
+All heavy lifting lives in **`dev/lipas/help_authoring.clj`**
+(`lipas.help-authoring`, self-contained: loads on any branch, can be
+piped inline to remote nREPLs). This skill is the workflow around it.
+
+## Prerequisites
+
+- `GEMINI_API_KEY` in the backend JVM env (comes from `../.env.sh`)
+- nREPL: local `clj-nrepl-eval -p 7888`; remote (e.g. lipas-dev) via an
+  SSH tunnel the user opens, e.g. port 7887
+- Load the util locally:
+  `(load-file ".../webapp/dev/lipas/help_authoring.clj")`
+  Remote REPLs can't `load-file` your disk — pipe the file inline:
+  `clj-nrepl-eval -p 7887 "$(cat dev/lipas/help_authoring.clj)"`
+
+## Workflow
+
+### 1. Analyze the videos
+
+One Gemini call per video, YouTube URL passed natively (`fileData.fileUri`
+— no download; the videos are typically DRM-protected anyway, and agentic
+CLIs like `agy`/`gemini` can NOT ingest YouTube natively, so don't try
+them for this):
+
+```clojure
+(require '[lipas.help-authoring :as ha])
+(def material (ha/analyze-video "https://www.youtube.com/watch?v=..."))
+(spit "/tmp/extract_<id>.md" material)
+```
+
+~50 s and ~300 input tokens per video-second. The prompt
+(`ha/extract-prompt`) asks for verbatim UI labels, exact mouse/keyboard
+mechanics and `[MM:SS]` timestamps — the value over plain transcripts.
+Save each extraction to a file for review; read them all before writing.
+
+The full Lipasinfo video inventory lives in
+`dev/lipas/kb_ingest.clj` (`video-sources`).
+
+### 2. Ground against the current product — never skip
+
+Videos age. Verify every UI label and mechanic before it goes into an
+article:
+
+- Labels: `grep -r "<label>" src/cljc/lipas/i18n/fi/`
+- Map tool behavior: `src/cljs/lipas/ui/map/` (`events.cljs`,
+  `editing.cljs`, `import.cljs`, `views.cljs`)
+- When unsure, check the running UI in the browser.
+
+Known drift examples found this way: simplify dialog retitled, import
+now auto-simplifies GPX tracks, self-intersection warning text rewritten.
+Record what you corrected — reviewers will ask.
+
+### 3. Consolidate into task-sized pages
+
+One page = one KB doc, so pages should answer one user task each
+("Reittigeometrian tuonti tiedostosta"), not bundle five. Author the
+result as an EDN content file under `dev/lipas/help_content/`:
+
+```edn
+{:section-slug "existing-or-new-section"
+ :after-slug   "page-to-insert-after"        ; optional
+ :pages [{:slug "..." :title "..." :summary "..."
+          :blocks [{:type :text :content "markdown..."}
+                   {:type :video :provider :youtube
+                    :video-id "..." :title "..."}]}]}
+```
+
+Keep the source video embedded on its page. Keep existing slugs stable —
+`?ohje=` deep links and KB citations resolve through them (renames need
+`:aliases`). `:summary` feeds both the landing list and KB retrieval.
+
+### 4. Publish fi
+
+```clojure
+(def content (clojure.edn/read-string (slurp "dev/lipas/help_content/<name>_fi.edn")))
+(ha/upsert-pages! (user/db) :fi content)
+```
+
+Existing pages (matched by slug) are replaced in place keeping their id;
+new pages are inserted after `:after-slug`. On v2 branches this publishes
+via `lipas.backend.help/save-help-data`, which also enqueues the KB sync
+job; on pre-v2 branches it writes `versioned_data` directly (check
+`:saved-via` in the return value — `:versioned-data` means no KB sync
+ran and the running UI may be v1).
+
+### 5. Translate (LIPAS Swedish code is `se`, not `sv`)
+
+Publish fi first — translation links resolve against the fi tree:
+
+```clojure
+(def se-pages (mapv #(-> (ha/translate-page ha/default-config % :se)
+                         (assoc :translation-of-slug (:slug %)))
+                    (:pages content)))
+(ha/upsert-pages! (user/db) :se (assoc content
+                                       :pages se-pages
+                                       :section-title "<translated>"))
+```
+
+Same for `:en`. Persist translated content as
+`dev/lipas/help_content/<name>_{se,en}.edn` for review/provenance.
+Spot-check translations: UI labels must be translated (LIPAS UI is fully
+localized), type codes and URLs unchanged.
+
+### 6. Deploy to a remote env (e.g. lipas-dev)
+
+Pipe the namespace, then run the same upserts reading the EDN files
+inline (heredoc). Order: fi → se → en. Verify afterwards:
+
+```clojure
+(require '[lipas.backend.config :as config])
+(def dbc (:db config/default-config))          ; remote REPL has no user/db
+(mapv :slug (lipas.help-authoring/get-tree dbc :fi))
+```
+
+`save-help-data` enqueues `help-kb-sync`; the app's worker picks it up
+from the shared DB queue. Confirm with
+`(lipas.backend.kb/search-kb (search) {:query "..." :lang "fi"})` or by
+checking the jobs table.
+
+### 7. Verify rendering
+
+Open the help center in the target env: `?ohje=<section-slug>/<page-slug>`
+on `/liikuntapaikat`. Check: markdown renders (headers, lists, bold),
+video embeds play, language switcher shows se/en counterparts, and the
+assistant retrieves the new content.
+
+## Cost & quality notes
+
+- gemini-3.1-pro-preview reads 720p screencast UI labels reliably; a
+  7-minute video ≈ 42k input tokens.
+- Extraction fidelity rules live in `ha/extract-prompt`; keep the
+  "only what's in the video / mark uncertain readings" contract if you
+  edit it.
+- PDFs: just `Read` them (the tool renders pages) and merge manually —
+  no Gemini needed.

--- a/webapp/.claude/skills/lipas-e2e/SKILL.md
+++ b/webapp/.claude/skills/lipas-e2e/SKILL.md
@@ -116,6 +116,7 @@ Things that bite if forgotten:
 - **Permissions checked in core, not middleware.** The handler trusts `core/upsert-sports-site!` to throw `:no-permission`. Privilege key for sites: `:site/create-edit`.
 - **Auto-permission grant on create.** A user creating a new site with no city/type role automatically gets `:site-manager` for that lipas-id (`core/ensure-permission!`). So "permission denied" only fires on edits, not creates.
 - **Append-only ⇒ no real delete.** Soft delete = flip status to `out-of-service-permanently`. For a clean slate, `lipas.test-utils/prune-db!` (test DB only).
+- **Backgrounded Chrome tabs do not render.** Chrome suspends requestAnimationFrame in hidden tabs and Reagent schedules renders on rAF — so via `cljs-eval`, app-db advances but the DOM stays frozen at whatever was last painted (looks exactly like a crashed React tree; even snackbars won't appear). State-level assertions still work; for DOM/visual assertions use a fresh Playwright session (`playwright-cli open --config=.playwright/cli.config.json https://localhost`), never the user's tab.
 
 ## Don't load (low signal for e2e)
 

--- a/webapp/dev/lipas/help_authoring.clj
+++ b/webapp/dev/lipas/help_authoring.clj
@@ -1,0 +1,290 @@
+(ns lipas.help-authoring
+  "Authoring tooling for help center (ohjeet) v2 content:
+
+   - extract article material from YouTube tutorial videos with Gemini's
+     native video understanding (fileData/fileUri — no download needed)
+   - translate finished pages between locales (fi/se/en)
+   - upsert pages into the per-locale help trees in versioned_data
+
+   Self-contained on purpose: only clj-http, cheshire, malli and
+   lipas.backend.db.db, so the namespace loads into any LIPAS REPL
+   regardless of branch, and the whole file can be piped inline to a
+   remote nREPL (e.g. lipas-dev) where load-file paths don't exist.
+
+   Driven by the help-video-ingest skill; see
+   .claude/skills/help-video-ingest/SKILL.md for the workflow."
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure.string :as str]
+            [lipas.backend.db.db :as db]))
+
+;;; ——— Gemini REST ———————————————————————————————————————————————————
+
+(def default-config
+  "Reads the key from the JVM environment; override per call if needed.
+   gemini-3.1-pro-preview is the cheapest model verified to read UI
+   labels reliably from 720p screencasts."
+  {:api-key  (System/getenv "GEMINI_API_KEY")
+   :base-url "https://generativelanguage.googleapis.com/v1beta"
+   :model    "gemini-3.1-pro-preview"})
+
+(defn gemini-generate
+  "Low-level generateContent. parts is a vector of Gemini part maps,
+   e.g. {:text ...} or {:fileData {:fileUri ...}}. Media parts must come
+   before the text prompt (Google's video best practice). Returns the
+   response text, or the parsed JSON map when :response-schema is given."
+  [{:keys [api-key base-url model]} parts
+   & {:keys [response-schema temperature max-tokens]
+      :or   {temperature 0.2 max-tokens 65536}}]
+  (let [gen-config (cond-> {:maxOutputTokens max-tokens
+                            :temperature     temperature}
+                     response-schema (assoc :responseMimeType "application/json"
+                                            :responseSchema response-schema))
+        resp (-> (http/post (str base-url "/models/" model ":generateContent")
+                            {:headers            {"x-goog-api-key" api-key
+                                                  "Content-Type"   "application/json"}
+                             :body               (json/encode
+                                                  {:contents [{:role "user" :parts parts}]
+                                                   :generationConfig gen-config})
+                             :socket-timeout     600000
+                             :connection-timeout 10000})
+                 :body
+                 (json/decode keyword))
+        text (-> resp :candidates first :content :parts last :text)]
+    (when-not text
+      (throw (ex-info "Gemini returned no text" {:resp resp})))
+    (if response-schema (json/decode text keyword) text)))
+
+;;; ——— Video → article material ——————————————————————————————————————
+
+(def extract-prompt
+  "Video analysis prompt. Asks for verbatim UI labels, mouse/keyboard
+   mechanics and per-step timestamps — the things audio transcripts miss.
+   Output language parameterized; source videos are Finnish."
+  "You are analyzing a Finnish screencast tutorial video about LIPAS (lipas.fi), Finland's national database of sports and outdoor recreation facilities. The video demonstrates how to use the LIPAS map view (Liikuntapaikat) to maintain facility data. The audience is municipality employees and other data maintainers.
+
+Your job: extract EVERYTHING instructional from this video, so precisely that a technical writer can produce help-center articles without ever watching the video. You have native video understanding — use both the narration (audio) and the visible UI (frames). The visible UI details are the most valuable part: transcripts already exist, pixels do not.
+
+Write the output in %s, as markdown, using exactly this structure:
+
+# Video: <title as shown or spoken>
+
+## Yleiskuvaus
+2-4 sentences: what the video teaches, which LIPAS views and tools appear.
+
+## UI-havainnot
+Bullet list of what the UI looks like: layout landmarks, panel names, notable buttons and icons with their exact on-screen labels, toolbars and their locations. Purpose: let the writer check whether the current LIPAS UI still matches the video's UI.
+
+## Tehtävät
+One section per distinct user task demonstrated:
+
+### <task title, phrased the way a user would search for it>
+- **Esitiedot:** prerequisites stated or clearly implied (login, edit permission, a selected facility, a file of a certain format, etc.)
+- **Vaiheet:** numbered steps. Every step: `[MM:SS]` what the user does — exact UI element labels verbatim in quotes, precise mouse/keyboard mechanics (single click, double-click, drag, right-click, keyboard modifiers, which map tool is active) — and what the system visibly does in response (e.g. a vertex appears, the line highlights red, a dialog opens).
+- **Vinkit ja varoitukset:** tips, warnings, common mistakes and edge cases the narrator mentions or the video shows.
+
+## Sanasto
+Domain terms used in the video, each with the meaning it carries in the video.
+
+## Epäselvät kohdat
+Anything you could not read or hear confidently.
+
+Fidelity rules — these override everything else:
+- ONLY content that is actually in the video. Never invent UI elements, labels, menu paths or type codes.
+- Transcribe on-screen UI labels VERBATIM, exactly as rendered in Finnish.
+- When the narration and the visible UI differ, report both and flag the difference.
+- If a label or detail is unreadable or uncertain, mark it `[epävarma: <best guess>]`.
+- Mouse and keyboard mechanics are critical: drawing, editing, splitting and importing geometries involve clicks, double-clicks, drags, modifier keys and map tool buttons — capture these exactly as demonstrated, step by step.
+- Give a `[MM:SS]` timestamp on every step so claims can be verified against the video.")
+
+(defn analyze-video
+  "Native Gemini video analysis of a public YouTube URL. Returns markdown
+   article material (see extract-prompt). ~50s and ~300 input tokens per
+   video-second at default resolution. lang = output language, e.g.
+   \"Finnish\"."
+  ([url] (analyze-video default-config url "Finnish"))
+  ([config url lang]
+   (gemini-generate config
+                    [{:fileData {:fileUri url}}
+                     {:text (format extract-prompt lang)}])))
+
+;;; ——— Page translation ———————————————————————————————————————————————
+
+(def ^:private locale->language
+  {:fi "Finnish" :se "Swedish" :en "English"})
+
+(defn- translatable-paths
+  "Paths (for get-in/assoc-in) of every human-readable string in a page."
+  [page]
+  (into (filterv #(get-in page %) [[:title] [:summary]])
+        (for [[i b] (map-indexed vector (:blocks page))
+              k     [:content :title :caption :alt]
+              :when (string? (get b k))]
+          [:blocks i k])))
+
+(defn translate-page
+  "Translates a v2 help page's strings from fi to target-locale (:se/:en),
+   preserving structure, slugs, ids and media references. Markdown inside
+   text blocks is kept as markdown; verbatim UI labels are handled by the
+   prompt: LIPAS UI is fully localized, so labels are translated too."
+  [config page target-locale]
+  (let [paths (translatable-paths page)
+        texts (mapv #(get-in page %) paths)
+        out   (gemini-generate
+               config
+               [{:text (str "Translate the following LIPAS help-center strings from Finnish to "
+                            (locale->language target-locale)
+                            ". They belong to one help article about maintaining sports-facility "
+                            "data on a map. Rules:\n"
+                            "- Preserve markdown structure exactly (headers, lists, bold, quotes).\n"
+                            "- LIPAS's user interface is fully localized, so translate quoted UI "
+                            "labels naturally into the target language (e.g. \"Lisää kartalle\" → "
+                            (case target-locale :se "\"Lägg till på kartan\"" "\"Add to map\"")
+                            " style), keeping them **bold**/quoted as in the source.\n"
+                            "- Keep LIPAS type codes (e.g. 4402), URLs and file-format names unchanged.\n"
+                            "- Finnish domain terms may be glossed once in parentheses when helpful.\n"
+                            "- Return JSON: {\"translations\": [...]} with exactly "
+                            (count texts) " strings, same order as the input.\n\n"
+                            "Input strings as JSON:\n" (json/encode texts))}]
+               :response-schema {:type "object"
+                                 :properties {:translations {:type "array"
+                                                             :items {:type "string"}}}
+                                 :required ["translations"]}
+               :max-tokens 32768)
+        translations (:translations out)]
+    (when (not= (count texts) (count translations))
+      (throw (ex-info "Translation count mismatch"
+                      {:expected (count texts) :got (count translations)})))
+    (reduce (fn [p [path t]] (assoc-in p path t))
+            page
+            (map vector paths translations))))
+
+;;; ——— Tree upsert ————————————————————————————————————————————————————
+
+(defn- ensure-ids
+  [page]
+  (-> page
+      (update :id #(or % (str (random-uuid))))
+      (update :blocks (fn [blocks]
+                        (mapv #(update % :block-id (fn [id] (or id (str (random-uuid)))))
+                              blocks)))))
+
+(defn- locale->type [locale] (str "help-v2-" (name locale)))
+
+(defn get-tree [db locale]
+  (or (db/get-versioned-data db (locale->type locale) "active") []))
+
+(defn slug->page-id
+  "Map of page slug → page id over every section of a locale tree."
+  [tree]
+  (into {} (for [s tree, p (:pages s)] [(:slug p) (:id p)])))
+
+(defn- upsert-page
+  "Replaces a same-slug page in place (keeping its id), or inserts the
+   new page at insert-idx. Returns [pages next-insert-idx]."
+  [pages page insert-idx]
+  (if-let [idx (first (keep-indexed (fn [i p] (when (= (:slug p) (:slug page)) i)) pages))]
+    [(assoc pages idx (assoc page :id (:id (get pages idx)))) insert-idx]
+    (let [idx (min insert-idx (count pages))]
+      [(vec (concat (subvec pages 0 idx) [page] (subvec pages idx)))
+       (inc idx)])))
+
+(defn- validate-tree!
+  "Best-effort: validates against lipas.schema.help/LocaleTree when the
+   v2 schema is on the classpath (it isn't on pre-v2 branches). Stored
+   trees carry string enum values, so decode with the string transformer
+   before validating."
+  [tree]
+  (when-let [schema (try (requiring-resolve 'lipas.schema.help/LocaleTree)
+                         (catch Exception _ nil))]
+    (let [m-validate (requiring-resolve 'malli.core/validate)
+          m-decode   (requiring-resolve 'malli.core/decode)
+          m-explain  (requiring-resolve 'malli.core/explain)
+          str-trans  ((requiring-resolve 'malli.transform/string-transformer))
+          decoded    (m-decode @schema tree str-trans)]
+      (when-not (m-validate @schema decoded)
+        (throw (ex-info "Tree does not validate against LocaleTree"
+                        {:explain (m-explain @schema decoded)})))
+      decoded)))
+
+(defn upsert-pages!
+  "Merges pages into one section of a locale's help tree and publishes.
+
+   content = {:section-slug ... :section-title ... :section-summary ...
+              :after-slug ... :pages [...]}
+
+   - Pages are matched by :slug: existing pages are replaced in place
+     (keeping their :id, so translation-of links stay valid), new pages
+     are inserted after :after-slug (or appended).
+   - The section is created (title/summary required then) if missing.
+   - Page maps may carry :translation-of-slug — resolved to the fi
+     page's id and stored as :translation-of.
+   - Missing :id/:block-id are filled with fresh uuids.
+   - Publishes via lipas.backend.help/save-help-data when available
+     (v2 branches: also enqueues the KB sync job), otherwise writes
+     versioned_data directly.
+
+   Returns {:locale ... :section ... :pages [slugs] :saved-via ...}."
+  [db locale {:keys [section-slug section-title section-summary after-slug pages]}]
+  (let [tree        (vec (get-tree db locale))
+        fi-ids      (when (not= :fi locale) (slug->page-id (get-tree db :fi)))
+        resolve-tr  (fn [p]
+                      (if-let [slug (:translation-of-slug p)]
+                        (-> p
+                            (dissoc :translation-of-slug)
+                            (assoc :translation-of
+                                   (or (get fi-ids slug)
+                                       (throw (ex-info "translation-of-slug not found in fi tree"
+                                                       {:slug slug})))))
+                        (dissoc p :translation-of-slug)))
+        pages       (mapv (comp ensure-ids resolve-tr) pages)
+        sec-idx     (or (first (keep-indexed
+                                (fn [i s] (when (= (:slug s) section-slug) i)) tree))
+                        (count tree))
+        section     (or (get tree sec-idx)
+                        {:id      (str (random-uuid))
+                         :slug    section-slug
+                         :title   (or section-title section-slug)
+                         :pages   []})
+        section     (cond-> section
+                      (and section-summary (not (:summary section)))
+                      (assoc :summary section-summary))
+        insert-idx  (let [ps (:pages section)]
+                      (or (some->> ps
+                                   (keep-indexed (fn [i p] (when (= (:slug p) after-slug) i)))
+                                   first
+                                   inc)
+                          (count ps)))
+        new-pages   (first
+                     (reduce (fn [[ps idx] page]
+                               (upsert-page ps page idx))
+                             [(vec (:pages section)) insert-idx]
+                             pages))
+        tree        (assoc tree sec-idx (assoc section :pages new-pages))
+        _           (validate-tree! tree)
+        ;; v1 branches also have a save-help-data (different type/arity) —
+        ;; only trust it when the v2 marker var is present too.
+        save-fn     (try (when (requiring-resolve 'lipas.backend.help/locale->type)
+                           (requiring-resolve 'lipas.backend.help/save-help-data))
+                         (catch Exception _ nil))]
+    (if save-fn
+      (save-fn db locale tree)
+      (db/add-versioned-data! db (locale->type locale) "active" tree))
+    {:locale    locale
+     :section   section-slug
+     :pages     (mapv :slug pages)
+     :saved-via (if save-fn :help/save-help-data :versioned-data)}))
+
+(comment
+  ;; Analyze one video (≈50 s):
+  (def material (analyze-video "https://www.youtube.com/watch?v=XcZrIepjYe0"))
+
+  ;; Publish authored pages (EDN under dev/lipas/help_content/):
+  (def content (clojure.edn/read-string (slurp "dev/lipas/help_content/reitit_fi.edn")))
+  (upsert-pages! (user/db) :fi content)
+
+  ;; Translate the pages and publish per locale:
+  (def se-pages (mapv #(-> (translate-page default-config % :se)
+                           (assoc :translation-of-slug (:slug %)))
+                      (:pages content)))
+  (upsert-pages! (user/db) :se (assoc content :pages se-pages)))

--- a/webapp/dev/lipas/help_content/reitit_en.edn
+++ b/webapp/dev/lipas/help_content/reitit_en.edn
@@ -1,0 +1,72 @@
+{:section-slug
+ "liikunta-ja-ulkoilupaikan-tietojen-lisaaminen-ja-muokkaaminen",
+ :section-title
+ "Adding and editing sports and outdoor facility information",
+ :after-slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen",
+ :pages
+ [{:slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen",
+   :title "Adding a route-based sports facility",
+   :summary
+   "How to add a new route-based sports facility (e.g., fitness trail, ski track, outdoor route) to the LIPAS system by drawing the route on the map, and what information about the route is saved.",
+   :blocks
+   [{:type :text,
+     :content
+     "### General information on saving routes\n\nThe LIPAS database collects information on routes equipped for sports and outdoor recreation in Finland. The routes to be saved must be maintained, there must be potential landowner permissions or agreements for their use, and the route must have an owner and an administrator. In addition, the route must be guided with terrain markers or its use must be otherwise instructed. Trails used solely under everyman's rights (jokaisenoikeus) are not saved in the LIPAS database.\n\nA special focus is on sports and outdoor routes maintained by municipalities and recreation area associations. Routes maintained by Metsähallitus (the Finnish Forest and Park Service) are not specifically collected, as Metsähallitus takes care of the data for its own route network in its own systems.\n\nRoutes are classified into several sports facility types (e.g., 4401 Fitness trail, 4402 Ski track, 4403 Walking route/outdoor route, 4405 Hiking route, 4411 Mountain biking route). One physical route can be described using multiple types: typically, the same track is a ski track in winter and a fitness trail in summer. You can find descriptions of the type classifications in the Type classification browser in the Instructions section."}
+    {:type :text,
+     :content
+     "### Drawing a route on the map\n\n**Prerequisites:** Logging in (lipas.fi/kirjaudu) and editing rights to the sports facilities of the municipality in question. If you do not have an account, register and specify which data you want editing rights for — the administrators will confirm your account.\n\n1. Click the **+** button in the bottom left corner of the map view (New sports facility).\n2. Select **Sports facility type** — you can search for a type by typing or select from the list. A short description of the type is shown when selecting. Click **OK**.\n3. Center the map on the route area by panning, zooming, or using address search. If you see the text *\"Map needs to be zoomed in closer\"*, zoom in on the map until the **Add to map** button is activated.\n4. Click **Add to map** and draw the route: each mouse click adds one route point, and a line is drawn between the points. Finish the route section by **double-clicking**.\n5. If the route consists of several separate sections, select **Add route section** and draw the next section in the same way.\n6. Click **Done**.\n7. Fill in the route details and click **Save**. A notification *\"Saved successfully\"* is shown upon successful saving.\n\n**Tip:** Draw the route to follow the track in the terrain as accurately as possible. In addition to the background map, you can utilize other map layers (e.g., aerial image).\n\n**Note:** The route line should not intersect itself. If the route crosses itself, the problem area is indicated with a red mark. See the instructions on fixing route geometry."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "XcZrIepjYe0",
+     :title "Video: Adding a route-based sports facility"}
+    {:type :text,
+     :content
+     "### Route details\n\n**Basic information:** The default selection for the sports facility status is *Active*; other options are *Planned* and *Temporarily out of use*. Mandatory fields are marked with an asterisk, and they must be filled in before saving. The street address is mandatory — if the route does not have a clear address, use the closest possible address, for example, the address of the starting point or parking lot. In addition to the route name, you can provide a separate marketing name; if there is no specific marketing name, just fill in the standard name field. In the Contact information field, you can specify who is responsible for the sports facility's customer service or feedback.\n\n**Additional information:** The fields on the Additional information tab change according to the sports facility type. Surface material and route width apply to the entire route by default — if the route sections have different properties, specify the details for each route section separately. You can enter the route length manually or let the system calculate it automatically (calculator icon, *\"Calculate route length automatically\"*)."}
+    {:type :pdf,
+     :url
+     "https://drive.google.com/file/d/19wXBU-wyjSMJ-5Uv1P7VOxy6JBZY8sIh/preview",
+     :title "Route instructions (PDF, 11/2023)"}],
+   :translation-of-slug
+   "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"}
+  {:slug "reittigeometrian-tuonti-tiedostosta",
+   :title "Importing route geometry from a file",
+   :summary
+   "Instead of drawing, the route geometry can be imported from a ready-made file (GPX, GeoJSON, KML, Shapefile), for example from a track saved by a GPS device or a sports application.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Prerequisites:** Login and editing rights, as well as a route file in a supported format: **GPX**, **GeoJSON** (.json/.geojson), **KML** or **Shapefile** (zipped). The coordinate system of the GPX file must be WGS84 (the standard format for GPS devices and applications).\n\n1. Center the map on the route area, for example using the **Search from map area** search.\n2. Click the **+** button in the bottom left corner, select the sports facility type and click **OK**.\n3. Select the **Import from file** tab (next to the Draw tab). If you see the warning *\"The map must be zoomed in closer\"*, zoom in on the map until it disappears.\n4. Click the **Import geometries from file** button. The *\"Import geometries\"* window opens.\n5. Select a file from your computer (Choose File).\n6. The route sections identified from the file are listed in the window. Select the sections to import from the checkboxes and click **Import selected**. The route is drawn on the map.\n7. Check that the geometry looks correct, and click **Done**. Then fill in the route details and save."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "DUa_aMbg9k0",
+     :title "Video: Importing route geometry from a file"}
+    {:type :text,
+     :content
+     "### Tips\n\n- If the file contains several separate route sections, they will all be listed in the import window and you can select the ones you want.\n- The import window may show extra or oddly named rows due to the file's character encoding — just select the clearly named route sections.\n- The system automatically simplifies the imported route track slightly, as GPS tracks, for example, often contain unnecessarily dense points. If the track is still too dense, use the Simplify tool (see the instructions on fixing route geometry).\n- You can also import geometry into an existing route: open the route in edit mode and select *\"Import geometries from file\"* from the tool menu."}],
+   :translation-of-slug "reittigeometrian-tuonti-tiedostosta"}
+  {:slug "reittigeometrian-korjaaminen-ja-yksinkertaistaminen",
+   :title "Correcting and simplifying route geometry",
+   :summary
+   "How to correct route line errors (self-intersecting route, overlapping points) and how to simplify an overly dense route track.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Prerequisites:** The route is selected and edit mode is on (pencil icon **Edit**). In edit mode, the points of the route line become visible.\n\n### Moving, adding, and removing route points\n\n- **Move** a route point by grabbing it with the mouse and dragging it to a new location.\n- **Add** a new point by clicking the route line where you want the point.\n- **Remove** a point by holding down the **Alt key** and clicking the point.\n\n### Correcting a self-intersecting route\n\nIf the route line intersects itself, a red warning sign is displayed at the problem area: *\"Change the course of the route so that the route section does not intersect itself. You can split the route into multiple sections if necessary.\"* LIPAS allows saving, but an intersecting route can prevent the data from being utilized in other services.\n\n1. Select **Split route section** (scissors icon) from the tool menu.\n2. Click the route line at the intersection. The split divides the route into two route sections, which removes the error mark.\n3. Verify the split by hovering the mouse over the line: the separate route section is highlighted as its own line.\n\nIf the problem area has a dense cluster of overlapping points (e.g., a GPS track \"tangle\"), do not split blindly: first remove unnecessary overlapping points one by one using the **Alt + click** function until the course of the route becomes clear, and only then split if necessary."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "M3tmvCVyoD4",
+     :title "Video: Splitting a route and simplifying a route track"}
+    {:type :text,
+     :content
+     "### Simplifying a route track\n\nAn imported GPS track often has points unnecessarily densely, which makes the route heavy to process.\n\n1. Select **Simplify** from the tool menu. A *\"Simplify geometries\"* slider opens at the bottom of the map.\n2. Drag the slider (scale 0–10) to the right: the system reduces the route points and shows the result on the map in real time.\n3. Zoom in closer and check that the simplified line still follows the track running in the terrain. If the line cuts corners too much, decrease the adjustment or correct individual points by dragging.\n4. Accept by clicking **OK**, or reject by clicking **Cancel**.\n5. You can undo the simplification with the **Undo** button (arrow icon in the tool menu).\n\n**Warning:** Simplification is a compromise between accuracy and manageability — always check the result on the map. If you accept the maximum simplification, the tool will no longer reduce points from the same section again; the remaining points must be removed manually (Alt + click).\n\n### Removing a route section\n\nYou can remove an entire route section by selecting **Remove route section** (trash can icon) from the tool menu and clicking the section to be removed.\n\nFinally, remember to save the changes (**Save**)."}],
+   :translation-of-slug
+   "reittigeometrian-korjaaminen-ja-yksinkertaistaminen"}
+  {:slug "reittimaisen-liikuntapaikan-poistaminen",
+   :title "Deleting a route-type sports facility",
+   :summary
+   "How to delete a route from the LIPAS system and what the different deletion reasons mean.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Prerequisites:** The route to be deleted is selected on the map and you have edit rights to it.\n\n1. Click the **trash can icon** (Delete sports facility) on the toolbar.\n2. In the window that opens, select the **Reason for deletion**:\n   - *Permanently out of use* — the route is no longer in use. The facility is archived, but it can still be found using the sports facility search.\n   - *Temporarily out of use* — the route is temporarily out of use. The facility is archived accordingly.\n   - *Incorrect information* — the facility is incorrect (e.g., saved twice). The route is permanently deleted and will no longer appear in searches or on the map.\n3. If necessary, select the **Year** when the deletion occurred.\n4. Confirm by clicking **Delete**. A success notification will be displayed.\n\n**Tip:** If the route is out of use only for a certain period (e.g., route change or renovation), use the status *Temporarily out of use* — this way the route's history and data are preserved."}],
+   :translation-of-slug "reittimaisen-liikuntapaikan-poistaminen"}]}

--- a/webapp/dev/lipas/help_content/reitit_fi.edn
+++ b/webapp/dev/lipas/help_content/reitit_fi.edn
@@ -1,0 +1,58 @@
+;; Route-editing help pages (fi), consolidated 2026-07-16 from Lipasinfo
+;; videos XcZrIepjYe0 / DUa_aMbg9k0 / M3tmvCVyoD4 (Gemini 3.1 Pro native
+;; video analysis) + the 23.11.2023 jyu.fi route guide PDF, grounded
+;; against current UI code. See docs/wip/reitti-ohjeet-konsolidointi.md.
+;; Publish with lipas.help-authoring/upsert-pages!.
+{:section-slug "liikunta-ja-ulkoilupaikan-tietojen-lisaaminen-ja-muokkaaminen"
+ :after-slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+ :pages
+ [{:slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+   :title "Reittimäisen liikuntapaikan lisääminen"
+   :summary "Miten uusi reittimäinen liikuntapaikka (esim. kuntorata, latu, ulkoilureitti) lisätään LIPAS-järjestelmään piirtämällä reitti kartalle, ja mitä tietoja reitistä tallennetaan."
+   :blocks
+   [{:type :text
+     :content "### Yleistä reittien tallentamisesta\n\nLIPAS-tietokantaan kerätään tiedot Suomen liikuntaan ja ulkoiluun varustetuista reiteistä. Tallennettavien reittien tulee olla hoidettuja, niiden käyttöön tulee olla mahdolliset maanomistajien luvat tai sopimukset, ja reitillä on oltava omistaja sekä ylläpitäjä. Lisäksi reitin tulee olla opastettu maastomerkeillä tai sen käyttö on muilla tavoin ohjeistettua. Pelkästään jokaisenoikeuksin käytettäviä polkuja ei tallenneta LIPAS-tietokantaan.\n\nErityinen painopiste on kuntien ja virkistysalueyhdistysten ylläpitämissä liikunta- ja ulkoilureiteissä. Metsähallituksen ylläpitämiä reittejä ei erityisesti kerätä, sillä Metsähallitus huolehtii oman reittiverkostonsa tiedoista omissa järjestelmissään.\n\nReitit on luokiteltu useisiin liikuntapaikkatyyppeihin (esim. 4401 Kuntorata, 4402 Latu, 4403 Kävelyreitti/ulkoilureitti, 4405 Retkeilyreitti, 4411 Maastopyöräilyreitti). Yksi fyysinen reitti voidaan kuvata useamman tyypin avulla: tyypillisesti sama ura on talvella latu ja kesällä kuntorata. Tyyppiluokittelun kuvaukset löydät Ohjeet-osion Tyyppiluokkaselaimesta."}
+    {:type :text
+     :content "### Reitin piirtäminen kartalle\n\n**Esitiedot:** Kirjautuminen (lipas.fi/kirjaudu) ja muokkausoikeudet kyseisen kunnan liikuntapaikkoihin. Jos sinulla ei ole tunnusta, rekisteröidy ja määritä mihin tietoihin haluat muokkausoikeudet — ylläpitäjät vahvistavat tunnuksesi.\n\n1. Napsauta karttanäkymän vasemman alakulman **+**-painiketta (Uusi liikuntapaikka).\n2. Valitse **Liikuntapaikkatyyppi** — voit hakea tyyppiä kirjoittamalla tai valita listasta. Tyypin lyhyt kuvaus näytetään valinnan yhteydessä. Napsauta **OK**.\n3. Kohdista kartta reitin alueelle siirtämällä, zoomaamalla tai osoitehaulla. Jos näet tekstin *\"Kartta täytyy zoomata lähemmäs\"*, lähennä karttaa kunnes **Lisää kartalle** -painike aktivoituu.\n4. Napsauta **Lisää kartalle** ja piirrä reitti: jokainen hiiren napsautus lisää yhden reittipisteen, ja pisteiden välille piirtyy viiva. Päätä reittiosa **kaksoisnapsauttamalla**.\n5. Jos reitti koostuu useista erillisistä osista, valitse **Lisää reittiosa** ja piirrä seuraava osa samalla tavalla.\n6. Napsauta **Valmis**.\n7. Täytä reitin tiedot ja napsauta **Tallenna**. Onnistuneesta tallennuksesta näytetään ilmoitus *\"Tallennus onnistui\"*.\n\n**Vinkki:** Piirrä reitti myötäilemään maastossa olevaa uraa mahdollisimman tarkasti. Voit hyödyntää taustakartan lisäksi muita karttatasoja (esim. ilmakuvaa).\n\n**Huom:** Reittiviiva ei saisi leikata itseään. Jos reitti risteää itsensä kanssa, ongelmakohta osoitetaan punaisella merkillä. Katso ohje reittigeometrian korjaamisesta."}
+    {:type :video
+     :provider :youtube
+     :video-id "XcZrIepjYe0"
+     :title "Video: Reittimäisen liikuntapaikan lisääminen"}
+    {:type :text
+     :content "### Reitin tiedot\n\n**Perustiedot:** Liikuntapaikan tilan oletusvalinta on *Toiminnassa*; muut vaihtoehdot ovat *Suunniteltu* ja *Poistettu käytöstä väliaikaisesti*. Pakolliset kentät on merkitty tähdellä, ja ne on täytettävä ennen tallennusta. Katuosoite on pakollinen — jos reitillä ei ole selkeää osoitetta, käytä lähintä mahdollista osoitetta, esimerkiksi lähtöpisteen tai parkkipaikan osoitetta. Reitin nimen lisäksi voit antaa erillisen markkinointinimen; jos erityistä markkinointinimeä ei ole, täytä vain tavallinen nimikenttä. Yhteystiedot-kenttään voit määrittää, kuka vastaa liikuntapaikan asiakaspalvelusta tai palautteista.\n\n**Lisätiedot:** Lisätiedot-välilehden kentät vaihtuvat liikuntapaikkatyypin mukaan. Pintamateriaali ja reitin leveys koskevat oletuksena koko reittiä — jos reittiosilla on eri ominaisuudet, määritä tiedot kullekin reittiosalle erikseen. Reitin pituuden voit syöttää käsin tai antaa järjestelmän laskea sen automaattisesti (laskin-kuvake, *\"Laske reitin pituus automaattisesti\"*)."}
+    {:type :pdf
+     :url "https://drive.google.com/file/d/19wXBU-wyjSMJ-5Uv1P7VOxy6JBZY8sIh/preview"
+     :title "Reittiohje (PDF, 11/2023)"}]}
+
+  {:slug "reittigeometrian-tuonti-tiedostosta"
+   :title "Reittigeometrian tuonti tiedostosta"
+   :summary "Reitin geometrian voi piirtämisen sijaan tuoda valmiista tiedostosta (GPX, GeoJSON, KML, Shapefile), esimerkiksi GPS-laitteen tai urheilusovelluksen tallentamasta jäljestä."
+   :blocks
+   [{:type :text
+     :content "**Esitiedot:** Kirjautuminen ja muokkausoikeudet sekä reittitiedosto tuetussa muodossa: **GPX**, **GeoJSON** (.json/.geojson), **KML** tai **Shapefile** (zip-pakattuna). GPX-tiedoston koordinaatiston on oltava WGS84 (GPS-laitteiden ja sovellusten vakiomuoto).\n\n1. Kohdista kartta reitin alueelle esimerkiksi **Hae kartan alueelta** -haulla.\n2. Napsauta vasemman alakulman **+**-painiketta, valitse liikuntapaikkatyyppi ja napsauta **OK**.\n3. Valitse **Tuo tiedostosta** -välilehti (Piirrä-välilehden vieressä). Jos näet varoituksen *\"Kartta täytyy zoomata lähemmäs\"*, lähennä karttaa kunnes se poistuu.\n4. Napsauta **Tuo geometriat tiedostosta** -painiketta. *\"Tuo geometriat\"* -ikkuna aukeaa.\n5. Valitse tiedosto koneeltasi (Valitse tiedosto / Choose File).\n6. Ikkunaan listautuvat tiedostosta tunnistetut reittiosat. Valitse tuotavat osat valintaruuduista ja napsauta **Tuo valitut**. Reitti piirtyy kartalle.\n7. Tarkista, että geometria näyttää oikealta, ja napsauta **Valmis**. Täytä sitten reitin tiedot ja tallenna."}
+    {:type :video
+     :provider :youtube
+     :video-id "DUa_aMbg9k0"
+     :title "Video: Reittigeometrian tuonti tiedostosta"}
+    {:type :text
+     :content "### Vinkit\n\n- Jos tiedostossa on useita erillisiä reittiosia, ne kaikki listautuvat tuonti-ikkunaan ja voit valita niistä haluamasi.\n- Tuonti-ikkunassa voi näkyä ylimääräisiä tai oudosti nimettyjä rivejä tiedoston merkistökoodauksen takia — valitse vain selkeästi nimetyt reittiosat.\n- Järjestelmä yksinkertaistaa tuotua reittijälkeä automaattisesti kevyesti, sillä esimerkiksi GPS-jäljet sisältävät usein tarpeettoman tiheästi pisteitä. Jos jälki on silti liian tiheä, käytä Yksinkertaista-työkalua (katso ohje reittigeometrian korjaamisesta).\n- Voit tuoda geometrian myös olemassa olevaan reittiin: avaa reitti muokkaustilaan ja valitse työkaluvalikosta *\"Tuo geometriat tiedostosta\"*."}]}
+
+  {:slug "reittigeometrian-korjaaminen-ja-yksinkertaistaminen"
+   :title "Reittigeometrian korjaaminen ja yksinkertaistaminen"
+   :summary "Miten reittiviivan virheet (itsensä kanssa risteävä reitti, päällekkäiset pisteet) korjataan ja miten liian tiheä reittijälki yksinkertaistetaan."
+   :blocks
+   [{:type :text
+     :content "**Esitiedot:** Reitti on valittuna ja muokkaustila on päällä (kynäkuvake **Muokkaa**). Muokkaustilassa reittiviivan pisteet tulevat näkyviin.\n\n### Reittipisteiden siirtäminen, lisääminen ja poistaminen\n\n- **Siirrä** reittipistettä tarttumalla siihen hiirellä ja raahaamalla se uuteen kohtaan.\n- **Lisää** uusi piste napsauttamalla reittiviivaa kohdasta, johon haluat pisteen.\n- **Poista** piste pitämällä **Alt-näppäin** pohjassa ja napsauttamalla pistettä.\n\n### Itsensä kanssa risteävän reitin korjaaminen\n\nJos reittiviiva leikkaa itsensä, ongelmakohdassa näytetään punainen huomiomerkki: *\"Muuta reitin kulkua niin, että reittiosa ei risteä itsensä kanssa. Voit tarvittaessa katkaista reitin useampaan osaan.\"* LIPAS sallii tallentamisen, mutta risteävä reitti voi estää tietojen hyödyntämisen muissa palveluissa.\n\n1. Valitse työkaluvalikosta **Katkaise reittiosa** (saksikuvake).\n2. Napsauta reittiviivaa risteyskohdassa. Katkaisu jakaa reitin kahdeksi reittiosaksi, jolloin virhemerkki poistuu.\n3. Varmista katkaisu viemällä hiiri viivan päälle: erillinen reittiosa korostuu omana viivanaan.\n\nJos ongelmakohdassa on tiheä sumppu päällekkäisiä pisteitä (esim. GPS-jäljen \"sykerö\"), älä katkaise sokkona: poista ensin turhat päällekkäiset pisteet **Alt + napsautus** -toiminnolla yksi kerrallaan, kunnes reitin kulku selkeytyy, ja katkaise vasta sitten tarvittaessa."}
+    {:type :video
+     :provider :youtube
+     :video-id "M3tmvCVyoD4"
+     :title "Video: Reitin katkaisu ja reittijäljen yksinkertaistaminen"}
+    {:type :text
+     :content "### Reittijäljen yksinkertaistaminen\n\nTuodussa GPS-jäljessä on usein pisteitä tarpeettoman tiheästi, mikä tekee reitistä raskaan käsitellä.\n\n1. Valitse työkaluvalikosta **Yksinkertaista**. Kartan alareunaan avautuu *\"Yksinkertaista geometrioita\"* -säädin.\n2. Vedä liukusäädintä (asteikko 0–10) oikealle: järjestelmä vähentää reittipisteitä ja näyttää tuloksen kartalla reaaliajassa.\n3. Zoomaa lähemmäs ja tarkista, että yksinkertaistettu viiva seuraa yhä maastossa kulkevaa uraa. Jos viiva oikoo liikaa, pienennä säätöä tai korjaa yksittäisiä pisteitä raahaamalla.\n4. Hyväksy napsauttamalla **OK**, tai hylkää napsauttamalla **Peruuta**.\n5. Voit perua yksinkertaistamisen **Kumoa**-painikkeella (nuolikuvake työkaluvalikossa).\n\n**Varoitus:** Yksinkertaistaminen on kompromissi tarkkuuden ja käsiteltävyyden välillä — tarkista tulos aina kartalta. Jos hyväksyt maksimiyksinkertaistuksen, työkalu ei enää vähennä pisteitä samasta osasta uudelleen; loput pisteet on poistettava käsin (Alt + napsautus).\n\n### Reittiosan poistaminen\n\nKokonaisen reittiosan voit poistaa valitsemalla työkaluvalikosta **Poista reittiosa** (roskakorikuvake) ja napsauttamalla poistettavaa osaa.\n\nMuista lopuksi tallentaa muutokset (**Tallenna**)."}]}
+
+  {:slug "reittimaisen-liikuntapaikan-poistaminen"
+   :title "Reittimäisen liikuntapaikan poistaminen"
+   :summary "Miten reitti poistetaan LIPAS-järjestelmästä ja mitä eri poistosyyt tarkoittavat."
+   :blocks
+   [{:type :text
+     :content "**Esitiedot:** Poistettava reitti on valittuna kartalta ja sinulla on muokkausoikeudet siihen.\n\n1. Napsauta työkalurivin **roskakorikuvaketta** (Poista liikuntapaikka).\n2. Valitse aukeavassa ikkunassa **Poiston syy**:\n   - *Poistettu käytöstä pysyvästi* — reitti ei ole enää käytössä. Kohde arkistoituu, mutta se löytyy edelleen liikuntapaikkahaulla.\n   - *Poistettu käytöstä väliaikaisesti* — reitti on tilapäisesti pois käytöstä. Kohde arkistoituu vastaavasti.\n   - *Väärä tieto* — kohde on virheellinen (esim. kahteen kertaan tallennettu). Reitti poistetaan lopullisesti, eikä se näy enää hauissa eikä kartalla.\n3. Valitse tarvittaessa **Vuosi**, jolloin poisto tapahtui.\n4. Vahvista napsauttamalla **Poista**. Onnistumisesta näytetään ilmoitus.\n\n**Vinkki:** Jos reitti on pois käytöstä vain määräajan (esim. reittimuutos tai kunnostus), käytä tilaa *Poistettu käytöstä väliaikaisesti* — näin reitin historia ja tiedot säilyvät."}]}]}

--- a/webapp/dev/lipas/help_content/reitit_se.edn
+++ b/webapp/dev/lipas/help_content/reitit_se.edn
@@ -1,0 +1,72 @@
+{:section-slug
+ "liikunta-ja-ulkoilupaikan-tietojen-lisaaminen-ja-muokkaaminen",
+ :section-title
+ "Lägga till och redigera uppgifter om idrotts- och friluftsplatser",
+ :after-slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen",
+ :pages
+ [{:slug "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen",
+   :title "Lägga till en ruttformad idrottsplats",
+   :summary
+   "Hur en ny ruttformad idrottsplats (t.ex. motionsspår, skidspår, friluftsled) läggs till i LIPAS-systemet genom att rita rutten på kartan, och vilka uppgifter som sparas om rutten.",
+   :blocks
+   [{:type :text,
+     :content
+     "### Allmänt om att spara rutter\n\nI LIPAS-databasen samlas information om Finlands utrustade rutter för motion och friluftsliv. Rutterna som sparas ska vara underhållna, det ska finnas eventuella tillstånd eller avtal med markägare för användningen av dem, och rutten måste ha en ägare samt en upprätthållare. Dessutom ska rutten vara skyltad med terrängmärken eller dess användning på annat sätt anvisad. Stigar som enbart används med allemansrätten sparas inte i LIPAS-databasen.\n\nEtt särskilt fokus ligger på motions- och friluftsleder som upprätthålls av kommuner och friluftsområdesföreningar. Rutter som upprätthålls av Forststyrelsen (Metsähallitus) samlas inte in specifikt, eftersom Forststyrelsen sköter informationen om sitt eget ruttnätverk i sina egna system.\n\nRutter är indelade i flera idrottsplatstyper (t.ex. 4401 Motionsspår, 4402 Skidspår, 4403 Promenadrutt/friluftsled, 4405 Vandringsled, 4411 Terrängcyklingsrutt). En fysisk rutt kan beskrivas med hjälp av flera typer: typiskt sett är samma spår ett skidspår på vintern och ett motionsspår på sommaren. Beskrivningar av typklassificeringen hittar du i Typklassbläddraren (Tyyppiluokkaselain) i avsnittet Anvisningar."}
+    {:type :text,
+     :content
+     "### Rita rutten på kartan\n\n**Förkunskaper:** Inloggning (lipas.fi/kirjaudu) och redigeringsrättigheter till idrottsplatserna i den aktuella kommunen. Om du inte har ett konto, registrera dig och ange vilka uppgifter du vill ha redigeringsrättigheter till — administratörerna bekräftar ditt konto.\n\n1. Klicka på **+**-knappen i kartvyns nedre vänstra hörn (Ny idrottsplats).\n2. Välj **Idrottsplatstyp** — du kan söka efter typen genom att skriva eller välja från listan. En kort beskrivning av typen visas i samband med valet. Klicka på **OK**.\n3. Centrera kartan över ruttens område genom att flytta, zooma eller använda adressökningen. Om du ser texten *\"Kartan måste zoomas in närmare\"*, zooma in kartan tills knappen **Lägg till på kartan** aktiveras.\n4. Klicka på **Lägg till på kartan** och rita rutten: varje musklick lägger till en ruttpunkt, och en linje ritas mellan punkterna. Avsluta ruttdelen genom att **dubbelklicka**.\n5. Om rutten består av flera separata delar, välj **Lägg till ruttdel** och rita nästa del på samma sätt.\n6. Klicka på **Färdig**.\n7. Fyll i ruttens uppgifter och klicka på **Spara**. Vid en lyckad sparning visas meddelandet *\"Sparandet lyckades\"*.\n\n**Tips:** Rita rutten så att den följer spåret i terrängen så noggrant som möjligt. Du kan utnyttja andra kartlager (t.ex. flygbild) utöver bakgrundskartan.\n\n**Obs:** Ruttlinjen bör inte korsa sig själv. Om rutten korsar sig själv markeras problemområdet med ett rött märke. Se anvisningen om att korrigera ruttgeometrin."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "XcZrIepjYe0",
+     :title "Video: Lägga till en ruttformad idrottsplats"}
+    {:type :text,
+     :content
+     "### Ruttens uppgifter\n\n**Grunduppgifter:** Standardvalet för idrottsplatsens status är *I bruk*; andra alternativ är *Planerad* och *Tillfälligt ur bruk*. Obligatoriska fält är markerade med en stjärna, och de måste fyllas i innan du sparar. Gatuadress är obligatorisk — om rutten inte har en tydlig adress, använd närmaste möjliga adress, till exempel adressen till startpunkten eller parkeringsplatsen. Utöver ruttens namn kan du ange ett separat marknadsföringsnamn; om det inte finns något särskilt marknadsföringsnamn, fyll bara i det vanliga namnfältet. I fältet Kontaktuppgifter kan du ange vem som ansvarar för idrottsplatsens kundtjänst eller respons.\n\n**Tilläggsuppgifter:** Fälten på fliken Tilläggsuppgifter ändras beroende på idrottsplatstyp. Ytmaterial och ruttens bredd gäller som standard hela rutten — om ruttdelarna har olika egenskaper, ange uppgifterna för varje ruttdel separat. Ruttens längd kan du mata in manuellt eller låta systemet beräkna den automatiskt (kalkylatorikonen, *\"Beräkna ruttens längd automatiskt\"*)."}
+    {:type :pdf,
+     :url
+     "https://drive.google.com/file/d/19wXBU-wyjSMJ-5Uv1P7VOxy6JBZY8sIh/preview",
+     :title "Ruttanvisning (PDF, 11/2023)"}],
+   :translation-of-slug
+   "reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"}
+  {:slug "reittigeometrian-tuonti-tiedostosta",
+   :title "Import av ruttgeometri från fil",
+   :summary
+   "I stället för att rita kan ruttens geometri importeras från en färdig fil (GPX, GeoJSON, KML, Shapefile), till exempel från ett spår som sparats av en GPS-enhet eller sportapp.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Förkunskaper:** Inloggning och redigeringsrättigheter samt en ruttfil i ett format som stöds: **GPX**, **GeoJSON** (.json/.geojson), **KML** eller **Shapefile** (zip-komprimerad). GPX-filens koordinatsystem måste vara WGS84 (standardformat för GPS-enheter och appar).\n\n1. Centrera kartan över ruttens område, till exempel med sökningen **Sök i kartområdet**.\n2. Klicka på **+**-knappen i det nedre vänstra hörnet, välj typ av idrottsplats och klicka på **OK**.\n3. Välj fliken **Importera från fil** (bredvid fliken Rita). Om du ser varningen *\"Kartan måste zoomas in närmare\"*, zooma in kartan tills den försvinner.\n4. Klicka på knappen **Importera geometrier från fil**. Fönstret *\"Importera geometrier\"* öppnas.\n5. Välj en fil från din dator (Välj fil / Choose File).\n6. I fönstret listas de ruttdelar som identifierats i filen. Välj de delar som ska importeras i kryssrutorna och klicka på **Importera valda**. Rutten ritas på kartan.\n7. Kontrollera att geometrin ser rätt ut och klicka på **Klar**. Fyll sedan i ruttens uppgifter och spara."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "DUa_aMbg9k0",
+     :title "Video: Import av ruttgeometri från fil"}
+    {:type :text,
+     :content
+     "### Tips\n\n- Om filen innehåller flera separata ruttdelar listas alla i importfönstret och du kan välja de du vill ha.\n- I importfönstret kan det visas extra eller konstigt namngivna rader på grund av filens teckenkodning — välj bara de tydligt namngivna ruttdelarna.\n- Systemet förenklar automatiskt det importerade ruttspåret något, eftersom till exempel GPS-spår ofta innehåller onödigt tätt med punkter. Om spåret ändå är för tätt, använd verktyget Förenkla (se anvisningen om att korrigera ruttgeometri).\n- Du kan också importera geometrin till en befintlig rutt: öppna rutten i redigeringsläge och välj *\"Importera geometrier från fil\"* i verktygsmenyn."}],
+   :translation-of-slug "reittigeometrian-tuonti-tiedostosta"}
+  {:slug "reittigeometrian-korjaaminen-ja-yksinkertaistaminen",
+   :title "Korrigering och förenkling av ruttgeometri",
+   :summary
+   "Hur man korrigerar fel i ruttlinjen (rutt som korsar sig själv, överlappande punkter) och hur man förenklar ett för tätt ruttspår.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Förutsättningar:** Rutten är vald och redigeringsläget är aktiverat (pennikonen **Redigera**). I redigeringsläget blir ruttlinjens punkter synliga.\n\n### Flytta, lägga till och ta bort ruttpunkter\n\n- **Flytta** en ruttpunkt genom att ta tag i den med musen och dra den till en ny plats.\n- **Lägg till** en ny punkt genom att klicka på ruttlinjen där du vill ha punkten.\n- **Ta bort** en punkt genom att hålla ner **Alt-tangenten** och klicka på punkten.\n\n### Korrigering av en rutt som korsar sig själv\n\nOm ruttlinjen skär sig själv visas en röd varningssymbol vid problemområdet: *\"Ändra ruttens sträckning så att ruttdelen inte korsar sig själv. Du kan vid behov dela upp rutten i flera delar.\"* LIPAS tillåter sparande, men en korsande rutt kan hindra att informationen utnyttjas i andra tjänster.\n\n1. Välj **Dela ruttdel** (saxikonen) i verktygsmenyn.\n2. Klicka på ruttlinjen i korsningen. Delningen delar upp rutten i två ruttdelar, varvid felmarkeringen försvinner.\n3. Säkerställ delningen genom att föra muspekaren över linjen: den separata ruttdelen markeras som en egen linje.\n\nOm det finns ett tätt kluster av överlappande punkter vid problemområdet (t.ex. ett \"trassel\" i GPS-spåret), dela inte i blindo: ta först bort onödiga överlappande punkter med **Alt + klick**-funktionen en i taget tills ruttens sträckning blir tydlig, och dela först därefter vid behov."}
+    {:type :video,
+     :provider :youtube,
+     :video-id "M3tmvCVyoD4",
+     :title "Video: Delning av rutt och förenkling av ruttspår"}
+    {:type :text,
+     :content
+     "### Förenkling av ruttspår\n\nI ett importerat GPS-spår finns det ofta punkter onödigt tätt, vilket gör rutten tung att hantera.\n\n1. Välj **Förenkla** i verktygsmenyn. I kartans nederkant öppnas reglaget *\"Förenkla geometrier\"*.\n2. Dra skjutreglaget (skala 0–10) åt höger: systemet minskar antalet ruttpunkter och visar resultatet på kartan i realtid.\n3. Zooma in och kontrollera att den förenklade linjen fortfarande följer spåret i terrängen. Om linjen genar för mycket, minska inställningen eller korrigera enskilda punkter genom att dra i dem.\n4. Godkänn genom att klicka på **OK**, eller avbryt genom att klicka på **Avbryt**.\n5. Du kan ångra förenklingen med knappen **Ångra** (pilikonen i verktygsmenyn).\n\n**Varning:** Förenkling är en kompromiss mellan noggrannhet och hanterbarhet — kontrollera alltid resultatet på kartan. Om du godkänner maximal förenkling kommer verktyget inte längre att minska punkterna från samma del igen; de återstående punkterna måste tas bort manuellt (Alt + klick).\n\n### Ta bort en ruttdel\n\nDu kan ta bort en hel ruttdel genom att välja **Ta bort ruttdel** (papperskorgsikonen) i verktygsmenyn och klicka på den del som ska tas bort.\n\nKom slutligen ihåg att spara ändringarna (**Spara**)."}],
+   :translation-of-slug
+   "reittigeometrian-korjaaminen-ja-yksinkertaistaminen"}
+  {:slug "reittimaisen-liikuntapaikan-poistaminen",
+   :title "Borttagning av ruttliknande idrottsplats",
+   :summary
+   "Hur en rutt tas bort från LIPAS-systemet och vad de olika borttagningsorsakerna innebär.",
+   :blocks
+   [{:type :text,
+     :content
+     "**Förutsättningar:** Rutten som ska tas bort är vald på kartan och du har redigeringsrättigheter till den.\n\n1. Klicka på **papperskorgsikonen** i verktygsfältet (Ta bort idrottsplats).\n2. Välj **Orsak till borttagning** i fönstret som öppnas:\n   - *Permanent tagen ur bruk* — rutten är inte längre i bruk. Objektet arkiveras, men det kan fortfarande hittas via idrottsplatssökningen.\n   - *Tillfälligt tagen ur bruk* — rutten är tillfälligt ur bruk. Objektet arkiveras på motsvarande sätt.\n   - *Felaktig information* — objektet är felaktigt (t.ex. sparat två gånger). Rutten tas bort permanent och visas inte längre i sökningar eller på kartan.\n3. Välj vid behov **År** då borttagningen skedde.\n4. Bekräfta genom att klicka på **Ta bort**. Ett meddelande visas när åtgärden har lyckats.\n\n**Tips:** Om rutten endast är ur bruk under en viss tid (t.ex. ruttändring eller renovering), använd statusen *Tillfälligt tagen ur bruk* — på så sätt bevaras ruttens historik och uppgifter."}],
+   :translation-of-slug "reittimaisen-liikuntapaikan-poistaminen"}]}

--- a/webapp/dev/lipas/kb_eval.clj
+++ b/webapp/dev/lipas/kb_eval.clj
@@ -1,0 +1,95 @@
+(ns lipas.kb-eval
+  "REPL-driven retrieval eval for the AI assistant knowledge base.
+
+   Golden questions are phrased the way real users ask (colloquial,
+   cross-lingual, misspelled) and each maps to the source-ref(s) that a
+   correct retrieval must surface. Run before shipping corpus, mapping
+   or embedding-model changes:
+
+     (require '[lipas.kb-eval :as kb-eval])
+     (kb-eval/run-eval (user/search))                 ; hybrid
+     (kb-eval/run-eval (user/search) :method :bm25)   ; lexical only
+     (kb-eval/run-eval (user/search) :method :knn)    ; semantic only
+     (kb-eval/compare-methods (user/search))"
+  (:require [lipas.backend.kb :as kb]))
+
+(def golden
+  "Each entry: :q question, :lang UI language, :expect set of acceptable
+   source-refs — hit means any of them appears in top-3."
+  [;; — Colloquial type-code lookups (the classic lipasinfo question) —
+   {:q "mikä tyyppikoodi padel-kentälle?" :expect #{"type:1390" "type:2295"}}
+   {:q "frisbeegolfrata" :expect #{"type:1180"}}
+   {:q "mihin tyyppiin skeittiparkki merkitään?" :expect #{"type:1150" "type:2250"}}
+   {:q "pulkkamäki" :expect #{"type:1190"}}
+   {:q "hiihtolatu" :expect #{"type:4402"}}
+   {:q "uimaranta" :expect #{"type:3220" "type:3230"}}
+   {:q "kuntosali" :expect #{"type:2120"}}
+   {:q "parkour-paikka" :expect #{"type:1140" "type:2380"}}
+   {:q "luontopolku" :expect #{"type:4404"}}
+   {:q "beach volley kenttä" :expect #{"type:1330"}}
+   {:q "golfkenttä" :expect #{"type:1650"}}
+   {:q "velodromi" :expect #{"type:1170"}}
+   {:q "yleisurheilukenttä" :expect #{"type:1220"}}
+   {:q "keilahalli" :expect #{"type:2610"}}
+   {:q "biljardisali" :expect #{"type:2620"}}
+   {:q "laavu" :expect #{"type:301"}}
+   {:q "ratsastuskenttä" :expect #{"type:6110"}}
+   {:q "maauimala" :expect #{"type:3210"}}
+   {:q "jäähalli" :expect #{"type:2510" "type:2520"}}
+   {:q "tenniskenttä ulkona" :expect #{"type:1370"}}
+
+   ;; — Semantic / no lexical overlap with the official name —
+   {:q "avantouintipaikka" :expect #{"type:3240"}}
+   {:q "boulderointi sisätiloissa" :expect #{"type:2370"}}
+   {:q "petankkikenttä sisällä" :expect #{"type:2290"}}
+   {:q "koirapuisto agilityyn" :expect #{"type:6210" "type:6220"}}
+   {:q "motocross-rata" :expect #{"type:5320" "type:5310"}}
+   {:q "pump track pyöräilyyn" :expect #{"type:1160"}}
+   {:q "missä tyypissä on kota tai kammi?" :expect #{"type:301"}}
+   {:q "paikka missä voi heittää koreja" :expect #{"type:1310"}}
+
+   ;; — Data-model field definitions —
+   {:q "mitä koululiikuntapaikka tarkoittaa?" :expect #{"prop:school-use?"}}
+   {:q "kentän valaistus tieto" :expect #{"prop:ligthing?" "prop:lighting-info"}}
+   {:q "mihin merkitään pintamateriaali?" :expect #{"prop:surface-material"}}
+   {:q "katsomon kapasiteetti" :expect #{"prop:stand-capacity-person"}}
+   {:q "reitin pituus kilometreinä" :expect #{"prop:route-length-km"}}
+
+   ;; — Help-CMS task pages (seeded dev content) —
+   {:q "miten lisään reitin?" :expect #{"tallentajille/reitin-lisaaminen"}}
+   {:q "kuinka tuon gpx-tiedoston kartalle?" :expect #{"tallentajille/reitin-lisaaminen"}}
+   {:q "miten lisään uuden liikuntapaikan?" :expect #{"tallentajille/pisteen-lisaaminen"}}
+   {:q "saavutettavuusanalyysin tekeminen" :expect #{"tyokalut/saavutettavuustyokalu"}}
+
+   ;; — Cross-lingual: question language ≠ document language —
+   {:q "var lägger jag till en padelbana?" :lang "se" :expect #{"type:1390" "type:2295"}}
+   {:q "how do I add a route?" :lang "en" :expect #{"tallentajille/reitin-lisaaminen"}}
+   {:q "swimming hall type code" :lang "en" :expect #{"type:3110"}}
+   {:q "skidspår" :lang "se" :expect #{"type:4402"}}])
+
+(defn run-eval
+  "Hit@3 rate over the golden set. Returns the rate, per-method, plus the
+   misses with what was retrieved instead."
+  [search & {:keys [method limit] :or {method :hybrid limit 3}}]
+  (let [results (mapv (fn [{:keys [q lang expect]}]
+                        (let [hits (kb/search-kb search {:query q
+                                                         :lang (or lang "fi")
+                                                         :limit limit
+                                                         :method method})
+                              refs (mapv :source-ref hits)]
+                          {:q q
+                           :hit? (boolean (some expect refs))
+                           :got refs
+                           :expect expect}))
+                      golden)
+        hits (count (filter :hit? results))]
+    {:method method
+     :hit-at-3 (format "%d/%d (%.0f%%)" hits (count results)
+                       (* 100.0 (/ hits (count results))))
+     :misses (->> results (remove :hit?) (mapv #(dissoc % :hit?)))}))
+
+(defn compare-methods
+  [search]
+  (into {}
+        (for [m [:bm25 :knn :hybrid]]
+          [m (:hit-at-3 (run-eval search :method m))])))

--- a/webapp/dev/lipas/kb_eval.clj
+++ b/webapp/dev/lipas/kb_eval.clj
@@ -58,8 +58,14 @@
    ;; — Help-CMS task pages (seeded dev content) —
    {:q "miten lisään reitin?" :expect #{"tallentajille/reitin-lisaaminen"}}
    {:q "kuinka tuon gpx-tiedoston kartalle?" :expect #{"tallentajille/reitin-lisaaminen"}}
-   {:q "miten lisään uuden liikuntapaikan?" :expect #{"tallentajille/pisteen-lisaaminen"}}
-   {:q "saavutettavuusanalyysin tekeminen" :expect #{"tyokalut/saavutettavuustyokalu"}}
+   {:q "miten lisään uuden liikuntapaikan?"
+    :expect #{"tallentajille/pisteen-lisaaminen"
+              "lipas-liikuntapaikan-lisaaminen-ja-muokkaaminen-2023"
+              "cDaGW3EOrsI"}}
+   {:q "saavutettavuusanalyysin tekeminen"
+    :expect #{"tyokalut/saavutettavuustyokalu"
+              "lipas-saavutettavuustyokalu-2023"
+              "UiKjGeS4Yyg" "XoGxJfolAPY" "FADGfqvjyY4"}}
 
    ;; — Cross-lingual: question language ≠ document language —
    {:q "var lägger jag till en padelbana?" :lang "se" :expect #{"type:1390" "type:2295"}}

--- a/webapp/dev/lipas/kb_eval.clj
+++ b/webapp/dev/lipas/kb_eval.clj
@@ -55,9 +55,18 @@
    {:q "katsomon kapasiteetti" :expect #{"prop:stand-capacity-person"}}
    {:q "reitin pituus kilometreinä" :expect #{"prop:route-length-km"}}
 
-   ;; — Help-CMS task pages (seeded dev content) —
-   {:q "miten lisään reitin?" :expect #{"tallentajille/reitin-lisaaminen"}}
-   {:q "kuinka tuon gpx-tiedoston kartalle?" :expect #{"tallentajille/reitin-lisaaminen"}}
+   ;; — Help-CMS task pages —
+   ;; CMS refs depend on which help content is loaded: dev-seed slugs
+   ;; (tallentajille/*) and migrated prod slugs are both listed as
+   ;; alternates so the eval works against either corpus.
+   {:q "miten lisään reitin?"
+    :expect #{"tallentajille/reitin-lisaaminen"
+              "liikunta-ja-ulkoilupaikan-tietojen-lisaaminen-ja-muokkaaminen/reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+              "lipas-reitin-lisaaminen-2023"
+              "XcZrIepjYe0"}}
+   {:q "kuinka tuon gpx-tiedoston kartalle?"
+    :expect #{"tallentajille/reitin-lisaaminen"
+              "DUa_aMbg9k0"}}
    {:q "miten lisään uuden liikuntapaikan?"
     :expect #{"tallentajille/pisteen-lisaaminen"
               "lipas-liikuntapaikan-lisaaminen-ja-muokkaaminen-2023"
@@ -69,7 +78,10 @@
 
    ;; — Cross-lingual: question language ≠ document language —
    {:q "var lägger jag till en padelbana?" :lang "se" :expect #{"type:1390" "type:2295"}}
-   {:q "how do I add a route?" :lang "en" :expect #{"tallentajille/reitin-lisaaminen"}}
+   {:q "how do I add a route?" :lang "en"
+    :expect #{"tallentajille/reitin-lisaaminen"
+              "liikunta-ja-ulkoilupaikan-tietojen-lisaaminen-ja-muokkaaminen/reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+              "lipas-reitin-lisaaminen-2023"}}
    {:q "swimming hall type code" :lang "en" :expect #{"type:3110"}}
    {:q "skidspår" :lang "se" :expect #{"type:4402"}}])
 

--- a/webapp/dev/lipas/kb_ingest.clj
+++ b/webapp/dev/lipas/kb_ingest.clj
@@ -57,10 +57,13 @@
   (str "https://www.jyu.fi/fi/file/" slug))
 
 (def ptv-sources
-  "PTV-integration guides; :file under <dir>/txt/. Unlike the jyu.fi
-   guides these aren't publicly hosted, so :url points where the user
-   performs the task (deep links inside entry bodies still carry the
-   DVV/suomi.fi URLs present in the source text)."
+  "PTV-integration guides; :file under <dir>/txt/. MIGRATED to the help
+   CMS 2026-07-09: the extracted entries live as the fi \"ptv-integraatio\"
+   help section (canonical, ?ohje= deep links) and were removed from the
+   kb-ingest snapshot — do NOT re-ingest or you get duplicates. Kept for
+   provenance and for re-extracting if the source PDFs are revised.
+   These aren't publicly hosted, so :url points where the user performs
+   the task (entry bodies still carry the DVV/suomi.fi URLs)."
   [{:slug "lipas-ptv-kayttoliittymaohje-0526" :lang "fi" :kind :ptv-guide
     :doc "Ohje PTV-integraation käyttöönottoon LIPAS-järjestelmässä"
     :url "https://lipas.fi/liikuntapaikat"}
@@ -305,8 +308,8 @@ Produce one entry per distinct user task or question the source answers. Rules:
    Runs the whole corpus; returns {:docs [...] :rejected [...]}."
   [dir]
   (let [pdf-results
-        (ingest-txt-sources! dir (concat (map #(assoc % :kind :jyu) pdf-sources)
-                                         ptv-sources))
+        ;; ptv-sources intentionally NOT included — migrated to help CMS.
+        (ingest-txt-sources! dir (map #(assoc % :kind :jyu) pdf-sources))
         video-results
         (for [{:keys [id lang title] :as src} video-sources
               :let [f (io/file dir "subs" (str id "." lang ".vtt"))

--- a/webapp/dev/lipas/kb_ingest.clj
+++ b/webapp/dev/lipas/kb_ingest.clj
@@ -56,6 +56,23 @@
 (defn pdf-url [slug]
   (str "https://www.jyu.fi/fi/file/" slug))
 
+(def ptv-sources
+  "PTV-integration guides; :file under <dir>/txt/. Unlike the jyu.fi
+   guides these aren't publicly hosted, so :url points where the user
+   performs the task (deep links inside entry bodies still carry the
+   DVV/suomi.fi URLs present in the source text)."
+  [{:slug "lipas-ptv-kayttoliittymaohje-0526" :lang "fi" :kind :ptv-guide
+    :doc "Ohje PTV-integraation käyttöönottoon LIPAS-järjestelmässä"
+    :url "https://lipas.fi/liikuntapaikat"}
+   {:slug "dvv-ptv-toimintaohjeet-koulutus-2025" :lang "fi" :kind :ptv-guide
+    :doc "Toimintaohjeet pakollisiksi PTV:ssä – näin kirjoitat hyvät toimintaohjeet (DVV:n PTV-koulutus 31.10.2025)"
+    :url "https://kehittajille.suomi.fi/palvelut/palvelutietovaranto/sisallon-tuottaminen/palvelun-kuvaamisen-ohjeet/miten-taytan-palvelun-perustiedot#toimintaohjeet"
+    :note "The source is DVV's (Digi- ja väestötietovirasto) training deck for PTV users. Focus on guidance that stays true over time: what the Toimintaohjeet field is for, how to write good toimintaohjeet, and what the 3.3.2026 mandatory-field change means for organizations using the IN API integration (such as LIPAS municipalities). Skip event dates, course schedules and other announcements."}
+   {:slug "lipas-ptv-tekoalykuvaukset" :lang "fi" :kind :ptv-guide
+    :doc "Miten tekoäly laatii PTV-kuvaukset LIPAS-järjestelmässä"
+    :url "https://lipas.fi/liikuntapaikat"
+    :note "Audience: LIPAS users who want to understand how the AI-drafted PTV descriptions work — what data the AI reads, what it produces, that a human always reviews before publishing. Skip developer-only details (model names and parameters, JSON schema internals, API endpoints, code references)."}])
+
 (def video-sources
   "Lipasinfo channel (@lipasinfo7382), full inventory 2026-07;
    corpus boundary confirmed by the team. Subtitles under <dir>/subs/."
@@ -167,7 +184,7 @@ Produce one entry per distinct user task or question the source answers. Rules:
 - Each entry must be SELF-CONTAINED: understandable without the other entries or the source. No \"kuten edellä\", no unresolved references.
 - title: the task or question phrased the way a user would ask it (e.g. \"Reitin tuonti GPX-tiedostosta\").
 - body: 100-400 words of markdown. Concrete steps as numbered lists. Prerequisites (login, edit rights) stated when the source states them.
-- Write in the SAME LANGUAGE as the source.
+- Write in the language stated in the Source header (translate faithfully if the source material is written in another language).
 - ONLY facts from the source. Do not invent UI elements, menu names or type codes not present in the source. Auto-generated transcripts contain recognition errors — fix obvious ones from context, and OMIT anything you cannot confidently reconstruct.
 - Skip marketing, greetings, presenter introductions and anything that is not actionable guidance. A short intro video may yield just one overview entry; a dense guide may yield many.
 - start-seconds: for video transcripts, the [s=N] marker closest to where the entry's topic starts; 0 for PDFs or if unsure.")
@@ -184,7 +201,7 @@ Produce one entry per distinct user task or question the source answers. Rules:
         [:issues :string]]]]])))
 
 (def ^:private ground-system-prompt
-  "You are a strict fact-checker. You get SOURCE MATERIAL and ENTRIES derived from it. For each entry decide whether every substantive claim (steps, UI elements, names, codes, constraints) is supported by the source. Transcript wording may be paraphrased or cleaned up — that is fine. Adding facts that are not in the source is not. Report grounded=false with the offending claims in issues when the entry invents anything.")
+  "You are a strict fact-checker. You get SOURCE MATERIAL and ENTRIES derived from it. For each entry decide whether every substantive claim (steps, UI elements, names, codes, constraints) is supported by the source. Wording may be paraphrased, cleaned up or translated into another language — that is fine. Adding facts that are not in the source is not. Report grounded=false with the offending claims in issues when the entry invents anything.")
 
 (defn- gemini-json
   [system-prompt prompt schema]
@@ -196,8 +213,10 @@ Produce one entry per distinct user task or question the source answers. Rules:
       (get-in [:message :content])))
 
 (defn extract-entries
-  [{:keys [doc title lang]} source-text]
-  (let [header (str "Source: " (or doc title) " (language: " lang ")\n\n")]
+  [{:keys [doc title lang note]} source-text]
+  (let [header (str "Source: " (or doc title) " (language: " lang ")\n"
+                    (when note (str "Note: " note "\n"))
+                    "\n")]
     (:entries (gemini-json extract-system-prompt
                            (str header source-text)
                            extract-schema))))
@@ -240,11 +259,12 @@ Produce one entry per distinct user task or question the source answers. Rules:
      :lang          lang
      :source-type   (name kind)
      :source-ref    slug
-     :deep-link     (case kind
-                      :jyu (pdf-url slug)
-                      :youtube (if (pos? (or start-seconds 0))
-                                 (video-url slug start-seconds)
-                                 (video-url slug)))
+     :deep-link     (or (:url source)
+                        (case kind
+                          :jyu (pdf-url slug)
+                          :youtube (if (pos? (or start-seconds 0))
+                                     (video-url slug start-seconds)
+                                     (video-url slug))))
      :type-codes    valid
      :review-status "machine"
      ;; review metadata — stripped before indexing by kb/ingested->docs
@@ -265,16 +285,28 @@ Produce one entry per distinct user task or question the source answers. Rules:
 
 ;;; ——— Drivers ———————————————————————————————————————————————————————
 
+(defn- ingest-txt-sources!
+  [dir sources]
+  (for [{:keys [slug] :as src} sources
+        :let [f (io/file dir "txt" (str slug ".txt"))]
+        :when (.exists f)]
+    (ingest-source! src (slurp f))))
+
+(defn ingest-ptv!
+  "PTV corpus only (ptv-sources); dir layout as in ingest-all!.
+   Returns {:docs [...] :rejected [...]}."
+  [dir]
+  (let [results (ingest-txt-sources! dir ptv-sources)]
+    {:docs (vec (mapcat :docs results))
+     :rejected (vec (mapcat :rejected results))}))
+
 (defn ingest-all!
   "dir = directory with txt/<slug>.txt and subs/<id>.<lang>.vtt.
    Runs the whole corpus; returns {:docs [...] :rejected [...]}."
   [dir]
   (let [pdf-results
-        (for [{:keys [slug lang] :as src} pdf-sources
-              :let [f (io/file dir "txt" (str slug ".txt"))]
-              :when (.exists f)]
-          (ingest-source! (assoc src :kind :jyu :slug slug :lang lang)
-                          (slurp f)))
+        (ingest-txt-sources! dir (concat (map #(assoc % :kind :jyu) pdf-sources)
+                                         ptv-sources))
         video-results
         (for [{:keys [id lang title] :as src} video-sources
               :let [f (io/file dir "subs" (str id "." lang ".vtt"))
@@ -298,14 +330,31 @@ Produce one entry per distinct user task or question the source answers. Rules:
    :by-source (->> docs (map :source-ref) frequencies)})
 
 (defn save-ingested!
-  "Persists accepted docs to versioned_data and resyncs the KB index."
+  "Persists accepted docs to versioned_data and resyncs the KB index.
+   NOTE: replaces the whole snapshot — use add-ingested! to extend it."
   [db search docs]
   (db/add-versioned-data! db "kb-ingest" "active"
                           (mapv #(dissoc % :grounded :issues :unknown-codes) docs))
   (kb/sync! db search))
 
+(defn add-ingested!
+  "Merges docs into the existing kb-ingest snapshot — replaces docs from
+   the same sources (:source-ref), keeps everything else — and resyncs
+   the KB index."
+  [db search docs]
+  (let [clean    (mapv #(dissoc % :grounded :issues :unknown-codes) docs)
+        refs     (set (map :source-ref clean))
+        existing (remove #(contains? refs (:source-ref %))
+                         (db/get-versioned-data db "kb-ingest" "active"))]
+    (save-ingested! db search (vec (concat existing clean)))))
+
 (comment
   (def dir "/private/tmp/claude-501/-Users-tipo-lipas-lipas/8045ae23-5da4-4056-ba5c-c74d5956ff56/scratchpad/kb-ingest")
   (def result (ingest-all! dir))
   (report result)
-  (save-ingested! (user/db) (user/search) (:docs result)))
+  (save-ingested! (user/db) (user/search) (:docs result))
+
+  ;; PTV corpus incrementally on top of an existing snapshot
+  (def ptv-result (ingest-ptv! dir))
+  (report ptv-result)
+  (add-ingested! (user/db) (user/search) (:docs ptv-result)))

--- a/webapp/dev/lipas/kb_ingest.clj
+++ b/webapp/dev/lipas/kb_ingest.clj
@@ -1,0 +1,311 @@
+(ns lipas.kb-ingest
+  "One-off ingestion of jyu.fi PDF guides and Lipasinfo YouTube
+   transcripts into the knowledge base. REPL-driven; results are written
+   to versioned_data (type \"kb-ingest\") so lipas.backend.kb/sync! can
+   rebuild the index deterministically at any time.
+
+   Pipeline per source: extract (LLM: source text → task-shaped entries)
+   → grounding (separate LLM call verifies every claim against source)
+   → mechanical checks (type codes exist) → doc assembly. Everything
+   enters as review-status \"machine\"; a human pass flips to
+   \"reviewed\".
+
+   Usage:
+     (require '[lipas.kb-ingest :as ingest])
+     (def result (ingest/ingest-all! \"/path/to/kb-ingest\"))
+     (ingest/report result)
+     (ingest/save-ingested! (user/db) (user/search) (:docs result))"
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [lipas.backend.db.db :as db]
+            [lipas.backend.kb :as kb]
+            [lipas.backend.llm :as llm]
+            [lipas.data.types :as types]
+            [malli.json-schema :as json-schema]
+            [malli.util :as mu]
+            [taoensso.timbre :as log]))
+
+;;; ——— Corpus ————————————————————————————————————————————————————————
+
+(def pdf-sources
+  "jyu.fi guide PDFs; :file under <dir>/txt/, extracted with pdftotext."
+  [{:slug "lipas-liikuntapaikan-lisaaminen-ja-muokkaaminen-2023" :lang "fi"
+    :doc "Pistemäisen liikuntapaikan lisääminen ja muokkaaminen"}
+   {:slug "lipas-reitin-lisaaminen-2023" :lang "fi"
+    :doc "Reittimäisen liikuntapaikan tallennus ja muokkaus"}
+   {:slug "lipas-saavutettavuustyokalu-2023" :lang "fi"
+    :doc "Saavutettavuustyökalun käyttö"}
+   {:slug "lipas-monipuolisuustyokalu-2023" :lang "fi"
+    :doc "Monipuolisuustyökalun käyttö"}
+   {:slug "lipas-utp-sisaltoohje-2026" :lang "fi"
+    :doc "Luontoon.fi-sisällönsyötön yleisohje"}
+   {:slug "lipas-utp-kalastusohje" :lang "fi"
+    :doc "Kalastuskohteiden sisällönsyöttö Luontoon.fi-palveluun"}
+   {:slug "lipas-tilaohje-2023" :lang "fi"
+    :doc "Liikuntapaikan tila/status-tiedon merkitys"}
+   {:slug "lipas-avustukset-2023" :lang "fi"
+    :doc "Liikuntapaikkarakentamisen avustustiedot"}
+   {:slug "lipas-taloustiedot-2023" :lang "fi"
+    :doc "Kuntien liikunta- ja nuorisotoimen taloustiedot"}
+   ;; lipas-utp-pyorailyohjeistus.pdf has a corrupt xref table -
+   ;; pdftotext can't read it. Re-add when a clean copy exists.
+   ])
+
+(defn pdf-url [slug]
+  (str "https://www.jyu.fi/fi/file/" slug))
+
+(def video-sources
+  "Lipasinfo channel (@lipasinfo7382), full inventory 2026-07;
+   corpus boundary confirmed by the team. Subtitles under <dir>/subs/."
+  [{:id "gMK-uOm6a7k" :lang "fi" :title "LIPAS-palvelun esittely"}
+   {:id "cGHg7C5FSos" :lang "fi" :title "LIPAS intro"}
+   {:id "cDaGW3EOrsI" :lang "fi" :title "Pistemäisen liikuntapaikan lisääminen"}
+   {:id "XcZrIepjYe0" :lang "fi" :title "Reittimäisen liikuntapaikan lisääminen"}
+   {:id "DUa_aMbg9k0" :lang "fi" :title "Reittigeometrian tuonti tiedostosta"}
+   {:id "M3tmvCVyoD4" :lang "fi" :title "Reitin katkaisu ja reittijäljen yksinkertaistaminen"}
+   {:id "dbBfReS_RFs" :lang "fi" :title "Aluemaisen kohteen lisääminen ja muokkaaminen"}
+   {:id "CALwXxFKAAA" :lang "fi" :title "Alueen tallennus"}
+   {:id "6MOxSpd1fUg" :lang "fi" :title "Raporttityökalun käyttö"}
+   {:id "X5qZHzOc5JY" :lang "fi" :title "Lipas.fi/tilastot"}
+   {:id "uz9BKFg2bl8" :lang "fi" :title "Aluehallintoviraston Lipas-käyttö"}
+   {:id "UiKjGeS4Yyg" :lang "fi" :title "Monipuolisuustyökalun käyttöönotto"}
+   {:id "MovCvE0yuKU" :lang "fi" :title "Liikuntapaikkojen monipuolisuusvertailut"}
+   {:id "FADGfqvjyY4" :lang "fi" :title "Kestävää liikuntaa: saavutettavuus ja monipuolisuus (webinaari)"}
+   {:id "rFuvGwqjASI" :lang "fi" :title "Luontoon.fi-tiedonsyöttö: muut kohteet"}
+   {:id "LBnm9mES8GY" :lang "fi" :title "Luontoon.fi-tiedonsyöttö: kalastus"}
+   {:id "TxkbYn91WW8" :lang "fi" :title "Luontoon.fi-tiedonsyöttö: pyöräily"}
+   {:id "UMCrs_T8OLg" :lang "fi" :title "Luontoon.fi-tiedonsyöttö: melonta"}
+   {:id "Ge1pxWPs3_s" :lang "fi" :title "Luontoon.fi-tiedonsyöttö: retkeily ja ulkoilu"}
+   {:id "MASE23FjsiI" :lang "en" :title "Analysing accessibility of sport facilities"}
+   {:id "XoGxJfolAPY" :lang "en" :title "Starting to use LIPAS accessibility tool"}])
+
+(defn video-url
+  ([id] (str "https://www.youtube.com/watch?v=" id))
+  ([id t] (str (video-url id) "&t=" t)))
+
+;;; ——— VTT → timestamped transcript —————————————————————————————————
+
+(defn- vtt-ts->seconds [ts]
+  (let [[h m s] (map #(Double/parseDouble %) (str/split ts #":"))]
+    (long (+ (* 3600 h) (* 60 m) s))))
+
+(defn vtt->transcript
+  "YouTube auto-caption VTT → plain text with [s=N] markers roughly every
+   30 seconds so the extract pass can attach start times to entries.
+   Strips inline word-timing tags and the rolling-window duplicates."
+  [vtt-str]
+  (let [cue-re #"(?m)^(\d{2}:\d{2}:\d{2})\.\d{3} --> .*$"
+        lines (str/split-lines vtt-str)]
+    (loop [lines lines, cur-ts 0, last-mark -100, seen-prev "", out []]
+      (if-let [line (first lines)]
+        (if-let [[_ ts] (re-find cue-re line)]
+          (recur (rest lines) (vtt-ts->seconds ts) last-mark seen-prev out)
+          (let [text (-> line
+                         (str/replace #"<[^>]*>" "")
+                         str/trim)]
+            (if (or (str/blank? text)
+                    (str/starts-with? text "WEBVTT")
+                    (str/starts-with? text "Kind:")
+                    (str/starts-with? text "Language:")
+                    (= text seen-prev))
+              (recur (rest lines) cur-ts last-mark seen-prev out)
+              (let [mark? (>= (- cur-ts last-mark) 30)
+                    out (conj out (if mark? (str "[s=" cur-ts "] " text) text))]
+                (recur (rest lines) cur-ts (if mark? cur-ts last-mark) text out)))))
+        (str/join "\n" out)))))
+
+(defn gemini-video-transcript
+  "Transcribe a public YouTube video via Gemini video input — the fallback
+   for videos without auto-captions. Returns plain text with [s=N] topic
+   markers, matching vtt->transcript's output shape."
+  [url lang]
+  (let [{:keys [base-url api-key]} llm/gemini-config
+        model (:model llm/gemini-default-params)
+        body  {:contents
+               [{:role "user"
+                 :parts [{:fileData {:fileUri url}}
+                         {:text (str "Transcribe this video's narration in its original language (" lang "). "
+                                     "Clean up filler words. Insert a [s=N] marker (N = seconds from video start) "
+                                     "at each topic change and roughly every 30 seconds. When the narration alone "
+                                     "is unclear, describe the on-screen UI action concisely in [UI: ...] brackets. "
+                                     "Output only the transcript.")}]}]
+               :generationConfig {:maxOutputTokens 65536
+                                  :temperature 0.2}}
+        resp  (-> (http/post (str base-url "/models/" model ":generateContent")
+                             {:headers            {"x-goog-api-key" api-key
+                                                   "Content-Type"   "application/json"}
+                              :body               (json/encode body)
+                              :content-type       :json
+                              :socket-timeout     600000
+                              :connection-timeout 10000})
+                  :body
+                  (json/decode keyword))]
+    (-> resp :candidates first :content :parts first :text)))
+
+;;; ——— LLM passes ———————————————————————————————————————————————————
+
+(def ^:private extract-schema
+  (json-schema/transform
+   (mu/open-schema
+    [:map {:closed true}
+     [:entries
+      [:vector
+       [:map {:closed true}
+        [:title :string]
+        [:body :string]
+        [:start-seconds :int]]]]])))
+
+(def ^:private extract-system-prompt
+  "You convert LIPAS user-guide source material (PDF text or video transcript) into knowledge-base entries for an AI help assistant.
+
+LIPAS (lipas.fi) is Finland's national sports facility GIS. Users are municipality employees who maintain facility data.
+
+Produce one entry per distinct user task or question the source answers. Rules:
+
+- Each entry must be SELF-CONTAINED: understandable without the other entries or the source. No \"kuten edellä\", no unresolved references.
+- title: the task or question phrased the way a user would ask it (e.g. \"Reitin tuonti GPX-tiedostosta\").
+- body: 100-400 words of markdown. Concrete steps as numbered lists. Prerequisites (login, edit rights) stated when the source states them.
+- Write in the SAME LANGUAGE as the source.
+- ONLY facts from the source. Do not invent UI elements, menu names or type codes not present in the source. Auto-generated transcripts contain recognition errors — fix obvious ones from context, and OMIT anything you cannot confidently reconstruct.
+- Skip marketing, greetings, presenter introductions and anything that is not actionable guidance. A short intro video may yield just one overview entry; a dense guide may yield many.
+- start-seconds: for video transcripts, the [s=N] marker closest to where the entry's topic starts; 0 for PDFs or if unsure.")
+
+(def ^:private ground-schema
+  (json-schema/transform
+   (mu/open-schema
+    [:map {:closed true}
+     [:verdicts
+      [:vector
+       [:map {:closed true}
+        [:title :string]
+        [:grounded :boolean]
+        [:issues :string]]]]])))
+
+(def ^:private ground-system-prompt
+  "You are a strict fact-checker. You get SOURCE MATERIAL and ENTRIES derived from it. For each entry decide whether every substantive claim (steps, UI elements, names, codes, constraints) is supported by the source. Transcript wording may be paraphrased or cleaned up — that is fine. Adding facts that are not in the source is not. Report grounded=false with the offending claims in issues when the entry invents anything.")
+
+(defn- gemini-json
+  [system-prompt prompt schema]
+  (-> (llm/gemini-complete (assoc llm/gemini-config
+                                  :response-schema schema
+                                  :max-tokens 32768)
+                           system-prompt
+                           prompt)
+      (get-in [:message :content])))
+
+(defn extract-entries
+  [{:keys [doc title lang]} source-text]
+  (let [header (str "Source: " (or doc title) " (language: " lang ")\n\n")]
+    (:entries (gemini-json extract-system-prompt
+                           (str header source-text)
+                           extract-schema))))
+
+(defn ground-entries
+  "Returns entries with :grounded / :issues merged in from the verifier."
+  [source-text entries]
+  (let [verdicts (:verdicts
+                  (gemini-json ground-system-prompt
+                               (str "SOURCE MATERIAL:\n\n" source-text
+                                    "\n\nENTRIES:\n\n"
+                                    (json/encode (map #(select-keys % [:title :body]) entries)))
+                               ground-schema))
+        by-title (into {} (map (juxt :title identity)) verdicts)]
+    (mapv (fn [e]
+            (let [v (get by-title (:title e))]
+              (assoc e
+                     :grounded (:grounded v false)
+                     :issues (:issues v "no verdict returned"))))
+          entries)))
+
+;;; ——— Mechanical checks & doc assembly —————————————————————————————
+
+(defn- mentioned-type-codes
+  "Type codes the entry text mentions that actually exist. Codes that look
+   like type codes but don't exist are returned separately for review."
+  [text]
+  (let [candidates (->> (re-seq #"\b(\d{3,4})\b" text)
+                        (map (comp parse-long second))
+                        distinct)]
+    {:valid (filterv #(contains? types/all %) candidates)
+     :unknown (vec (remove #(contains? types/all %) candidates))}))
+
+(defn- ->doc
+  [{:keys [kind slug lang] :as source} idx {:keys [title body start-seconds] :as entry}]
+  (let [{:keys [valid unknown]} (mentioned-type-codes (str title " " body))]
+    {:id            (str (name kind) ":" slug ":" idx)
+     :title         title
+     :body          body
+     :lang          lang
+     :source-type   (name kind)
+     :source-ref    slug
+     :deep-link     (case kind
+                      :jyu (pdf-url slug)
+                      :youtube (if (pos? (or start-seconds 0))
+                                 (video-url slug start-seconds)
+                                 (video-url slug)))
+     :type-codes    valid
+     :review-status "machine"
+     ;; review metadata — stripped before indexing by kb/ingested->docs
+     :grounded      (:grounded entry)
+     :issues        (:issues entry)
+     :unknown-codes unknown}))
+
+(defn ingest-source!
+  "Full pipeline for one source. Returns {:docs [...] :rejected [...]}."
+  [{:keys [kind slug] :as source} source-text]
+  (log/info "Ingesting" (name kind) slug)
+  (let [entries (extract-entries source source-text)
+        graded  (ground-entries source-text entries)
+        docs    (map-indexed (partial ->doc source) graded)
+        {grounded true rejected false} (group-by (comp boolean :grounded) docs)]
+    (log/info "Ingested" slug {:entries (count docs) :rejected (count rejected)})
+    {:docs (vec grounded) :rejected (vec rejected)}))
+
+;;; ——— Drivers ———————————————————————————————————————————————————————
+
+(defn ingest-all!
+  "dir = directory with txt/<slug>.txt and subs/<id>.<lang>.vtt.
+   Runs the whole corpus; returns {:docs [...] :rejected [...]}."
+  [dir]
+  (let [pdf-results
+        (for [{:keys [slug lang] :as src} pdf-sources
+              :let [f (io/file dir "txt" (str slug ".txt"))]
+              :when (.exists f)]
+          (ingest-source! (assoc src :kind :jyu :slug slug :lang lang)
+                          (slurp f)))
+        video-results
+        (for [{:keys [id lang title] :as src} video-sources
+              :let [f (io/file dir "subs" (str id "." lang ".vtt"))
+                    transcript (if (.exists f)
+                                 (vtt->transcript (slurp f))
+                                 (gemini-video-transcript (video-url id) lang))]]
+          (ingest-source! (assoc src :kind :youtube :slug id :lang lang
+                                 :doc title)
+                          (str "Video title: " title "\n\n" transcript)))
+        results (concat pdf-results video-results)]
+    {:docs (vec (mapcat :docs results))
+     :rejected (vec (mapcat :rejected results))}))
+
+(defn report
+  [{:keys [docs rejected]}]
+  {:accepted (count docs)
+   :rejected (mapv #(select-keys % [:id :title :issues]) rejected)
+   :unknown-type-codes (->> docs
+                            (filter (comp seq :unknown-codes))
+                            (mapv #(select-keys % [:id :unknown-codes])))
+   :by-source (->> docs (map :source-ref) frequencies)})
+
+(defn save-ingested!
+  "Persists accepted docs to versioned_data and resyncs the KB index."
+  [db search docs]
+  (db/add-versioned-data! db "kb-ingest" "active"
+                          (mapv #(dissoc % :grounded :issues :unknown-codes) docs))
+  (kb/sync! db search))
+
+(comment
+  (def dir "/private/tmp/claude-501/-Users-tipo-lipas-lipas/8045ae23-5da4-4056-ba5c-c74d5956ff56/scratchpad/kb-ingest")
+  (def result (ingest-all! dir))
+  (report result)
+  (save-ingested! (user/db) (user/search) (:docs result)))

--- a/webapp/dev/user.clj
+++ b/webapp/dev/user.clj
@@ -529,27 +529,16 @@
                         (set (keys prop-types-new/all))
                         (set (keys prop-types-old/all))))
 
-  (require '[lipas.data.help :as help-data])
-  (require '[lipas.backend.core :as core])
-  (core/save-help-data (db) help-data/sections)
-  *1
+  ;; Help content v2: one versioned_data doc per locale
+  (require '[lipas.backend.help :as help*])
+  (help*/get-help-data (db))                ; {:fi [...] :se [...] :en [...]}
+  (help*/migrate-v1->v2! (db))              ; one-shot v1 → v2 (fi gets all)
+  (help*/save-help-data (db) :fi [])        ; publish one locale
 
   (require '[malli.core :as m])
   (require '[malli.error :as me])
   (require '[lipas.schema.help :as help-schema])
-
-  (me/humanize (m/explain help-schema/HelpData (core/get-help-data (db))))
-
-  (def help-dada (core/get-help-data (db)))
-
-  (m/validate help-schema/HelpData help-dada)
-
-  (require '[lipas.schema.help :as help-schema])
-
-  (def help-dada-v2
-    (-> (core/get-help-data (db)) help-schema/transform-old-to-new-format))
-
-  (core/save-help-data (db) help-dada-v2)
+  (me/humanize (m/explain help-schema/HelpData (help*/get-help-data (db))))
 
   (lipas.backend.core/process-elevation-queue! (db) (search))
   (reindex-search!)

--- a/webapp/dev/user.clj
+++ b/webapp/dev/user.clj
@@ -532,7 +532,9 @@
   ;; Help content v2: one versioned_data doc per locale
   (require '[lipas.backend.help :as help*])
   (help*/get-help-data (db))                ; {:fi [...] :se [...] :en [...]}
-  (help*/migrate-v1->v2! (db))              ; one-shot v1 → v2 (fi gets all)
+  ;; v1 → v2 (fi gets all) now runs automatically as a migratus migration
+  ;; (lipas.migrations.help-v1-to-v2); call directly only for manual poking.
+  (help*/migrate-v1->v2! (db))
   (help*/save-help-data (db) :fi [])        ; publish one locale
 
   (require '[malli.core :as m])

--- a/webapp/docs/README.md
+++ b/webapp/docs/README.md
@@ -14,32 +14,53 @@ Technical documentation for developers working on the webapp.
 
 ## Contents
 
+### Start Here
+
+- **domain-map.md** - Compact system map, sources of truth, invariants, and
+  verification routes
+- **glossary.md** - LIPAS vocabulary and easily confused concepts
+- **architecture.md** - Long-form system architecture and design decisions
+- **data-model.md** - Sports-site and shared domain data model
+
 ### Architecture & Core
-- **architecture.md** - System design, patterns, decisions
-- **frontend.md** - Frontend architecture overview
+
+- **backend.md** - Backend components, routing, middleware, and save flow
+- **frontend.md** - Re-frame/Reagent frontend architecture
+- **database.md** - PostgreSQL tables, views, revision model, and migrations
+- **search.md** - Elasticsearch mappings, enrichment, indexing, and queries
+- **auth.md** - Authentication and contextual privilege model
 - **i18n.md** - Internationalization system
-- **agent-tooling.md** - How we work with AI coding agents (skills, runtime tools, principles)
+- **map-gis.md** - Map and geospatial architecture
+- **reports.md** - Report generation
+- **agent-tooling.md** - Agent context, runtime helpers, and maintenance approach
 
 ### Guides
+
 - **guide-debugging.md** - Debugging heuristics
 - **guide-testing.md** - REPL-driven testing
 - **guide-frontend-patterns.md** - Frontend code patterns & snippets
 
 ### Subsystems
+
 - **heatmap.md** - Heatmap analysis feature
 - **geoserver.md** - GeoServer integration
-- **wfs.md** - WFS layer configuration
+- **itrs.md** - ITRS classification support
 - **mui.md** - Material-UI usage
+- **ai-workbench.md** - AI workbench behavior
 
 ### Integrations (Technical Details)
+
 - **integration-ptv.md** - PTV implementation details
+- **integration-ptv-architecture.md** - PTV component and data flow
 - **integration-ptv-audit.md** - PTV data audit
+- **ptv-ai-integration.md** - PTV AI-assisted workflows
 - **integration-yti.md** - YTI terminology integration
 
 ### API (Internal)
 - **api-v1-internal.md** - V1 API implementation details
 
 ### LLM Context
+
 Specialized context for AI assistants:
 - **context-babashka.md** - Babashka scripting
 - **context-ptv.md** - PTV integration context
@@ -50,7 +71,11 @@ Temporary planning and tracking docs. Delete when completed.
 
 ## Primary LLM Context
 
-The main LLM context is in [`../CLAUDE.md`](../CLAUDE.md).
+- Codex: [`../AGENTS.md`](../AGENTS.md)
+- Claude Code: [`../CLAUDE.md`](../CLAUDE.md)
+
+Both entry points route to this directory for deeper domain knowledge. Prefer
+links to executable source and tests over copying facts that can drift.
 
 ## See Also
 

--- a/webapp/docs/agent-tooling.md
+++ b/webapp/docs/agent-tooling.md
@@ -1,6 +1,8 @@
 # Agent Tooling
 
-How we work with AI coding agents (Claude Code et al.) on LIPAS — what we're building, why, and how to extend it.
+How we work with AI coding agents on LIPAS—what we're building, why, and how to
+extend it. `AGENTS.md` is the Codex entry point and `CLAUDE.md` is the Claude
+Code entry point; both should route to the same project-owned domain knowledge.
 
 This is meta-documentation: it explains the *approach*, not the codebase. For agent-shaped reference docs about LIPAS itself, see the rest of `webapp/docs/`.
 
@@ -65,8 +67,8 @@ Three loading tiers, ordered by cost:
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
-│  CLAUDE.md                                                         │
-│  Always loaded every session. Must stay tiny.                      │
+│  AGENTS.md / CLAUDE.md                                             │
+│  Native agent entry point. Must stay compact.                      │
 │  Vocabulary, invariants, REPL access, must-knows.                  │
 └────────────────────────────────────────────────────────────────────┘
                               │
@@ -147,9 +149,11 @@ When you reach for something that should already exist:
 
 A new skill (vs. a new scenario in lipas-e2e) when the task domain is genuinely separate. E.g. `lipas-ptv` if PTV scenarios grow enough to deserve their own SKILL.md and trip-wires. Don't fragment prematurely — a skill earns its split by having ≥3 scenarios and distinct trip-wires.
 
-### Updating CLAUDE.md
+### Updating an agent entry point
 
-CLAUDE.md is **always loaded**, so every line costs every conversation. Add to it only when:
+`AGENTS.md` and `CLAUDE.md` are loaded by their respective agents, so every line
+has a recurring context cost. Keep shared invariants aligned while adapting
+tool-specific instructions. Add to an entry point only when:
 
 - The fact is touched by ≥3 different task types (otherwise it goes in a skill).
 - It's a vocabulary item or invariant agents need to even *parse* the codebase.
@@ -194,7 +198,9 @@ The skill earns its place by repeatedly saving rediscovery cost. Entries that ne
 
 Honest open questions:
 
-- **Should we cull `webapp/docs/`?** Several files are LLM-generated marketing prose, generic LLM coaching, or leaked system prompts. They actively cost context. We've deferred the rewrite until the skill has carried real weight, so the cull is evidence-driven.
+- **Should we cull `webapp/docs/`?** Several files are long-form or generic and
+  may contain stale generated claims. Keep culling evidence-driven: repair
+  misleading facts first, then remove documents that have no demonstrated use.
 - **Should `.claude/skills/clj-surgeon/` and `.claude/skills/playwright-cli/` be checked in?** They're currently per-developer installs. Same answer applies: prove the value via use, then standardize.
 - **When does a tap>-based event bus pay off?** Probably only when we hit a class of bugs whose root cause is invisible to snapshots (e.g. event-ordering bugs). Until then, defer.
 - **How does this scale to non-LIPAS projects?** The architecture is generic; the skill content isn't. The interesting question is whether the *patterns* (skill router, catalog, scenarios, runtime tools ns) become a template.
@@ -205,4 +211,6 @@ The space is moving fast. What works in 2026 may not be what works in 2027. We'r
 
 - `webapp/.claude/skills/lipas-e2e/SKILL.md` — the first skill instance
 - `webapp/dev/lipas/e2e/tools.clj` — the runtime tooling layer
-- `webapp/CLAUDE.md` — the always-on tier
+- `webapp/docs/domain-map.md` — cross-agent source-of-truth router
+- `webapp/AGENTS.md` — Codex entry point
+- `webapp/CLAUDE.md` — Claude Code entry point

--- a/webapp/docs/architecture.md
+++ b/webapp/docs/architecture.md
@@ -61,22 +61,25 @@ LIPAS is a **distributed GIS application** consisting of:
 - **Single-page application** with ClojureScript frontend
 - **RESTful API** serving JSON data
 - **Background job processing** for async operations
-- **Event-sourced data model** with full audit trail
+- **Append-oriented full-state revisions** for core registry data
 - **GIS-first design** with rich geospatial capabilities
 
 ---
 
 ## Core Design Principles
 
-### 1. Immutability Over Mutability
+### 1. Versioned State Over In-Place Updates
 
-**Opinion:** Data should be append-only. Every change creates a new revision rather than mutating existing records.
+**Opinion:** Normal sports-site edits should preserve prior state by inserting a
+complete new revision rather than overwriting the current document.
 
-**Implementation:** The `sports_site` table stores every revision. A database view (`sports_site_current`) exposes only the latest revision per facility. This provides:
-- Complete audit trail
-- Point-in-time queries
-- Safe concurrent modifications
-- Easy rollback capabilities
+**Implementation:** The `sports_site` table stores full JSONB revisions. A
+database view (`sports_site_current`) exposes the latest non-draft revision per
+facility, ordered by effective `event_date` and then insertion `created_at`.
+Historical correction and data-migration paths can deliberately update existing
+rows, so this is an append-oriented state-revision model rather than strict event
+sourcing. It does not by itself provide optimistic concurrency or automatic
+rollback.
 
 ### 2. Separation of Read and Write Paths
 
@@ -84,9 +87,11 @@ LIPAS is a **distributed GIS application** consisting of:
 
 **Implementation:**
 - **PostgreSQL** is the source of truth for writes
-- **Elasticsearch** serves all read/search operations
-- Write path: API → Validate → DB → Enrich → Index
-- Read path: API → Elasticsearch (bypasses DB entirely)
+- **Elasticsearch** serves search, geospatial queries, reports, and selected API
+  read projections
+- Write path: API → Validate/authorize → DB transaction → post-commit jobs/index
+- Read paths: use Elasticsearch for projections and PostgreSQL for authoritative
+  current/history/internal lookups
 
 ### 3. Data Enrichment at Index Time
 
@@ -140,7 +145,7 @@ Benefits:
 | Routing      | Reitit               | Data-driven routing with OpenAPI |
 | Validation   | Malli                | Schema definition and validation |
 | Database     | PostgreSQL + PostGIS | Relational storage with spatial  |
-| Search       | Elasticsearch 7.x    | Full-text search and analytics   |
+| Search       | Elasticsearch 8      | Full-text search and analytics   |
 | DI/Lifecycle | Integrant            | Component management             |
 | SQL          | HugSQL               | SQL-first database access        |
 | Migrations   | Migratus             | Database schema migrations       |
@@ -388,6 +393,7 @@ The job system handles async operations using PostgreSQL-backed queues:
 - `analysis` - Diversity grid recalculation
 - `elevation` - Route elevation enrichment
 - `webhook` - External system notifications (disabled; no live producers)
+- `help-kb-sync` - Synchronize published help content into the knowledge base
 
 Reminder production and queue cleanup are run directly by the scheduler,
 not through the queue.
@@ -401,7 +407,8 @@ not through the queue.
 5. **Dead Letter Queue:** jobs exceeding max attempts move to `dead_letter_jobs` (and out of `jobs`)
 6. **In-memory Circuit Breaker:** protects the MML elevation API
 
-See `docs/async-jobs.md` (repo root) for the full design.
+See `../../docs/async-jobs.md` for the system-level job design when that sibling
+repository documentation is available.
 
 ---
 
@@ -612,7 +619,10 @@ LIPAS                           PTV API
 - Explicit admin action
 
 **AI-Assisted Descriptions:**
-OpenAI generates Finnish service descriptions from facility data, with human review.
+The PTV AI workflow supports provider-specific generation with human review.
+Current production generation is Gemini-backed, while OpenAI-compatible paths
+remain available for fallback/workbench evaluation; consult
+`lipas.backend.ptv.ai` and `lipas.backend.ptv.workbench` for current selection.
 
 ### OSRM (Open Source Routing Machine)
 
@@ -765,8 +775,8 @@ Avoid:
 
 | Decision                    | Rationale                                          | Trade-offs                                        |
 |-----------------------------|----------------------------------------------------|---------------------------------------------------|
-| **Append-only data**        | Full audit trail, safe concurrent access           | Storage growth, complex queries for current state |
-| **Elasticsearch for reads** | Fast search, geo queries, faceted filtering        | Eventual consistency, index maintenance overhead  |
+| **Versioned state rows**    | Historical state and effective-date queries        | Storage growth, correction exceptions, no built-in optimistic locking |
+| **Elasticsearch projections** | Fast search, geo queries, faceted filtering      | Cross-store coherence and index maintenance       |
 | **Integrant for lifecycle** | Explicit dependencies, testable components         | Learning curve, boilerplate                       |
 | **Re-frame for frontend**   | Predictable state, time-travel debugging           | Verbose for simple cases                          |
 | **PostgreSQL job queue**    | Transactional consistency, no extra infrastructure | Limited throughput vs dedicated queue             |
@@ -779,11 +789,12 @@ Avoid:
 
 LIPAS demonstrates how a mature Clojure/ClojureScript application can handle complex GIS requirements while maintaining developer productivity. The key success factors are:
 
-1. **Immutable data model** - Audit trail and safe operations
+1. **Versioned domain state** - Historical revisions with explicit correction paths
 2. **Clear read/write separation** - Optimized for each path
 3. **Component architecture** - Testable, maintainable
 4. **Schema-first approach** - Validation everywhere
 5. **REPL-driven development** - Fast feedback loops
 6. **Feature-based organization** - Scalable codebase
 
-The system successfully balances pragmatism (SSH deployment, PostgreSQL queues) with sophistication (event sourcing, spatial analysis, AI integration).
+The system balances pragmatic infrastructure with data-driven Clojure,
+full-state revision history, spatial analysis, and AI-assisted integrations.

--- a/webapp/docs/auth.md
+++ b/webapp/docs/auth.md
@@ -1,6 +1,7 @@
 # Authentication & Authorization
 
-> **Status**: Complete
+> **Status**: Source-audited; see the runtime-scope and token-revocation caveats
+> below.
 
 This document describes LIPAS authentication (verifying user identity) and authorization (determining what actions users can perform).
 
@@ -55,6 +56,12 @@ Frontend automatically refreshes tokens every 15 minutes via `/actions/refresh-l
 3. Issues a new token with updated permissions
 
 If refresh fails with 401/403, user is logged out.
+
+Ordinary authenticated requests authorize from the permissions embedded in the
+JWT; they do not reload the user from PostgreSQL. The 15-minute refresh updates
+permissions for a normal active browser session, but a copied/stale token can
+remain usable until its six-hour expiry because there is no server-side token
+revocation check.
 
 ## Login Methods
 
@@ -111,16 +118,22 @@ Privileges are namespaced keywords representing specific actions:
    :activity/view      {:doc "View activity data"}
    :activity/edit      {:doc "Edit activity data"}
    :loi/create-edit    {:doc "Create and edit other locations"}
+   :loi/view           {:doc "View other locations"}
    :floorball/view     {:doc "View floorball data"}
+   :floorball/view-extended {:doc "View extended floorball data"}
    :floorball/edit     {:doc "Edit floorball data"}
    :analysis-tool/use  {:doc "Use analysis tools"}
+   :analysis-tool/experimental {:doc "Use experimental analysis tools"}
    :users/manage       {:doc "Manage users (admin)"}
    :org/member         {:doc "Organization member"}
    :org/manage         {:doc "Manage organization"}
+   :org/admin          {:doc "Create organizations"}
+   :ai-assistant/use   {:doc "Use the AI assistant"}
    :ptv/manage         {:doc "Manage PTV integration"}
    :ptv/audit          {:doc "Audit PTV descriptions"}
    :help/manage        {:doc "Edit help content"}
    :jobs/manage        {:doc "Manage background jobs"}
+   :itrs/edit          {:doc "Edit ITRS classification data"}
    ...})
 ```
 
@@ -136,10 +149,14 @@ Roles are bundles of privileges with optional context constraints:
 | `:type-manager` | Basic editing | `:type-code` (required) |
 | `:site-manager` | Basic editing | `:lipas-id` (required) |
 | `:activities-manager` | Activity editing | `:activity` (required) |
+| `:itrs-assessor` | ITRS editing | Optional city/type scopes |
 | `:floorball-manager` | Floorball editing | `:type-code` (optional) |
 | `:analysis-user` | Analysis tools | None |
+| `:analysis-experimental-user` | Standard + experimental analysis | None |
 | `:ptv-manager` | PTV management | `:city-code` (required) |
+| `:ptv-auditor` | PTV audit | None |
 | `:org-admin` | Organization management | `:org-id` (required) |
+| `:org-user` | Organization membership | `:org-id` (required) |
 
 **Basic privileges** (shared by manager roles):
 ```clojure
@@ -190,6 +207,14 @@ A role matches a context when **all** its context constraints match:
 - Missing constraint in role = always matches
 - `::roles/any` in context = matches any value (for "can user do this anywhere?" checks)
 - Set intersection for multi-value contexts (e.g., activities)
+
+Important: `check-privilege` interprets only the scope keys physically present
+on the stored role assignment. It does not consult the role definition's
+`:required-context-keys` at runtime. A missing scope therefore becomes global
+for that dimension. Permission schemas are expected to prevent malformed
+assignments, but current PTV/organization schema optionality does not fully match
+the role table. Treat permission-map validation as a security boundary and add
+focused tests when changing it.
 
 ```clojure
 ;; Check if user can edit a specific site
@@ -277,7 +302,11 @@ The `check-privilege` function checks for overrides first:
 
 ## Auto-Permission Assignment
 
-When a user creates a new sports site without existing permission to it, they automatically receive `:site-manager` role for that site:
+When a user creates a new sports site without existing edit permission, they
+normally receive a `:site-manager` role for that site. Planning sites created via
+the analysis-tool permission path intentionally skip this assignment. Draft and
+new-site permission gates also differ from existing published-site edits; verify
+all three cases when changing creation authorization.
 
 ```clojure
 ;; src/clj/lipas/backend/core.clj
@@ -297,16 +326,19 @@ For search queries, permissions can be applied as ES filters:
 ;; src/cljc/lipas/roles.cljc
 (defn wrap-es-query-site-has-privilege
   [query user required-privilege]
-  ;; Wraps query to only return sites user can edit
-  ;; Admin gets no filter; others get city/type/lipas-id filters
+  ;; UI search helper using city/type/lipas-id filters
   ...)
 ```
 
-This is used for "show only sites I can edit" search functionality.
+This is used for "show only sites I can edit" search functionality. It is not an
+authorization boundary: when the user has no affecting roles, the helper returns
+the original query unchanged, relying on the UI not to expose the filter. It also
+does not model activity or organization scopes. Enforce authority separately.
 
 ## API Authentication
 
-All authenticated API endpoints use JWT token authentication:
+After HTTP Basic login, ordinary authenticated API requests use JWT token
+authentication:
 
 ```
 GET /api/endpoint
@@ -317,9 +349,10 @@ The `token-auth` middleware extracts and validates the token, populating `:ident
 
 ## Security Considerations
 
-1. **Password hashing**: Uses buddy-hashers (bcrypt by default)
+1. **Password hashing**: Uses the configured/default buddy-hashers algorithm
 2. **Token signing**: HS512 with environment-configured secret
 3. **Token expiration**: 6 hours default, checked on every request
-4. **Refresh mechanism**: Prevents session hijacking with regular re-validation
+4. **Refresh mechanism**: Refreshes DB-backed permissions for the active UI;
+   it is not token revocation
 5. **Permission checks**: Applied at both route and business logic levels
 6. **No token storage on backend**: Stateless authentication

--- a/webapp/docs/backend.md
+++ b/webapp/docs/backend.md
@@ -48,8 +48,6 @@ The system is configured using [Integrant](https://github.com/weavejester/integr
                                       │  │ │
 :lipas/mailchimp ──────────────────┐  │  │ │
                                    │  │  │ │
-:lipas/aws ─────────────────────┐  │  │  │ │
-                                │  │  │  │ │
 :lipas/ptv (ref :lipas/db) ──┐  │  │  │  │ │
                              │  │  │  │  │ │
                              ↓  ↓  ↓  ↓  ↓ ↓
@@ -93,7 +91,6 @@ Components are defined in `system.clj` using `ig/init-key`:
 | `:lipas/search` | Elasticsearch client with index configurations |
 | `:lipas/emailer` | SMTP email sender |
 | `:lipas/mailchimp` | Newsletter integration |
-| `:lipas/aws` | AWS credentials for S3 |
 | `:lipas/ptv` | Finnish Public Service Directory integration |
 | `:lipas/app` | Ring application handler |
 | `:lipas/server` | Jetty HTTP server |
@@ -269,8 +266,8 @@ The `lipas.backend.core` namespace contains all business logic:
 ```clojure
 ;; Read operations
 (get-sports-site db lipas-id)           ; From PostgreSQL
-(get-sports-site2 search lipas-id)      ; From Elasticsearch (preferred)
-(get-sports-site-history db lipas-id)   ; All revisions
+(get-sports-site2 search lipas-id)      ; From Elasticsearch projection
+(get-sports-site-history db lipas-id)   ; Yearly revision snapshots
 
 ;; Write operations
 (save-sports-site! db search ptv user sports-site draft?)
@@ -281,24 +278,26 @@ The `lipas.backend.core` namespace contains all business logic:
 ```
 save-sports-site!
      │
-     ├─→ check-permissions! (throws if unauthorized)
-     │
      ├─→ jdbc/with-db-transaction
      │        │
-     │        ├─→ upsert-sports-site! → PostgreSQL
-     │        │
-     │        ├─→ index! → Elasticsearch (main index)
-     │        │
-     │        ├─→ index-legacy-sports-place! → Elasticsearch (legacy index)
-     │        │
-     │        ├─→ jobs/enqueue-job! "elevation" (for routes)
-     │        │
-     │        ├─→ jobs/enqueue-job! "analysis"
-     │        │
-     │        └─→ sync-ptv! (if PTV integration enabled)
+     │        ├─→ read previous current DB revision
+     │        ├─→ permission/existence checks
+     │        ├─→ upsert-sports-site! → append PostgreSQL revision
+     │        └─→ sync-ptv! when enabled/applicable
+     │             └─→ may append and index another revision in the transaction
      │
+     ├─→ COMMIT
+     ├─→ enqueue affected elevation/analysis jobs (published only)
+     ├─→ index! → Elasticsearch main projection (published only)
+     ├─→ index or delete legacy projection according to facility status
      └─→ Return saved sports site
 ```
+
+Jobs and ordinary search indexing deliberately happen after commit. Therefore
+an indexing failure does not roll back PostgreSQL and may require reindexing to
+repair DB/ES drift. PTV synchronization is a known exception because its current
+implementation can index inside the transaction. Draft saves skip PTV, jobs,
+and Elasticsearch.
 
 ### Data Enrichment
 

--- a/webapp/docs/data-model.md
+++ b/webapp/docs/data-model.md
@@ -33,17 +33,18 @@ LIPAS follows a **data-driven** philosophy where:
 3. **Schemas are shared** between frontend (ClojureScript) and backend (Clojure) via `.cljc` files
 4. **Type-specific behavior** is determined by looking up data structures, not hardcoded logic
 
-### Append-Only Event Sourcing
+### Append-Oriented State Revisions
 
-The core entity (sports sites) uses an append-only pattern:
+The normal sports-site write path uses full-state revisions:
 - Every edit creates a new revision with shared `lipas-id`
-- Revisions are never updated or deleted
-- Current state is derived via database views
-- Full audit trail is preserved
+- `sports_site_current` derives the authoritative current non-draft DB state
+- Elasticsearch derives enriched current read/search projections
+- Historical correction and migration paths can deliberately update old rows;
+  this is not strict event sourcing
 
-### Multilingual by Default
+### Multilingual Domain Data
 
-All user-facing text supports three languages:
+Reference data commonly supports Finnish, Swedish, and English:
 ```clojure
 {:fi "Finnish text"
  :se "Swedish text"
@@ -136,23 +137,23 @@ The sports site schema is a **multi-schema** that dispatches on `:type-code`:
 ;; src/cljc/lipas/schema/sports_sites.cljc
 
 (def sports-site
-  (into [:multi {:dispatch (fn [x] (-> x :type :type-code))}]
-        (for [[type-code type-def] types/all]
-          [type-code (make-sports-site-schema
-                      {:type-codes #{type-code}
-                       :location-schema (case (:geometry-type type-def)
-                                          "Point" #'location-schema/point-location
-                                          "LineString" #'location-schema/line-string-location
-                                          "Polygon" #'location-schema/polygon-location)
-                       :extras-schema (-> [:map]
-                                          (add-properties-schema props)
-                                          (add-activities-schema activity))})])))
+  (m/schema (make-sports-site-multi-schema false)))
+
+(def new-sports-site
+  (m/schema (make-sports-site-multi-schema false false)))
 ```
+
+`make-sports-site-multi-schema` iterates `types/all`, dispatches on
+`[:type :type-code]`, chooses a location schema from `:geometry-type`, and adds
+known property, floorball, and activity schema data. The exact implementation
+constructs plain Malli vectors; inspect it rather than copying an abbreviated
+generator into new code.
 
 This approach:
 - Validates each facility against type-appropriate rules
 - Allows different geometry types per facility type
-- Includes only valid properties for each type
+- Selects and validates known properties for each type while keeping maps open
+  enough to preserve compatible historical/unknown fields
 
 ---
 
@@ -250,9 +251,9 @@ Each property includes:
 |-------------|---------------------------------|-----------------------------|
 | `numeric`   | Numeric value (int or double)   | `number?`                   |
 | `boolean`   | True/false                      | `boolean?`                  |
-| `string`    | Free text                       | `[:string {:max N}]`        |
+| `string`    | Free text                       | `[:string]`                 |
 | `enum`      | Single selection from options   | `[:enum "opt1" "opt2" ...]` |
-| `enum-coll` | Multiple selection from options | `[:set [:enum ...]]`        |
+| `enum-coll` | Multiple selection from options | `[:sequential [:enum ...]]` |
 
 ### Property-Type Binding
 
@@ -474,10 +475,11 @@ Route segments can include per-feature properties:
 
 ### Elevation Enrichment
 
-Routes trigger **elevation enrichment** jobs:
-1. After save, a job fetches elevation data from external API
-2. Altitude values are added to coordinates
-3. Route statistics (total ascent/descent) are computed
+Eligible LineString changes trigger **elevation enrichment** jobs. The registry
+checks whether a new/changed two-dimensional geometry needs enrichment. The job
+fetches MML elevation coverage and appends Z coordinates; it does not currently
+compute total ascent/descent. Worker persistence uses stale-write protection so
+it does not overwrite a newer revision silently.
 
 ---
 
@@ -536,7 +538,8 @@ Activities add rich content beyond basic facility data:
 
 Separate from facility status, documents have publication status:
 - `"published"` - Visible to all, included in search
-- `"draft"` - Only visible to author, excluded from current views
+- `"draft"` - Excluded from current/yearly views and fetched through the
+  author/status application query
 
 ---
 
@@ -611,13 +614,11 @@ For API responses, special schemas handle JSON encoding:
 |---------------------------------------------------------|--------------------------------------------|
 | `src/cljc/lipas/schema/sports_sites.cljc`               | Main sports site schema                    |
 | `src/cljc/lipas/schema/sports_sites/location.cljc`      | Location and geometry schemas              |
-| `src/cljc/lipas/schema/sports_sites/types.cljc`         | Type-specific schema helpers               |
 | `src/cljc/lipas/schema/sports_sites/activities.cljc`    | Activity content schemas                   |
 | `src/cljc/lipas/schema/sports_sites/fields.cljc`        | Floorball fields schema                    |
 | `src/cljc/lipas/schema/sports_sites/circumstances.cljc` | Floorball circumstances schema             |
 | `src/cljc/lipas/schema/lois.cljc`                       | LOI schemas                                |
 | `src/cljc/lipas/schema/common.cljc`                     | Shared schemas (coordinates, status, etc.) |
-| `src/cljc/lipas/schema/core.cljc`                       | Low-level schema primitives                |
 
 ### Database Layer
 

--- a/webapp/docs/database.md
+++ b/webapp/docs/database.md
@@ -1,6 +1,9 @@
 # Database Schema
 
-LIPAS uses PostgreSQL with extensive JSONB document storage. The schema follows an append-only event sourcing pattern for core entities.
+LIPAS uses PostgreSQL with extensive JSONB document storage. Core entities use
+append-oriented full-state revisions. This is not strict event sourcing: normal
+writes append, while explicit historical-correction and migration paths may
+update existing rows.
 
 ## Architecture Overview
 
@@ -8,7 +11,7 @@ LIPAS uses PostgreSQL with extensive JSONB document storage. The schema follows 
 ┌─────────────────────────────────────────────────────────────┐
 │                      PostgreSQL                             │
 ├─────────────────────────────────────────────────────────────┤
-│  Event Log Tables          │  Current State Views          │
+│  Versioned State Tables    │  Current State Views          │
 │  ─────────────────         │  ────────────────────         │
 │  sports_site (append-only) │  sports_site_current          │
 │  loi (append-only)         │  loi_current                  │
@@ -27,21 +30,22 @@ LIPAS uses PostgreSQL with extensive JSONB document storage. The schema follows 
 
 ## Core Tables
 
-### `sports_site` - Facility Event Log
+### `sports_site` - Facility Revision Log
 
-The central table implementing **append-only event sourcing**. Every edit creates a new revision sharing the same `lipas_id`.
+The central table stores complete facility revisions. Normal edits create a new
+row sharing the same `lipas_id`.
 
 ```sql
 CREATE TABLE sports_site (
   id         uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  created_at timestamptz DEFAULT CURRENT_TIMESTAMP,
-  event_date timestamptz NOT NULL,  -- When this revision became valid
+  created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  event_date timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
   lipas_id   integer NOT NULL,      -- Permanent facility identifier
   status     text NOT NULL,         -- 'published', 'draft'
   document   jsonb NOT NULL,        -- Full facility data
-  author_id  uuid REFERENCES account(id),
-  type_code  integer NOT NULL,      -- Facility type (indexed)
-  city_code  text NOT NULL          -- City code (indexed)
+  author_id  uuid NOT NULL REFERENCES account(id),
+  type_code  integer NOT NULL,      -- Relational projection from document
+  city_code  text NOT NULL          -- Relational projection from document
 );
 ```
 
@@ -49,7 +53,8 @@ CREATE TABLE sports_site (
 - `lipas_id` is the permanent identifier for a facility
 - `id` (UUID) uniquely identifies each revision
 - `document` contains the complete facility data as JSONB
-- Revisions are never updated or deleted (append-only)
+- Normal application saves append revisions. Backdated permanent-closure repair
+  and data migrations are deliberate exceptions that can update existing rows.
 
 ### `account` - User Accounts
 
@@ -150,7 +155,7 @@ CREATE INDEX idx_versioned_data_type_event_date
 
 ### `sports_site_current`
 
-Shows only the latest **published** revision for each facility.
+Shows the latest **non-draft** revision for each facility.
 
 ```sql
 CREATE VIEW sports_site_current AS
@@ -166,7 +171,9 @@ JOIN (
 ) b ON a.id = b.id AND b.row_number = 1;
 ```
 
-**Usage:** Most read operations use this view via `get-sports-site`.
+**Usage:** Internal authoritative current reads use this view via
+`get-sports-site`. Major public/search/report paths use the derived Elasticsearch
+projection instead.
 
 ### `sports_site_by_year`
 
@@ -179,7 +186,7 @@ FROM sports_site a
 JOIN (
   SELECT id, row_number() OVER (
     PARTITION BY lipas_id, date_trunc('year', event_date)
-    ORDER BY event_date DESC
+    ORDER BY event_date DESC, created_at DESC
   ) AS row_number
   FROM sports_site
   WHERE status != 'draft'
@@ -205,7 +212,8 @@ JOIN (
 
 A unified job queue. State model: `pending -> processing -> completed`.
 Retries are pending jobs with a future `run_at`; permanently failed jobs
-live only in `dead_letter_jobs`. See `docs/async-jobs.md` (repo root).
+live only in `dead_letter_jobs`. See `../../docs/async-jobs.md` when the sibling
+system-level documentation is available.
 
 ### `jobs` - Main Job Queue
 
@@ -230,8 +238,8 @@ CREATE TABLE jobs (
   updated_at     timestamptz DEFAULT now()
 );
 
--- Fetch performance index
-CREATE INDEX idx_jobs_pending ON jobs (status, run_at, priority)
+-- Fetch performance index (pending rows only)
+CREATE INDEX idx_jobs_pending ON jobs (priority DESC, run_at ASC)
   WHERE status = 'pending';
 
 -- Deduplication applies to pending jobs only
@@ -347,8 +355,7 @@ For complex data transformations:
 | Table            | Index                                | Purpose          |
 |------------------|--------------------------------------|------------------|
 | `sports_site`    | Primary on `id`                      | Row lookup       |
-| `sports_site`    | Implied on `lipas_id`, `event_date`  | View performance |
-| `jobs`           | `(status, run_at, priority)` partial | Job fetching     |
+| `jobs`           | `(priority DESC, run_at ASC)` partial for pending rows | Job fetching |
 | `jobs`           | `(type, dedup_key)` unique partial   | Deduplication    |
 | `versioned_data` | `(type, event_date DESC)`            | Latest by type   |
 
@@ -384,7 +391,7 @@ CREATE INDEX idx_document_status ON sports_site
 ### Creating New Revision
 
 ```clojure
-;; Appends new row, doesn't update existing
+;; Normal path appends a new row; see correction exception above
 (db/upsert-sports-site! db-spec user sports-site)
 ```
 
@@ -413,7 +420,7 @@ RETURNING id;
 User Edit
     │
     ▼
-sports_site table (new revision appended)
+sports_site table (normally a new full-state revision)
     │
     ▼
 sports_site_current view (reflects latest)
@@ -425,4 +432,6 @@ Elasticsearch index (enriched, denormalized)
 API responses / Search queries
 ```
 
-The database is the **source of truth** with full history. Elasticsearch serves as a read-optimized cache of current revisions.
+The database is the **source of truth**. Elasticsearch serves derived enriched
+projections for search and major read paths. The existing history query is a
+yearly snapshot view, not an exact row-by-row revision log.

--- a/webapp/docs/domain-map.md
+++ b/webapp/docs/domain-map.md
@@ -1,0 +1,224 @@
+# LIPAS Domain Map
+
+Use this document to find the source of truth for a change. It is intentionally
+compact: follow the links for detail, then verify current behavior in source,
+tests, and the REPL.
+
+## System in one page
+
+LIPAS is Finland's national registry of sports facilities. Its central record is
+a data-driven sports-site document identified permanently by `lipas-id` and
+stored as an ordered series of revisions.
+
+```text
+Browser SPA (Re-frame/Reagent, OpenLayers)
+    │ HTTP actions and queries
+    ▼
+Ring/Reitit application
+    │ authentication, coercion, authorization, orchestration
+    ├── PostgreSQL/PostGIS ── authoritative records and revision history
+    ├── Elasticsearch ─────── derived search/read projections
+    ├── PostgreSQL jobs ───── post-commit enrichment and integration work
+    └── External systems ──── PTV, UTP/Luontoon.fi, OSRM, GeoServer, MML
+```
+
+Integrant owns stateful component construction and lifecycle. Shared `.cljc`
+data and Malli schemas carry domain vocabulary and validation between backend
+and frontend.
+
+## Sources of truth by concern
+
+| Concern | Authoritative starting points | Deep reference / representative tests |
+|---|---|---|
+| Runtime components | `lipas.backend.config`, `lipas.backend.system`, `lipas.jobs.system` | [architecture.md](architecture.md), [backend.md](backend.md) |
+| HTTP application | `lipas.backend.handler`, `lipas.backend.api.v1.routes`, `lipas.backend.api.v2` | `lipas.backend.api.v1.*-test`, `lipas.backend.api.v2.handler-test` |
+| Sports-site shape | `lipas.schema.sports-sites` and its nested schema namespaces | [data-model.md](data-model.md), `lipas.schema.sports-sites-test` |
+| Type/property vocabulary | `lipas.data.types`, `lipas.data.prop-types`, `lipas.data.owners`, `lipas.data.admins`, `lipas.data.status` | schema tests under `test/clj/lipas/schema/` |
+| Sports-site persistence | `lipas.backend.db.db`, `lipas.backend.db.sports-site`, `resources/sql/sports_site.sql` | [database.md](database.md), handler/integration tests |
+| Save orchestration | `lipas.backend.core/save-sports-site!` | `lipas.backend.org-test`, API handler/integration tests, `dev/lipas/e2e/tools.clj` |
+| Search projection | `lipas.backend.core/enrich`, `index!`, `lipas.backend.search`, `lipas.search-indexer` | [search.md](search.md), search and legacy-index tests |
+| Authorization | `lipas.roles`, then route middleware and business-level checks | [auth.md](auth.md), `lipas.roles-test`, `lipas.backend.org-test` |
+| Organizations | `lipas.backend.org`, `lipas.schema.org`, organization routes/UI | `lipas.backend.org-test` |
+| Background jobs | `lipas.jobs.registry`, `lipas.jobs.core`, `lipas.jobs.worker`, `lipas.jobs.handler` | job namespace tests and admin jobs UI |
+| PTV | `lipas.backend.ptv.*`, `lipas.data.ptv`, organization PTV configuration | [context-ptv.md](context-ptv.md), [integration-ptv-architecture.md](integration-ptv-architecture.md) |
+| Help and assistant | `lipas.backend.help`, `lipas.backend.kb`, `lipas.backend.assistant`, `lipas.backend.llm`, shared schemas, matching UI features | current tests plus `docs/wip/ai-assistant-implementation.md` while it remains WIP |
+| Frontend state/navigation | `lipas.ui.core`, `lipas.ui.routes`, feature `events`/`subs`/`views` namespaces | [frontend.md](frontend.md), [guide-frontend-patterns.md](guide-frontend-patterns.md) |
+| GIS and analysis | `lipas.backend.gis`, `lipas.backend.analysis.*`, map feature namespaces | [map-gis.md](map-gis.md), [heatmap.md](heatmap.md) |
+| I18n | `lipas.i18n.*`, translation maps and `:tr` subscriptions | [i18n.md](i18n.md) |
+
+When a document and code disagree, migrations and executable source/tests win.
+Correct the document as part of the task when the difference is durable.
+
+## Architectural boundaries
+
+### Domain data and schemas
+
+The project is intentionally data-driven:
+
+- `lipas.data.*` maps define facility types, properties, owner/admin values,
+  statuses, activities, cities, and other controlled vocabulary.
+- `lipas.schema.*` derives or composes Malli contracts from that vocabulary.
+- `.cljc` makes genuinely shared domain rules available to Clojure and
+  ClojureScript.
+- Roles and privileges are data in `lipas.roles`; `check-privilege` interprets
+  that data against a role context.
+- Reitit routes, Integrant systems, and the job registry are declarative maps
+  interpreted at system boundaries.
+
+Prefer extending these established data/dispatch points over adding parallel
+conditional logic. Normalize external representations at entry points and keep
+one canonical internal shape.
+
+### Backend effects
+
+Keep pure decisions and transformations separate from effects:
+
+```text
+transport/coercion → domain decision/transformation → DB transaction
+                                            └──────→ post-commit effects
+```
+
+HTTP handlers should primarily adapt transport data and invoke application
+functions. PostgreSQL queries belong in the DB layer. Search enrichment should
+be deterministic from an authoritative sports-site document wherever possible.
+External calls and background work need explicit failure and consistency rules.
+
+### Frontend flow
+
+The SPA follows Re-frame's unidirectional model:
+
+```text
+DOM input → event → coeffect/effect → app-db → subscription → view
+```
+
+Keep views declarative, subscriptions as derived reads, and events/effects as
+state transitions and side-effect orchestration. Put reusable domain
+transformations in pure/shared functions rather than render bodies.
+
+## Sports-site lifecycle
+
+### Two different statuses
+
+Do not confuse these:
+
+| Status | Location | Meaning |
+|---|---|---|
+| Facility `:status` | Inside the JSONB `document` | Domain lifecycle: `planning`, `planned`, `active`, temporary/permanent out-of-service, or `incorrect-data` |
+| Revision publication status | `sports_site.status` column / metadata `:doc-status` | Storage visibility: `published` or `draft` |
+
+`sports_site_current` selects the newest non-draft revision per `lipas_id`; it
+does not select only facilities whose document status is `active`.
+
+### Normal save path
+
+`lipas.backend.core/save-sports-site!` is the complete application save path:
+
+1. Start a PostgreSQL transaction and read the current revision when updating.
+2. Check contextual permissions and existence through
+   `upsert-sports-site!`; allocate a `lipas-id` for a new site.
+3. Insert a full new revision. Published revisions appear through
+   `sports_site_current`; drafts are fetched separately by author.
+4. If enabled and applicable, PTV synchronization runs inside the transaction
+   and can append another sports-site revision. The current PTV implementation
+   also indexes that revision from inside the transaction; the returned response
+   is aligned with the PTV revision.
+5. Commit the transaction.
+6. Enqueue applicable background jobs. Registry trigger functions decide which
+   jobs the before/after change requires.
+7. Synchronously index the current document into `sports_sites_current` and
+   either index or remove it from the status-filtered legacy index.
+
+Draft saves skip PTV, jobs, and Elasticsearch indexing.
+
+Use `save-sports-site!` for normal application/E2E behavior. The similarly named
+`upsert-sports-site!` handles DB revision insertion and permissions but does not
+perform the post-commit search/job integration path. The `*` variant is for
+trusted migrations or controlled internal use and skips normal safeguards.
+
+### Consistency model
+
+PostgreSQL is authoritative. Elasticsearch writes happen after commit, so an
+indexing failure can leave a committed DB revision missing or stale in search.
+Reindexing repairs this direction of drift. Background jobs are enqueued before
+indexing so an Elasticsearch failure does not suppress required work.
+
+PTV synchronization is a known exception to the otherwise post-commit indexing
+boundary: it can index from inside the DB transaction, after which the outer save
+indexes the final revision again following commit. Consequently, failures in the
+PTV branch can produce different DB/ES ordering than an ordinary save. Verify
+both layers explicitly when changing that path.
+
+The main search index is a derived enriched projection. The legacy index uses a
+legacy transformation and contains only `active` and
+`out-of-service-temporarily` facilities. The two projections are not equivalent.
+
+### Historical sharp edges
+
+- Normal saves append revisions, but the historical permanent-closure repair
+  path mutates later revision documents to `incorrect-data` before inserting the
+  new revision. Treat “append-only” as the normal write model, not proof that no
+  maintenance SQL ever updates an existing row.
+- `core/get-sports-site-history` reads `sports_site_by_year`; it returns yearly
+  snapshots and can collapse multiple revisions from the same year. Use the raw
+  revision table or the E2E `revision-count` helper when exact revision count is
+  the invariant.
+- PTV synchronization may create two revisions during one logical save.
+- A new site's creator can receive a contextual `:site-manager` role if existing
+  permissions do not cover it. Planning-site creation also has an analysis-tool
+  permission path.
+- Reconstructing old JSON documents can silently discard unknown historical
+  fields. Prefer transformations that preserve keys unless removal is explicit.
+
+## Authorization mental model
+
+Authorization is privilege-based and context-sensitive:
+
+```text
+stored role assignment
+    + role definition's privilege set
+    + requested context (city/type/site/activity/org)
+    = privilege decision
+```
+
+`lipas.roles/check-privilege` is shared between backend and frontend. It selects
+role assignments whose constraints match the supplied context, always includes
+the unassignable `:default` role, expands active roles to privileges, and checks
+the requested privilege. `::roles/any` asks whether a matching permission exists
+for any value of a context dimension.
+
+The runtime matcher uses scope keys present on the stored assignment; it does
+not enforce the role definition's `:required-context-keys`. Missing assignment
+scope matches globally for that dimension, so permission-map schema validation
+is security-sensitive. Keep role definitions, user schemas, editor UI, and tests
+aligned—especially for PTV and organization roles.
+
+Frontend permission checks control affordances; backend route and business
+checks enforce authority. Never treat a hidden button as authorization. Prefer
+privilege checks over direct role-name checks; `check-role` is normally for
+classification, tracking, or UI purposes rather than granting access.
+
+JWTs contain a permissions snapshot. The UI refreshes from the DB every 15
+minutes, but ordinary API authorization does not re-read the user; stale tokens
+can retain old permissions until their six-hour expiry. There is no general
+server-side revocation mechanism in the current flow.
+
+## Verification by change type
+
+| Change | Minimum focused evidence | Likely broader evidence |
+|---|---|---|
+| Pure domain transform | REPL examples plus focused unit/property test | callers' namespace tests |
+| Shared schema/data | Malli validation in REPL and schema tests | backend and frontend compile; compatibility fixtures |
+| Permission rule | `check-privilege` matrix at REPL | `lipas.roles-test`, handler/org tests, UI affordance check |
+| Sports-site save | focused handler/core test and before/after DB value | revision count, `e2e/coherent?`, job/index assertions |
+| Search enrichment/mapping | enriched document and focused search test | reindex against dev data only when explicitly in scope |
+| Re-frame behavior | event/subscription state at CLJS REPL | `(user/compile-cljs)` and browser-visible assertion |
+| Migration | migration SQL/data check on disposable/dev DB | affected queries and compatibility tests; never production implicitly |
+
+See [AGENTS.md](../AGENTS.md) for the complete exploration, REPL, clean-test,
+and browser feedback loop.
+
+## Maintenance rule
+
+Keep this file as a router and invariant ledger, not a second implementation.
+Add a fact only when it changes how multiple tasks should be approached. Put
+subsystem detail in its focused document and link to executable source/tests.

--- a/webapp/docs/frontend.md
+++ b/webapp/docs/frontend.md
@@ -10,13 +10,14 @@ LIPAS (lipas.fi) is a comprehensive sports facility management system with a Clo
 
 ### Core Technologies
 - **ClojureScript**: Primary language for frontend development
-- **Re-frame**: State management and event handling framework (v1.4.3)
-- **Reagent**: React wrapper for ClojureScript (v2.0.0-alpha2) - **Preferred approach**
-- **UIx**: Modern React hooks integration (v1.1.1) - Limited use recommended
-- **Shadow-cljs**: Build tool and hot-reload development (v2.28.16)
+- **Re-frame**: State management and event handling framework (v1.4.5)
+- **Reagent**: React wrapper for ClojureScript (v2.0.1)
+- **React**: v19.1
+- **Shadow-cljs**: Build tool and hot-reload development (v3.3.6)
 
 #### React Library Context
-**Important**: UIx was introduced approximately one year ago when Reagent's future React 19+ support was uncertain. Now that Reagent supports modern React versions, the codebase contains a mix of both approaches. While both libraries interoperate well, **new development should prefer Reagent with traditional Re-frame patterns** for consistency and maintainability. UIx usage should be limited to specific cases where React hooks provide clear benefits.
+Use Reagent 2 functional components (`r/defc`) and `reagent.hooks` where React
+hooks are needed. UIx is no longer a project dependency.
 
 ### UI Framework
 - **Material-UI (MUI)**: Component library for consistent UI design
@@ -136,12 +137,12 @@ If there's any possibility that another part of the application might need the s
        [child-component {:data form-data}]])))
 ```
 
-#### UIx Hooks Integration (Use Sparingly)
+#### Hooks Integration
 ```clojure
-;; Only use when hooks provide clear benefits
-(defn hook-based-component []
-  (let [data (use-subscribe [:subscription-query])]
-    [:div data]))
+;; Hooks must be called at component top level and effects list dependencies.
+(r/defc hook-based-component []
+  (let [value (hooks/use-state nil)]
+    [:div (str value)]))
 ```
 
 ### 4. Available Re-frame Effects
@@ -384,7 +385,9 @@ You can return back to the Clojure REPL by evaluating `:cljs/quit` in ClojureScr
 
 You can inspect possible build warnings and errors with: `(user/compile-cljs)`
 
-Currently no automated UI tests exist.
+There is no conventional standalone browser test suite. REPL-driven E2E helpers
+in `dev/lipas/e2e/` provide repeatable setup and cross-layer assertions; use a
+real browser for the user-visible interaction under test.
 
 ## Security Patterns
 
@@ -488,11 +491,9 @@ The `lipas.ui.mui` wrapper is legacy. For new code, import MUI components direct
 
 ;; New (direct import)
 (ns my-ns
-  (:require ["@mui/material/Button$default" :as Button]
-            [reagent.core :as r]))
+  (:require ["@mui/material/Button$default" :as Button]))
 
-(def button (r/adapt-react-class Button))
-[button {:variant "contained"} "Click"]
+[:> Button {:variant "contained"} "Click"]
 ```
 
 Note: The wrapper still works and is used throughout the codebase, but direct imports reduce indirection and make dependencies clearer.
@@ -502,7 +503,7 @@ Note: The wrapper still works and is used throughout the codebase, but direct im
 ### Recommended Enhancements
 
 1. **Complete Malli Migration**: Finish replacing all Spec validations
-2. **Standardize on Reagent**: Gradually refactor UIx components to Reagent
+2. **Keep Reagent 2 patterns consistent**: Use `r/defc` and explicit hook dependencies
 3. **Code Splitting**: Implement lazy loading for large features
 4. **Testing Coverage**: Expand automated testing
 5. **Performance**: Implement virtual scrolling for large lists

--- a/webapp/docs/glossary.md
+++ b/webapp/docs/glossary.md
@@ -1,0 +1,52 @@
+# LIPAS Glossary
+
+Compact vocabulary for reading code, issues, and domain documentation. Source
+maps and schemas remain authoritative for enumerated values.
+
+| Term | Meaning |
+|---|---|
+| LIPAS | Finnish national sports facility registry; also the surrounding application and data ecosystem |
+| liikuntapaikka / sports site | Core registry entity: a sports or recreation facility represented by a versioned document |
+| `lipas-id` | Permanent positive integer identifying a sports site across all of its revisions |
+| revision `id` | UUID identifying one row/revision in `sports_site`; not the public facility identifier |
+| `event-date` | Domain-effective timestamp used to order revisions; distinct from row `created-at` |
+| facility status | `:status` inside a sports-site document, describing planning/operational lifecycle |
+| document status / `doc-status` | DB revision publication state: `published` or `draft` |
+| current revision | Newest non-draft revision selected by `sports_site_current` for a `lipas-id` |
+| yearly history | Latest revision per facility/year from `sports_site_by_year`; not a complete revision log |
+| type code | Numeric sports-facility classification key; drives allowed geometry, properties, labels, and integrations |
+| main/sub-category | Higher levels grouping individual sports-site type codes |
+| property type | Data definition describing a type-specific sports-site property and its schema/UI metadata |
+| owner | Controlled value for who owns a facility, defined in `lipas.data.owners` |
+| admin | Controlled value for the entity administering a facility, defined in `lipas.data.admins`; not the same as the user `:admin` role |
+| LOI | Location of interest (`loi`), a separate versioned entity for other mapped destinations |
+| PTV | Palvelutietovaranto, Finland's national public-service information repository |
+| UTP / Luontoon.fi | External outdoor/recreation content domain attached to selected LIPAS entities; older code and docs may use UTP terminology |
+| ITRS | Classification/editing domain governed by the `:itrs/edit` privilege |
+| search index | `sports_sites_current`, the current enriched Elasticsearch projection used for search and many reads |
+| legacy index | `legacy_sports_sites_current`, transformed for legacy API behavior and restricted to selected facility statuses |
+| enrichment | Deterministic transformation that resolves reference data and adds search/geospatial metadata before indexing |
+| coherence | Agreement between the authoritative DB revision and its expected derived Elasticsearch projection |
+| role assignment | Stored map such as `{:role :city-manager :city-code #{...}}` containing a role plus contextual constraints |
+| privilege | Namespaced capability such as `:site/create-edit`; authorization should normally ask for privileges, not role names |
+| role context | Values such as city, type, `lipas-id`, activity, or organization against which a role assignment is matched |
+| `::roles/any` | Sentinel used to ask whether permission exists for any value of a context dimension |
+| Re-frame app-db | Client-side immutable application state; events change it and subscriptions derive reads from it |
+| Integrant system | Runtime graph of stateful components such as DB, search client, app, server, emailer, and PTV client |
+| job registry | Data-driven definitions for background job behavior, including triggers, priority, retry, debounce, and concurrency policy |
+| dead letter | Permanently failed job moved out of the live queue for inspection/acknowledgement |
+
+## Similar names that are not interchangeable
+
+| Names | Difference |
+|---|---|
+| `save-sports-site!` vs `upsert-sports-site!` | Complete DB + integration path versus DB revision operation |
+| `get-sports-site` vs `get-sports-site2` | Current authoritative DB view versus current Elasticsearch projection |
+| facility `:status` vs DB `sports_site.status` | Domain lifecycle versus draft/published revision visibility |
+| `sports_site_current` vs `sports_sites_current` | PostgreSQL view versus Elasticsearch index |
+| `lipas-id` vs sports-site row `id` | Stable facility identifier versus revision UUID |
+| history vs revision count | Existing history API is yearly snapshots; exact revision count requires the raw log |
+| admin value vs admin role | Facility administrator classification versus globally privileged user role |
+
+Add terms when they decode recurring project language. Keep implementation
+details in [domain-map.md](domain-map.md) or focused subsystem documentation.

--- a/webapp/docs/search.md
+++ b/webapp/docs/search.md
@@ -29,7 +29,7 @@ All index names are configured in `src/clj/lipas/backend/config.clj`:
 |-------------------------------|---------------------------------------|-----------------------|
 | `sports_sites_current`        | Main sports site search               | `:sports-site`        |
 | `legacy_sports_sites_current` | V1 API compatibility format           | `:legacy-sports-site` |
-| `analytics`                   | All revisions for analytics           | `:sports-sites`       |
+| `analytics`                   | All revisions for analytics           | `:analytics`          |
 | `lois`                        | Locations of Interest                 | `:lois`               |
 | `schools`                     | School data for reachability analysis | —                     |
 | `vaestoruutu_1km`             | Population grid (1km resolution)      | `:population-grid`    |
@@ -37,6 +37,8 @@ All index names are configured in `src/clj/lipas/backend/config.clj`:
 | `diversity`                   | Pre-calculated diversity indices      | custom                |
 | `subsidies`                   | Subsidy reporting data                | —                     |
 | `city_stats`                  | City-level statistics                 | —                     |
+| `lipas_kb_v1`                 | Help/assistant knowledge base          | `:kb`                 |
+| `assistant_logs`              | Assistant interaction logs             | `:assistant`          |
 
 ### Aliasing Strategy
 
@@ -44,7 +46,8 @@ Indexes use aliases for zero-downtime reindexing:
 1. Create new index with timestamp suffix (e.g., `search-2024-01-15t10-30-00`)
 2. Index all documents to new index
 3. Atomically swap alias to new index
-4. Delete old index
+4. Delete all stale concrete indexes for that alias/mode, including orphaned
+   failed-run indexes
 
 ## Mappings
 
@@ -56,7 +59,7 @@ The sports sites index uses **explicit mapping with strict mode** to prevent ind
 
 **Key characteristics:**
 - `dynamic: "strict"` - rejects queries on unmapped fields
-- `total_fields.limit: 300` - reduced from 2000
+- `total_fields.limit: 450`
 - All ~260 fields explicitly mapped
 
 **Mapping generation** (`search/generate-explicit-mapping`):
@@ -152,14 +155,20 @@ Multimethod dispatches on type-code for custom enrichment:
 ```
 1. Save sports-site!
    ↓
-2. Insert to sports_site table (new revision)
+2. Commit a published sports_site revision
    ↓
-3. core/enrich - Add :search-meta with resolved lookups
+3. Enqueue applicable post-commit jobs
    ↓
-4. search/index! - Send to sports_sites_current (sync or async)
+4. core/enrich - Add :search-meta with resolved lookups
    ↓
-5. If active status: Also index to legacy_sports_sites_current
+5. Synchronously index sports_sites_current
+   ↓
+6. Index legacy_sports_sites_current only for active or temporarily
+   out-of-service sites; delete other statuses from the legacy projection
 ```
+
+Draft saves skip this path. PTV synchronization is an exception that can index
+inside the database transaction before the ordinary post-commit index step.
 
 ## Query Patterns
 
@@ -168,7 +177,7 @@ Multimethod dispatches on type-code for custom enrichment:
 ```clojure
 (search/search client "sports_sites_current"
   {:size 100
-   :query {:bool {:filter [{:term {:status.keyword "active"}}]}}})
+   :query {:bool {:filter [{:term {:status "active"}}]}}})
 ```
 
 ### Full-Text with Field Boosting
@@ -250,7 +259,7 @@ Multimethod dispatches on type-code for custom enrichment:
 1. **Create timestamped index**: `search-2024-01-15t10-30-00`
 2. **Bulk index by type-code**: Iterates all ~250 type codes
 3. **Swap alias**: Atomically point alias to new index
-4. **Delete old indexes**: Clean up previous indexes
+4. **Delete stale indexes**: Clean up previous and orphaned failed-run indexes
 
 ### Bulk Indexing
 

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -23,7 +23,8 @@ Backend (clj):
 |---|---|
 | `lipas.backend.llm` | Generic LLM plumbing extracted from `ptv.ai`: provider registry, `complete`/`gemini-complete` (+retry, OpenAI fallback), `embed`/`embed-one` (gemini-embedding-001, 768 dims, L2-renormalized). `ptv.ai` now wraps it with PTV-specific schema defaults. |
 | `lipas.backend.kb` | KB doc builders + sync + retrieval. `help-cms->docs`, `code-data->docs` (types incl. colloquial `:tags`, prop-types), `ingested->docs` (reads versioned_data type=`kb-ingest`), `sync!` (content-hash diff → embed only changed, delete orphans), `search-kb` (hybrid BM25+kNN, client-side RRF, cross-lingual kNN unfiltered, per-language dedup by source-ref), `get-doc` (full entry by id). |
-| `lipas.backend.assistant` | Agent: Gemini function-calling loop, **first turn forced to call a tool** (toolConfig ANY). Tools: `search_kb`, `get_kb_document`, `lookup_type_code`, `explain_field`, `list_stale_sites`, `list_sites_missing_data`, `get_site_summary`, `escalate_to_support` (draft-only). `editable-scope` from roles = *relevance default* for listing tools, not authorization (site data is public). Per-user in-memory rate limits (30 chat/h, 5 escalations/day). `chat!`/`escalate!` entrypoints, exchange logging to `assistant_logs`. `context-schema` (closed Malli map) validates the widget's app-db snapshot. |
+| `lipas.backend.assistant` | Agent: Gemini function-calling loop, **first turn forced to call a tool** (toolConfig ANY). Tools: `search_kb`, `get_kb_document`, `lookup_type_code`, `explain_field`, `list_stale_sites`, `list_sites_missing_data`, `get_site_summary`, `check_site_permission` (**authoritative verdict from `roles/check-privilege` + user's roles with official names — never LLM-reasoned**), `escalate_to_support` (draft-only), plus **UI-action tools** `apply_search`, `show_site_on_map`, `pan_map_to_location`, `navigate_to_view` (propose-only: validated via `lipas.schema.assistant`, returned as `:actions` in the response, rendered as buttons the user clicks — nothing auto-fires). `editable-scope` from roles = *relevance default* for listing tools, not authorization (site data is public). Per-user in-memory rate limits (30 chat/h, 5 escalations/day). `chat!`/`escalate!` entrypoints, exchange logging to `assistant_logs` (incl. proposed action types). `context-schema` (closed Malli map) validates the widget's app-db snapshot. |
+| `lipas.schema.assistant` (cljc) | **Closed action vocabulary**: Malli multi-schema for the 4 action types + `views` registry (id → description, feeds the `navigate_to_view` tool enum and the frontend route mapping). Reuses canonical `lipas-id`/`city-code`/`active-type-code` schemas. The model never produces re-frame event vectors — it calls an action tool, the backend validates against this schema, the frontend translates. |
 | `lipas.backend.handler` | Routes `/actions/assistant-chat`, `/actions/assistant-escalate` (both `:require-privilege :ai-assistant/use`); help CMS routes `save-help-draft`, `get-help-versions`, `get-help-version`. |
 | `lipas.backend.search` | `kb-mapping` (strict; finnish/swedish/english analyzer subfields, dense_vector 768 cosine), `assistant-logs-mapping`. Registered in `mappings` ⇒ auto-created at startup. |
 | `lipas.backend.config` | `:indices` gained `:kb {:kb "lipas_kb_v1"}` and `:assistant {:logs "assistant_logs"}`. |
@@ -34,7 +35,8 @@ Frontend (cljs):
 
 | File | What |
 |---|---|
-| `lipas.ui.assistant.{events,subs,views}` | Widget: Fab launcher + panel at app root (`lipas.ui.views/main-panel`), privilege-gated. Markdown answers (`?ohje=` links open help dialog in place, external links new tab), source chips, escalation confirmation card (editable summary, shows what's sent where), new-chat button. `db->context` builds the per-message app-db snapshot (route, readable view, locale, selected site's lipas-id, edit-mode). Stateless server: full history sent per request. |
+| `lipas.ui.assistant.{events,subs,views}` | Widget: Fab launcher + panel at app root (`lipas.ui.views/main-panel`), privilege-gated. Markdown answers (`?ohje=` links open help dialog in place, external links new tab), source chips, escalation confirmation card (editable summary, shows what's sent where), new-chat button. **Action buttons**: `::run-action` is the whitelist translator (action map → dispatches; unknown types inert), gated on map edit-mode (notification instead of navigating away from unsaved edits); executed buttons flip to disabled+✓. `apply-search` → navigate to map + `search/replace-filters`; `show-site` → `map/show-sports-site`; `pan-to-location` → digitransit geocode then `set-center`/`set-zoom` (12 for places, 14 for addresses); `navigate-to-view` → `view->route` map. `db->context` builds the per-message app-db snapshot (route, readable view, locale, selected site's lipas-id, edit-mode). Stateless server: full history sent per request. |
+| `lipas.ui.search.events/replace-filters` | Replace whole search spec (string + filters) from clean defaults in one event → single ES query with `:fit-view` (map pans to results). Used by assistant action buttons. |
 | `lipas.ui.help.*` | Deep links: `?ohje=section/page` synced via replaceState; `::navigate-to` resolves slugs (pending-slugs if data not loaded yet); dialog moved to app root; content loads at app init (`::help/init`, dispatch-sync in `core.cljs` *before* router start). Markdown text blocks (react-markdown) + `lipas.utils/localized` fi→en→se fallback. Editor: Save draft / Publish / History dialog (load any revision into editor; publishing it = rollback). |
 
 Dev tooling:
@@ -104,6 +106,27 @@ looks wrong or empty, just resync.
 - **Escalation is two-phase**: agent drafts, UI confirmation card, separate
   endpoint sends via the `email` job queue (user's address in body,
   conversation id in subject).
+- **Names from data only**: the model decorates bare codes with world
+  knowledge and gets them wrong (city 320 → "Muurame"; it's Kemijärvi). Every
+  code in the prompt or a tool result carries its resolved name
+  (`city-label`/`type-label`/`describe-roles`; role names read from the UI
+  i18n file). Prompt forbids inferring names from codes.
+- **Answer links are allow-listed server-side** (`sanitize-answer-links`):
+  `?ohje=` links must match a deep-link retrieved this conversation; only
+  http(s)/mailto pass otherwise; fabricated slugs and tool-call-scheme links
+  (`navigate_to_view:profile`) degrade to plain text. The model fabricated
+  all three kinds in testing.
+- **Permissions**: user's roles (official names + scopes) in USER CONTEXT;
+  per-site verdicts via `check_site_permission` (real permission engine);
+  role semantics as code-derived KB docs (privilege `:doc` strings). The
+  *process* content (how to request rights, org flows) is Lipasinfo-authored
+  KB material — still missing.
+- **UI actions are propose-only, closed-vocabulary**: the model calls an
+  action tool → backend validates against `lipas.schema.assistant` (canonical
+  city/type/lipas-id enums; city *names* resolved server-side; site existence
+  checked) → widget renders a button → the user clicks. The frontend
+  translator is the only place an action becomes a dispatch; edit-mode blocks
+  execution. Max 3 actions per answer reach the client.
 - **Ingestion is migration, not mirroring**: entries live in versioned_data,
   `review-status "machine"` until a human flips them; grounding verifier
   rejects unsupported claims at ingest time.
@@ -131,13 +154,33 @@ looks wrong or empty, just resync.
 
 ## Current dev state
 
-- KB: 1063 docs (6 seeded help-cms + 969 code-data + 87 ingested + 1 log).
-  Help CMS content is **my dev seed** (2 sections / 3 pages) — real content
+- KB: 1079 docs (7 seeded help-cms + 984 code-data incl. 2 nav-structure
+  docs fi/en and 13 role docs + 87 ingested + 1 log). Help CMS content is **my dev seed**
+  (2 sections / 4 pages, incl. "Miten kopioin liikuntapaikan?") — real content
   should be authored by Lipasinfo via the editor (draft → publish).
-- Eval: hybrid 41/41 hit@3. Assistant verified in-browser: grounded how-tos
-  with citations (incl. `&t=` video timestamps), context adaptation, type-code
-  disambiguation, out-of-scope refusal, stale-sites listing (Utajärvi),
-  two-turn escalation, chat logging.
+- Multi-intent lesson (seasonal luistelukenttä/pallokenttä case): the
+  two-separate-sites rule is answered perfectly out of the box (ingested jyu
+  doc has the literal example). But a *latent* second intent (copy feature
+  eases creating the second site) is only surfaced if content carries it: the
+  agent's searches follow the user's phrasing, and a WORK-SAVING FEATURES
+  prompt rule proved unreliable at thinkingLevel minimal (with feature names
+  in the rule the model tips **without retrieving** = provenance risk; without
+  names it skips the extra search). Robust fix is content-level: the canonical
+  seasonal CMS article should itself contain the copy tip / cross-link.
+  Direct "miten kopioin kohteen?" questions answer correctly from the seeded
+  article (cited as `?ohje=` deep link).
+- Eval: hybrid 40/41 hit@3. The 1 miss ("paikka missä voi heittää koreja" →
+  1310) is **pre-existing**, verified unrelated to the nav docs by
+  delete-and-requery; kNN alone ranks it #2, the RRF merge drops it to #5.
+  Prompt-iteration backlog, not a regression.
+- Assistant verified in-browser: grounded how-tos with citations (incl. `&t=`
+  video timestamps), context adaptation, type-code disambiguation,
+  out-of-scope refusal, stale-sites listing (Utajärvi), two-turn escalation,
+  chat logging. **UI actions verified end-to-end** (Playwright, fresh
+  session): "Mitä liikuntapaikkoja on Äänekoskella?" → button → 225 results +
+  map fit; "Missä näen kuntien taloustilastot?" → button → `/tilastot/talous`;
+  edit-mode gate refuses with notification. Unit tests:
+  `lipas.backend.assistant-test` (action schema + tool handlers).
 
 ## Remaining / next
 
@@ -145,7 +188,9 @@ looks wrong or empty, just resync.
 2. Deploy: `GEMINI_API_KEY` in prod env; first `help-kb-sync` runs via
    scheduler/publish; **run ingestion against prod DB** (87 entries live only
    in local versioned_data); real CMS content; then flip GA
-   (`:ai-assistant/use` → `roles/basic`).
+   (`:ai-assistant/use` → `roles/basic`). If `assistant_logs` already exists
+   in an env, PUT `_mapping` with `actions {:type "keyword"}` (strict mapping;
+   fresh indices get it automatically).
 3. Kibana views over `assistant_logs` (escalation rate = failure metric,
    top questions = content backlog).
 4. Prompt iteration from `assistant_logs` (watch for hedged invention, e.g.

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -45,15 +45,15 @@ Dev tooling:
 | File | What |
 |---|---|
 | `dev/lipas/kb_eval.clj` | 41 golden questions, hit@3 runner, `compare-methods`. Current: bm25 78% / knn 100% / **hybrid 41/41**. Run before corpus/mapping/model changes. |
-| `dev/lipas/kb_ingest.clj` | One-off ingestion: extract (LLM → task-shaped entries) → grounding (separate verifier per source; 2/89 rejected) → type-code validation → docs saved to versioned_data `kb-ingest` → `kb/sync!`. VTT parsing with `[s=N]` markers → timestamped YouTube deep links; `gemini-video-transcript` fallback for the 9 caption-less videos. Corpus inventory (9 PDFs + all 21 Lipasinfo videos) is in the ns. |
+| `dev/lipas/kb_ingest.clj` | One-off ingestion: extract (LLM → task-shaped entries) → grounding (separate verifier per source; 2/89 rejected) → type-code validation → docs saved to versioned_data `kb-ingest` → `kb/sync!`. VTT parsing with `[s=N]` markers → timestamped YouTube deep links; `gemini-video-transcript` fallback for the 9 caption-less videos. Corpus inventory (9 PDFs + all 21 Lipasinfo videos + 3 PTV guides, see `ptv-sources`) is in the ns. PTV sources aren't publicly hosted → per-source `:url` overrides the deep link (lipas.fi/liikuntapaikat or the DVV instruction page); `ingest-ptv!` runs just that corpus and `add-ingested!` merges into the existing snapshot (replace-by-source-ref) instead of overwriting it. |
 
 ## Data flow
 
 ```
 help CMS (canonical, published only) ─┐
-lipas.data.types/prop-types (derived) ─┼─> kb/sync! ──> lipas_kb_v1 (1063 docs)
+lipas.data.types/prop-types (derived) ─┼─> kb/sync! ──> lipas_kb_v1
 versioned_data "kb-ingest" (one-off)  ─┘   (hash-diff,      │
-                                            orphan-delete)  ▼
+                                            orphan-delete)  ▼ (1102 docs)
 widget ──/actions/assistant-chat──> assistant loop ──tools──> search-kb / sites index
    ▲          (context snapshot)         │
    └── answer + sources + escalation? ◄──┘        exchanges ──> assistant_logs
@@ -155,8 +155,9 @@ looks wrong or empty, just resync.
 
 ## Current dev state
 
-- KB: 1079 docs (7 seeded help-cms + 984 code-data incl. 2 nav-structure
-  docs fi/en and 13 role docs + 87 ingested + 1 log). Help CMS content is **my dev seed**
+- KB: 1102 docs (17 help-cms + 983 code-data incl. 2 nav-structure
+  docs fi/en and 13 role docs + 102 ingested: 35 jyu + 52 youtube +
+  15 ptv-guide, 2026-07-09). Help CMS content is **my dev seed**
   (2 sections / 4 pages, incl. "Miten kopioin liikuntapaikan?") — real content
   should be authored by Lipasinfo via the editor (draft → publish).
 - Multi-intent lesson (seasonal luistelukenttä/pallokenttä case): the
@@ -240,7 +241,7 @@ help-cms->docs skip rules).
 2. Deploy: `GEMINI_API_KEY` in prod env; **run help-v2 migration against
    prod DB** (`(lipas.backend.help/migrate-v1->v2! db)`, once, before the
    first v2 publish); first `help-kb-sync` runs via scheduler/publish;
-   **run ingestion against prod DB** (87 entries live only in local
+   **run ingestion against prod DB** (102 entries live only in local
    versioned_data); real CMS content authoring (summaries + hand-tuned
    slugs where wanted, se/en translations when they exist); then flip GA
    (`:ai-assistant/use` → `roles/basic`). If `assistant_logs` already exists

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -23,6 +23,7 @@ Backend (clj):
 |---|---|
 | `lipas.backend.llm` | Generic LLM plumbing extracted from `ptv.ai`: provider registry, `complete`/`gemini-complete` (+retry, OpenAI fallback), `embed`/`embed-one` (gemini-embedding-001, 768 dims, L2-renormalized). `ptv.ai` now wraps it with PTV-specific schema defaults. |
 | `lipas.backend.kb` | KB doc builders + sync + retrieval. `help-cms->docs`, `code-data->docs` (types incl. colloquial `:tags`, prop-types), `ingested->docs` (reads versioned_data type=`kb-ingest`), `sync!` (content-hash diff → embed only changed, delete orphans), `search-kb` (hybrid BM25+kNN, client-side RRF, cross-lingual kNN unfiltered, per-language dedup by source-ref), `get-doc` (full entry by id). |
+| `lipas.backend.help` | Help content v2 storage: per-locale versioned_data docs (`help-v2-fi/-se/-en`), get/save/draft/versions per locale, `migrate-v1->v2!`. Schema in `lipas.schema.help` (cljc). |
 | `lipas.backend.assistant` | Agent: Gemini function-calling loop, **first turn forced to call a tool** (toolConfig ANY). Tools: `search_kb`, `get_kb_document`, `lookup_type_code`, `explain_field`, `list_stale_sites`, `list_sites_missing_data`, `get_site_summary`, `check_site_permission` (**authoritative verdict from `roles/check-privilege` + user's roles with official names — never LLM-reasoned**), `escalate_to_support` (draft-only), plus **UI-action tools** `apply_search`, `show_site_on_map`, `pan_map_to_location`, `navigate_to_view` (propose-only: validated via `lipas.schema.assistant`, returned as `:actions` in the response, rendered as buttons the user clicks — nothing auto-fires). `editable-scope` from roles = *relevance default* for listing tools, not authorization (site data is public). Per-user in-memory rate limits (30 chat/h, 5 escalations/day). `chat!`/`escalate!` entrypoints, exchange logging to `assistant_logs` (incl. proposed action types). `context-schema` (closed Malli map) validates the widget's app-db snapshot. |
 | `lipas.schema.assistant` (cljc) | **Closed action vocabulary**: Malli multi-schema for the 4 action types + `views` registry (id → description, feeds the `navigate_to_view` tool enum and the frontend route mapping). Reuses canonical `lipas-id`/`city-code`/`active-type-code` schemas. The model never produces re-frame event vectors — it calls an action tool, the backend validates against this schema, the frontend translates. |
 | `lipas.backend.handler` | Routes `/actions/assistant-chat`, `/actions/assistant-escalate` (both `:require-privilege :ai-assistant/use`); help CMS routes `save-help-draft`, `get-help-versions`, `get-help-version`. |
@@ -35,9 +36,9 @@ Frontend (cljs):
 
 | File | What |
 |---|---|
-| `lipas.ui.assistant.{events,subs,views}` | Widget: Fab launcher + panel at app root (`lipas.ui.views/main-panel`), privilege-gated. Markdown answers (`?ohje=` links open help dialog in place, external links new tab), source chips, escalation confirmation card (editable summary, shows what's sent where), new-chat button. **Action buttons**: `::run-action` is the whitelist translator (action map → dispatches; unknown types inert), gated on map edit-mode (notification instead of navigating away from unsaved edits); executed buttons flip to disabled+✓. `apply-search` → navigate to map + `search/replace-filters`; `show-site` → `map/show-sports-site`; `pan-to-location` → digitransit geocode then `set-center`/`set-zoom` (12 for places, 14 for addresses); `navigate-to-view` → `view->route` map. `db->context` builds the per-message app-db snapshot (route, readable view, locale, selected site's lipas-id, edit-mode). Stateless server: full history sent per request. |
+| `lipas.ui.assistant.{events,subs,views}` | Widget: Fab launcher + panel at app root (`lipas.ui.views/main-panel`), privilege-gated. Launcher placement: on the map route it's embedded in the bottom-right map-control container (`MapLauncher` in `map/views.cljs` — the corner is crowded there); elsewhere a fixed Fab bottom-right; when the fullscreen help dialog is open the fixed Fab always shows (zIndex 1350 > modal 1300, < snackbar 1400). Markdown answers (`?ohje=` links open help dialog in place, external links new tab), source chips, escalation confirmation card (editable summary, shows what's sent where), new-chat button. **Action buttons**: `::run-action` is the whitelist translator (action map → dispatches; unknown types inert), gated on map edit-mode (notification instead of navigating away from unsaved edits); executed buttons flip to disabled+✓. `apply-search` → navigate to map + `search/replace-filters`; `show-site` → `map/show-sports-site`; `pan-to-location` → digitransit geocode then `set-center`/`set-zoom` (12 for places, 14 for addresses); `navigate-to-view` → `view->route` map. `db->context` builds the per-message app-db snapshot (route, readable view, locale, selected site's lipas-id, edit-mode). Stateless server: full history sent per request. |
 | `lipas.ui.search.events/replace-filters` | Replace whole search spec (string + filters) from clean defaults in one event → single ES query with `:fit-view` (map pans to results). Used by assistant action buttons. |
-| `lipas.ui.help.*` | Deep links: `?ohje=section/page` synced via replaceState; `::navigate-to` resolves slugs (pending-slugs if data not loaded yet); dialog moved to app root; content loads at app init (`::help/init`, dispatch-sync in `core.cljs` *before* router start). Markdown text blocks (react-markdown) + `lipas.utils/localized` fi→en→se fallback. Editor: Save draft / Publish / History dialog (load any revision into editor; publishing it = rollback). |
+| `lipas.ui.help.*` | **v2 (see "Help center v2" below)**: docs-site read view (tree sidebar + content column), per-locale trees with fi fallback banner, nav search, mobile drawer. Deep links: `?ohje=section/page` synced via replaceState; `::navigate-to` resolves slugs *and aliases* (pending-slugs if data not loaded yet); dialog at app root; content loads at app init (`::help/init`, dispatch-sync in `core.cljs` *before* router start). Markdown text blocks (react-markdown). Editor: per-locale tabs, Save draft / Publish / History per locale, slug generate-from-title (+auto-alias). |
 
 Dev tooling:
 
@@ -182,12 +183,66 @@ looks wrong or empty, just resync.
   edit-mode gate refuses with notification. Unit tests:
   `lipas.backend.assistant-test` (action schema + tool handlers).
 
+## Help center v2 (2026-07-09)
+
+The built-in help was revamped in the same branch — the CMS is the KB's
+canonical source, so the two ship together.
+
+**Data model** (`lipas.schema.help`, storage `lipas.backend.help`): each
+locale (fi/se/en) has its own independent tree of sections → pages →
+blocks with **plain-string leaves** — replaces the v1 shared structure
+with `{:fi :se :en}` maps whose untranslated slots accumulated
+placeholder junk ("New Page", "Ny sida") that leaked into the UI and the
+KB. One versioned_data document per locale (`help-v2-fi/-se/-en`) so
+languages draft/publish/roll back independently. Nodes carry stable
+`:id`, human `:slug` (generated from title via `lipas.utils/->slug`),
+`:aliases` (old slugs keep resolving — deep-link/citation stability),
+optional `:summary` (landing lists + KB body) and `:translation-of`
+(reserved for future per-page fallback).
+
+**Migration**: `(lipas.backend.help/migrate-v1->v2! db)` — one-shot; fi
+gets everything with regenerated readable slugs (old timestamp slugs →
+aliases), se/en start empty (prod se/en content was placeholder junk or
+stale-seed lies like "Excel reports" over accessibility-tool content).
+v1 `"help"` rows stay untouched as history. Run once per environment.
+
+**Read view** (`lipas.ui.help.views` rewrite, docs-site pattern): tree
+sidebar (collapsible sections, sentence-case wrapping labels; the theme
+uppercases all heading variants so content titles set
+`textTransform "none"`), max-width content column, responsive 16:9
+video embeds, PDF document cards (title bar + open-in-new + 70vh
+preview), section landing lists (theme-colored — the v1 white-gradient
+cards were unreadable in dark mode), client-side search over the nav,
+mobile drawer, locale fallback to fi with an info banner
+(`:help/only-in-finnish`). `?ohje=` resolves slugs *and aliases* and
+rewrites the URL to canonical form.
+
+**Editor** (`lipas.ui.help.manage` rewrite): locale tabs (fi/se/en);
+Save draft / Publish / History act on the active locale only; plain
+TextFields (no per-field language tabs); slug field with
+generate-from-title button that auto-adds the old slug to aliases;
+summary fields.
+
+**KB**: `kb/help-cms->docs` walks the per-locale trees — the lang tag is
+trustworthy by construction and junk-language docs are impossible. Also
+fixed `block->text` emitting bare video/pdf URLs for languages with
+blank titles (with prod data this had produced 34 junk "New Page"
+docs). Page `:summary` is prepended to the doc body. Assistant context
+gained `:help {:section :page :title}` (open help page → "kysy tästä
+aiheesta" works through the universal Fab).
+
+Tests: `lipas.backend.help-test` (migration transform, slug util,
+help-cms->docs skip rules).
+
 ## Remaining / next
 
 1. **PR + code review** (branch has ~2.5k added lines; `/code-review` worth it).
-2. Deploy: `GEMINI_API_KEY` in prod env; first `help-kb-sync` runs via
-   scheduler/publish; **run ingestion against prod DB** (87 entries live only
-   in local versioned_data); real CMS content; then flip GA
+2. Deploy: `GEMINI_API_KEY` in prod env; **run help-v2 migration against
+   prod DB** (`(lipas.backend.help/migrate-v1->v2! db)`, once, before the
+   first v2 publish); first `help-kb-sync` runs via scheduler/publish;
+   **run ingestion against prod DB** (87 entries live only in local
+   versioned_data); real CMS content authoring (summaries + hand-tuned
+   slugs where wanted, se/en translations when they exist); then flip GA
    (`:ai-assistant/use` → `roles/basic`). If `assistant_logs` already exists
    in an env, PUT `_mapping` with `actions {:type "keyword"}` (strict mapping;
    fresh indices get it automatically).

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -1,0 +1,155 @@
+# AI Assistant & Knowledge Base — Implementation Status
+
+Status: **built and working end-to-end in dev** on branch `feat/ai-assistant`
+(commits `4742860d..732378d3`, 2026-07-08). Design rationale in
+[ai-assistant-plan.md](./ai-assistant-plan.md); this doc is the
+what-actually-exists map for getting up to speed from scratch.
+
+## What it is
+
+A context-aware AI help assistant for registered LIPAS users: floating chat
+widget on every route, answers grounded in an Elasticsearch knowledge base
+(help CMS + code-derived type/field docs + ingested jyu.fi PDFs and Lipasinfo
+YouTube transcripts), cites sources as in-app `?ohje=` deep links and
+timestamped video URLs, runs read-only data-maintenance queries, and escalates
+to human support (email to lipasinfo@jyu.fi) only after explicit user
+confirmation.
+
+## File map
+
+Backend (clj):
+
+| File | What |
+|---|---|
+| `lipas.backend.llm` | Generic LLM plumbing extracted from `ptv.ai`: provider registry, `complete`/`gemini-complete` (+retry, OpenAI fallback), `embed`/`embed-one` (gemini-embedding-001, 768 dims, L2-renormalized). `ptv.ai` now wraps it with PTV-specific schema defaults. |
+| `lipas.backend.kb` | KB doc builders + sync + retrieval. `help-cms->docs`, `code-data->docs` (types incl. colloquial `:tags`, prop-types), `ingested->docs` (reads versioned_data type=`kb-ingest`), `sync!` (content-hash diff → embed only changed, delete orphans), `search-kb` (hybrid BM25+kNN, client-side RRF, cross-lingual kNN unfiltered, per-language dedup by source-ref), `get-doc` (full entry by id). |
+| `lipas.backend.assistant` | Agent: Gemini function-calling loop, **first turn forced to call a tool** (toolConfig ANY). Tools: `search_kb`, `get_kb_document`, `lookup_type_code`, `explain_field`, `list_stale_sites`, `list_sites_missing_data`, `get_site_summary`, `escalate_to_support` (draft-only). `editable-scope` from roles = *relevance default* for listing tools, not authorization (site data is public). Per-user in-memory rate limits (30 chat/h, 5 escalations/day). `chat!`/`escalate!` entrypoints, exchange logging to `assistant_logs`. `context-schema` (closed Malli map) validates the widget's app-db snapshot. |
+| `lipas.backend.handler` | Routes `/actions/assistant-chat`, `/actions/assistant-escalate` (both `:require-privilege :ai-assistant/use`); help CMS routes `save-help-draft`, `get-help-versions`, `get-help-version`. |
+| `lipas.backend.search` | `kb-mapping` (strict; finnish/swedish/english analyzer subfields, dense_vector 768 cosine), `assistant-logs-mapping`. Registered in `mappings` ⇒ auto-created at startup. |
+| `lipas.backend.config` | `:indices` gained `:kb {:kb "lipas_kb_v1"}` and `:assistant {:logs "assistant_logs"}`. |
+| `lipas.jobs.*` | Job type `help-kb-sync` (dedup+debounce) in registry, handler in dispatcher, enqueued on every help publish (`core/save-help-data`) + daily scheduler tick. |
+| `lipas.roles` | New privilege `:ai-assistant/use`. **Admin-only now** (admin holds all privileges); GA = add it to `roles/basic`. |
+
+Frontend (cljs):
+
+| File | What |
+|---|---|
+| `lipas.ui.assistant.{events,subs,views}` | Widget: Fab launcher + panel at app root (`lipas.ui.views/main-panel`), privilege-gated. Markdown answers (`?ohje=` links open help dialog in place, external links new tab), source chips, escalation confirmation card (editable summary, shows what's sent where), new-chat button. `db->context` builds the per-message app-db snapshot (route, readable view, locale, selected site's lipas-id, edit-mode). Stateless server: full history sent per request. |
+| `lipas.ui.help.*` | Deep links: `?ohje=section/page` synced via replaceState; `::navigate-to` resolves slugs (pending-slugs if data not loaded yet); dialog moved to app root; content loads at app init (`::help/init`, dispatch-sync in `core.cljs` *before* router start). Markdown text blocks (react-markdown) + `lipas.utils/localized` fi→en→se fallback. Editor: Save draft / Publish / History dialog (load any revision into editor; publishing it = rollback). |
+
+Dev tooling:
+
+| File | What |
+|---|---|
+| `dev/lipas/kb_eval.clj` | 41 golden questions, hit@3 runner, `compare-methods`. Current: bm25 78% / knn 100% / **hybrid 41/41**. Run before corpus/mapping/model changes. |
+| `dev/lipas/kb_ingest.clj` | One-off ingestion: extract (LLM → task-shaped entries) → grounding (separate verifier per source; 2/89 rejected) → type-code validation → docs saved to versioned_data `kb-ingest` → `kb/sync!`. VTT parsing with `[s=N]` markers → timestamped YouTube deep links; `gemini-video-transcript` fallback for the 9 caption-less videos. Corpus inventory (9 PDFs + all 21 Lipasinfo videos) is in the ns. |
+
+## Data flow
+
+```
+help CMS (canonical, published only) ─┐
+lipas.data.types/prop-types (derived) ─┼─> kb/sync! ──> lipas_kb_v1 (1063 docs)
+versioned_data "kb-ingest" (one-off)  ─┘   (hash-diff,      │
+                                            orphan-delete)  ▼
+widget ──/actions/assistant-chat──> assistant loop ──tools──> search-kb / sites index
+   ▲          (context snapshot)         │
+   └── answer + sources + escalation? ◄──┘        exchanges ──> assistant_logs
+```
+
+The index is a **deterministic function of Postgres + code**: `(kb/sync! db
+search)` rebuilds everything (~20 s full, ~2 s no-change). If the index ever
+looks wrong or empty, just resync.
+
+## REPL recipes
+
+```clojure
+(require '[lipas.backend.kb :as kb])
+(kb/sync! (user/db) (user/search))                     ; rebuild/repair KB
+(kb/search-kb (user/search) {:query "..." :lang "fi"}) ; test retrieval
+
+(require '[lipas.kb-eval :as kb-eval])
+(kb-eval/compare-methods (user/search))                ; retrieval eval
+
+(require '[lipas.backend.assistant :as assistant])
+(assistant/answer! {:db (user/db) :search (user/search)
+                    :user (lipas.backend.core/get-user (user/db) "admin@lipas.fi")
+                    :message "Miten lisään liikuntapaikan" :history []
+                    :context {:route ":lipas.ui.routes.map/map"
+                              :view "map view (karttanäkymä)" :locale "fi"}})
+
+;; re-run ingestion (needs <dir> with txt/*.txt + subs/*.vtt, see kb-ingest ns)
+(require '[lipas.kb-ingest :as ingest])
+(def result (ingest/ingest-all! dir))
+(ingest/report result)
+(ingest/save-ingested! (user/db) (user/search) (:docs result))
+
+;; browser e2e login (playwright: run from webapp/, config needs
+;; {"browser":{"launchOptions":{"args":["--ignore-certificate-errors"]}}})
+(require '[lipas.e2e.tools :as e2e])
+(e2e/ui-login! "admin" (:admin-password environ.core/env))
+```
+
+## Key decisions & invariants
+
+- **One KB doc = one task/question in one language** ("task-shaped"): sharp
+  embeddings, retrieved unit = answer unit, honest citations. Titles phrased
+  as users ask.
+- **Grounding discipline**: forced first tool call; snippets are truncated →
+  agent must `get_kb_document` before answering how-tos; prompt forbids
+  inventing steps/UI details; no-coverage → offer escalation, not general
+  knowledge.
+- **Context adaptation = omission only**: user is always logged in (never show
+  login steps); steps the context proves done are skipped/acknowledged; never
+  ADD anything not in sources.
+- **Escalation is two-phase**: agent drafts, UI confirmation card, separate
+  endpoint sends via the `email` job queue (user's address in body,
+  conversation id in subject).
+- **Ingestion is migration, not mirroring**: entries live in versioned_data,
+  `review-status "machine"` until a human flips them; grounding verifier
+  rejects unsupported claims at ingest time.
+- Embedding model changes = bump `llm/embedding-defaults` → sync re-embeds all
+  (hash includes `embedding-model`).
+
+## Gotchas (each cost real time)
+
+- **test-utils suffixes ALL configured ES indices via a map walk** — it used
+  to be a hardcoded list; my `:kb` entry wasn't on it and `prune-es!` in
+  `full-system-fixture` **wiped the real dev KB between tests**. Never go back
+  to a list. (Recovery: one `sync!`.)
+- REPL: `user/reset` sometimes hits a clj-reload/integrant arity bug → use
+  `(integrant.repl/halt)` + `(integrant.repl/go)`. Stale-alias errors on
+  `:reload` after refresh → `remove-ns` first, then `:reload`. Config changes
+  need `refresh-all` + restart, or components keep stale `:indices`.
+- Gemini structured output: no `additionalProperties` (use `mu/open-schema`),
+  no `$ref` (inline schemas). Function calling and responseSchema are separate
+  modes — the agent loop returns markdown + we collect sources from tool
+  results instead.
+- YouTube: 9 of 21 videos have **no captions at all** → `gemini-video-transcript`
+  (fileData fileUri) fallback. yt-dlp rate-limits; pace with sleeps.
+- `lipas-utp-pyorailyohjeistus.pdf` is corrupt at the source (bad xref);
+  excluded from ingestion until JYU provides a clean copy.
+
+## Current dev state
+
+- KB: 1063 docs (6 seeded help-cms + 969 code-data + 87 ingested + 1 log).
+  Help CMS content is **my dev seed** (2 sections / 3 pages) — real content
+  should be authored by Lipasinfo via the editor (draft → publish).
+- Eval: hybrid 41/41 hit@3. Assistant verified in-browser: grounded how-tos
+  with citations (incl. `&t=` video timestamps), context adaptation, type-code
+  disambiguation, out-of-scope refusal, stale-sites listing (Utajärvi),
+  two-turn escalation, chat logging.
+
+## Remaining / next
+
+1. **PR + code review** (branch has ~2.5k added lines; `/code-review` worth it).
+2. Deploy: `GEMINI_API_KEY` in prod env; first `help-kb-sync` runs via
+   scheduler/publish; **run ingestion against prod DB** (87 entries live only
+   in local versioned_data); real CMS content; then flip GA
+   (`:ai-assistant/use` → `roles/basic`).
+3. Kibana views over `assistant_logs` (escalation rate = failure metric,
+   top questions = content backlog).
+4. Prompt iteration from `assistant_logs` (watch for hedged invention, e.g.
+   icon locations not in sources).
+5. Parked: lipasinfo email-history harvesting (PM/DPO); Drive-hosted melonta
+   guide; se/en translations of help content; v1.5 ideas (public-data tools,
+   anchor-seeded openers, related-articles via kNN).

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -202,11 +202,16 @@ languages draft/publish/roll back independently. Nodes carry stable
 optional `:summary` (landing lists + KB body) and `:translation-of`
 (reserved for future per-page fallback).
 
-**Migration**: `(lipas.backend.help/migrate-v1->v2! db)` — one-shot; fi
+**Migration**: `lipas.backend.help/migrate-v1->v2!` — one-shot; fi
 gets everything with regenerated readable slugs (old timestamp slugs →
 aliases), se/en start empty (prod se/en content was placeholder junk or
 stale-seed lies like "Excel reports" over accessibility-tool content).
-v1 `"help"` rows stay untouched as history. Run once per environment.
+v1 `"help"` rows stay untouched as history. Wired in as a migratus
+Clojure migration (`lipas.migrations.help-v1-to-v2`,
+`resources/migrations/20260723120000-help-v1-to-v2.edn`) so it runs
+automatically with the rest of the deploy migrations instead of a manual
+REPL step; no-ops (logged, not thrown) when there's no v1 data or v2
+content already exists.
 
 **Read view** (`lipas.ui.help.views` rewrite, docs-site pattern): tree
 sidebar (collapsible sections, sentence-case wrapping labels; the theme
@@ -239,10 +244,10 @@ help-cms->docs skip rules).
 ## Remaining / next
 
 1. **PR + code review** (branch has ~2.5k added lines; `/code-review` worth it).
-2. Deploy: `GEMINI_API_KEY` in prod env; **run help-v2 migration against
-   prod DB** (`(lipas.backend.help/migrate-v1->v2! db)`, once, before the
-   first v2 publish); first `help-kb-sync` runs via scheduler/publish;
-   **run ingestion against prod DB** (87 entries live only in local
+2. Deploy: `GEMINI_API_KEY` in prod env (help-v2 migration runs
+   automatically via migratus, no manual step); first `help-kb-sync` runs
+   via scheduler/publish; **run ingestion against prod DB** (87 entries
+   live only in local
    versioned_data) and **carry the fi `ptv-integraatio` help section
    (15 pages) to prod** after Lipasinfo review — take the section from
    lipas-dev's `help-v2-fi` tree (so review edits ride along), conj onto

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -250,10 +250,12 @@ help-cms->docs skip rules).
    (summaries + hand-tuned
    slugs where wanted, se/en translations when they exist); then flip GA
    (`:ai-assistant/use` → `roles/basic`). If `assistant_logs` already exists
-   in an env, PUT `_mapping` with `actions {:type "keyword"}` (strict mapping;
-   fresh indices get it automatically).
+   in an env, PUT `_mapping` with `actions {:type "keyword"}`,
+   `tool-rounds {:type "integer"}` and `budget-exhausted? {:type "boolean"}`
+   (strict mapping; fresh indices get all of them automatically).
 3. Kibana views over `assistant_logs` (escalation rate = failure metric,
-   top questions = content backlog).
+   top questions = content backlog, tool-rounds distribution +
+   budget-exhausted? rate = max-tool-iterations tuning — currently 8).
 4. Prompt iteration from `assistant_logs` (watch for hedged invention, e.g.
    icon locations not in sources).
 5. Parked: lipasinfo email-history harvesting (PM/DPO); Drive-hosted melonta

--- a/webapp/docs/wip/ai-assistant-implementation.md
+++ b/webapp/docs/wip/ai-assistant-implementation.md
@@ -45,7 +45,7 @@ Dev tooling:
 | File | What |
 |---|---|
 | `dev/lipas/kb_eval.clj` | 41 golden questions, hit@3 runner, `compare-methods`. Current: bm25 78% / knn 100% / **hybrid 41/41**. Run before corpus/mapping/model changes. |
-| `dev/lipas/kb_ingest.clj` | One-off ingestion: extract (LLM → task-shaped entries) → grounding (separate verifier per source; 2/89 rejected) → type-code validation → docs saved to versioned_data `kb-ingest` → `kb/sync!`. VTT parsing with `[s=N]` markers → timestamped YouTube deep links; `gemini-video-transcript` fallback for the 9 caption-less videos. Corpus inventory (9 PDFs + all 21 Lipasinfo videos + 3 PTV guides, see `ptv-sources`) is in the ns. PTV sources aren't publicly hosted → per-source `:url` overrides the deep link (lipas.fi/liikuntapaikat or the DVV instruction page); `ingest-ptv!` runs just that corpus and `add-ingested!` merges into the existing snapshot (replace-by-source-ref) instead of overwriting it. |
+| `dev/lipas/kb_ingest.clj` | One-off ingestion: extract (LLM → task-shaped entries) → grounding (separate verifier per source; 2/89 rejected) → type-code validation → docs saved to versioned_data `kb-ingest` → `kb/sync!`. VTT parsing with `[s=N]` markers → timestamped YouTube deep links; `gemini-video-transcript` fallback for the 9 caption-less videos. Corpus inventory (9 PDFs + all 21 Lipasinfo videos) is in the ns. `ingest-ptv!` + `ptv-sources` (LIPAS-PTV käyttöliittymäohje, DVV toimintaohjeet deck, docs/ptv-ai-integration.md translated en→fi) were used once and the 15 entries then **migrated into the help CMS** as the fi `ptv-integraatio` section (2026-07-09) — canonical `?ohje=` deep links, removed from the kb-ingest snapshot, excluded from `ingest-all!`. `add-ingested!` merges new sources into the existing snapshot (replace-by-source-ref) instead of overwriting it. |
 
 ## Data flow
 
@@ -155,9 +155,10 @@ looks wrong or empty, just resync.
 
 ## Current dev state
 
-- KB: 1102 docs (17 help-cms + 983 code-data incl. 2 nav-structure
-  docs fi/en and 13 role docs + 102 ingested: 35 jyu + 52 youtube +
-  15 ptv-guide, 2026-07-09). Help CMS content is **my dev seed**
+- KB: 1102 docs (32 help-cms incl. the 15-page fi `ptv-integraatio`
+  section + 983 code-data incl. 2 nav-structure docs fi/en and 13 role
+  docs + 87 ingested: 35 jyu + 52 youtube, 2026-07-09). Help CMS
+  content is otherwise **my dev seed**
   (2 sections / 4 pages, incl. "Miten kopioin liikuntapaikan?") — real content
   should be authored by Lipasinfo via the editor (draft → publish).
 - Multi-intent lesson (seasonal luistelukenttä/pallokenttä case): the
@@ -241,8 +242,12 @@ help-cms->docs skip rules).
 2. Deploy: `GEMINI_API_KEY` in prod env; **run help-v2 migration against
    prod DB** (`(lipas.backend.help/migrate-v1->v2! db)`, once, before the
    first v2 publish); first `help-kb-sync` runs via scheduler/publish;
-   **run ingestion against prod DB** (102 entries live only in local
-   versioned_data); real CMS content authoring (summaries + hand-tuned
+   **run ingestion against prod DB** (87 entries live only in local
+   versioned_data) and **carry the fi `ptv-integraatio` help section
+   (15 pages) to prod** after Lipasinfo review — take the section from
+   lipas-dev's `help-v2-fi` tree (so review edits ride along), conj onto
+   prod's fi tree, `save-help-data`; real CMS content authoring
+   (summaries + hand-tuned
    slugs where wanted, se/en translations when they exist); then flip GA
    (`:ai-assistant/use` → `roles/basic`). If `assistant_logs` already exists
    in an env, PUT `_mapping` with `actions {:type "keyword"}` (strict mapping;

--- a/webapp/docs/wip/ai-assistant-plan.md
+++ b/webapp/docs/wip/ai-assistant-plan.md
@@ -1,6 +1,9 @@
 # LIPAS AI Assistant & Knowledge Base — Implementation Plan
 
-Status: agreed design, implementation started on `feat/ai-assistant` (July 2026).
+Status: agreed design; **implemented** — see
+[ai-assistant-implementation.md](./ai-assistant-implementation.md) for the
+as-built map, REPL recipes and remaining work. This doc stays as the design
+rationale.
 
 ## Goal
 

--- a/webapp/docs/wip/ai-assistant-plan.md
+++ b/webapp/docs/wip/ai-assistant-plan.md
@@ -1,0 +1,225 @@
+# LIPAS AI Assistant & Knowledge Base — Implementation Plan
+
+Status: agreed design, implementation started on `feat/ai-assistant` (July 2026).
+
+## Goal
+
+A single knowledge base (KB) consolidating all LIPAS user-assistance material,
+served to registered users through a context-aware AI assistant available in
+every view of lipas.fi. The existing help CMS remains the canonical authoring
+surface; jyu.fi and YouTube content is ingested one-off; the assistant grounds
+every answer in the KB and cites sources with deep links.
+
+## Decisions (agreed)
+
+- KB lives in Elasticsearch (8.19.9-icu — no upgrade, no plugin needed;
+  `dense_vector` + kNN are core ES).
+- Hybrid retrieval: BM25 (finnish + ICU analyzers) + kNN, merged client-side
+  with RRF (avoids license-gated `rrf` retriever).
+- Embeddings: `gemini-embedding-001` via the existing Google API key.
+  `output_dimensionality: 768` (MRL; re-normalize after truncation),
+  task types `RETRIEVAL_DOCUMENT` (ingest, with title) / `RETRIEVAL_QUERY`.
+- Registered users only, gated by a new `:ai-assistant/use` privilege
+  (rollout: `:admin` first, then basic privilege set at GA).
+- lipasinfo email-history harvesting is **scoped out** pending PM/DPO decision.
+  The pipeline is source-agnostic so it can slot in later.
+- Aggregate-statistics tools ("how many X in Y") are out — v1 tools target
+  data-maintenance workflows (stale sites, missing data).
+- Escalation to human support is a first-class tool (two-phase confirm,
+  sends email to lipasinfo@jyu.fi under the hood).
+
+## Indices
+
+Both behind aliases (`lipas-kb` → `lipas-kb-v1`); schema change = new index +
+full sync + alias flip. Explicit mappings only — never dynamic (see the legacy
+dense_vector auto-mapping incident).
+
+### `lipas-kb`
+
+One doc = one task/question-sized entry ("task-shaped", see below).
+
+| Field | Type | Notes |
+|---|---|---|
+| `title`, `body` | text | finnish analyzer + ICU folding subfields; body stores markdown |
+| `lang` | keyword | fi / se / en; single index, kNN filters on lang |
+| `embedding` | dense_vector | dims 768, cosine, index: true |
+| `source-type` | keyword | help-cms / jyu / youtube / code-data / docs |
+| `source-ref` | keyword | page slug, video id, var name, URL |
+| `deep-link` | keyword | where citations land |
+| `type-codes` | integer | when entry is type-specific |
+| `updated-at` | date | |
+| `content-hash` | keyword | sync idempotency |
+| `embedding-model` | keyword | enables batch re-embed on model change |
+| `review-status` | keyword | machine / reviewed |
+
+### `assistant-logs`
+
+One doc per exchange: hashed user id, question, answer, tool calls, cited doc
+ids, latency, token counts, feedback (thumbs), `escalated?` flag. Summary
+events also emitted to the existing analytics event-log for Kibana/Ohry.
+Escalation rate = the assistant's primary failure metric; most-escalated
+topics = KB content backlog.
+
+## Content sources
+
+1. **help-CMS (canonical, continuous sync)** — published content only.
+2. **Code-derived (`source-type: code-data`, regenerated every sync)**:
+   `lipas.data.types` (one doc per type code), `lipas.data.prop-types`
+   (field definitions), `lipas.data.activities`, status/owner/admin enums.
+   Deterministic templates, no LLM. Long instructional prose from i18n EDN
+   (analysis help, PTV wizard, map hints) — long entries only, not tooltips.
+3. **jyu.fi PDFs (one-off)** — route/point/area guides, analysis tool guides,
+   Luontoon.fi content guides, data-model docs.
+4. **YouTube (one-off)** — Lipasinfo channel (@lipasinfo7382) + Luontoon.fi
+   playlist; transcripts via Gemini video input; citations carry timestamps.
+5. ~~lipasinfo email history~~ — parked (PM/DPO). Escalation emails (below)
+   are designed to be the clean future corpus if green-lit.
+
+One-off ingestion is *migration*, not mirroring: after ingest, canonical
+ownership moves to the help-CMS; jyu.fi shrinks to a brochure. Nightly job
+flags jyu/youtube docs older than N months for review.
+
+## Task-shaped entries
+
+One KB doc = one user intent, self-contained (no unresolved references),
+100–400 words of markdown: task-phrased title, short answer, prerequisites
+(role needed), numbered steps, pitfalls, related links + metadata. Rationale:
+one intent = one sharp embedding (retrieval precision); retrieved unit =
+answer unit (less hallucinated glue); task-phrased titles close the
+colloquial-vs-official vocabulary gap; citations land somewhere honest;
+maintenance/dedup/review operate at intent granularity.
+
+## KB integrity (multi-pass)
+
+Authored/ingested entries pass through:
+
+1. **Extract** (LLM): source → task-shaped entries.
+2. **Grounding** (separate LLM call): every claim supported by source, else flag.
+3. **Dedup**: embedding cosine > ~0.9 → LLM judge merges.
+4. **Consistency** (mechanical): referenced type codes exist, deep links
+   resolve, lang present, embedding-model current.
+5. **Review status**: enters as `machine`; Lipasinfo flips to `reviewed` in a
+   lightweight admin list. Agent prefers reviewed docs and cites vintage.
+6. **Golden eval set**: ~40 hand-authored questions (emails are out of scope)
+   stored in repo; retrieval eval (top-3 hit rate: bm25 / knn / hybrid) +
+   end-to-end answer eval before corpus or prompt changes ship.
+
+Code-derived docs skip 1–3 (deterministic).
+
+## Agent
+
+Server-side Gemini function-calling loop (generic LLM plumbing extracted from
+`lipas.backend.ptv.ai` into `lipas.backend.llm`; provider registry, retry,
+OpenAI fallback transfer as-is). Endpoint `/actions/assistant-chat` behind
+`:ai-assistant/use` middleware. Structured output (`response-schema`, already
+supported by the client): `{answer-md, citations [{doc-id, title, deep-link}],
+confidence}`. `search_kb` is force-run on every user turn before the model may
+answer; empty retrieval → honest "en löytänyt ohjetta" + escalation offer.
+
+### Tools (v1, read-only except escalation)
+
+| Tool | Purpose |
+|---|---|
+| `search_kb` | hybrid retrieval → snippets + deep links |
+| `get_kb_document` | full entry by id |
+| `lookup_type_code` | free text or code → full type spec |
+| `explain_field` | prop/field → definition, requirements |
+| `list_stale_sites` | sites not updated since date, city/type filtered |
+| `list_sites_missing_data` | sites lacking given fields (`must_not exists`) |
+| `get_site_summary` | site doc summary by lipas-id (no author PII) |
+| `escalate_to_support` | two-phase support handoff (below) |
+
+The three site tools run through the same role scoping as the UI (allowed
+city-codes/type-codes derived from JWT roles, server-side). No write tools;
+"fix it" answers end in a deep link to the edit view.
+
+### Escalation to support
+
+Agent may *propose* escalation, never send unilaterally:
+
+1. Agent calls `escalate_to_support` with a drafted problem summary.
+2. Widget renders a confirmation card: editable summary + notice
+   ("Lähetän kysymyksesi LIPAS-tukeen, saat vastauksen sähköpostiisi …") +
+   Send/Cancel.
+3. On confirm, a separate endpoint emails lipasinfo@jyu.fi via the existing
+   emailer: subject `[LIPAS-avustaja] <summary>` + conversation id, edited
+   summary, trimmed transcript (last N turns), context snapshot (view,
+   selected site as lipas.fi link, org, role scope), `Reply-To:` user's
+   registered email.
+
+Tighter rate cap than chat (few/user/day). Logged with `escalated?` flag.
+
+## Access, limits, privacy
+
+- `:ai-assistant/use` in `lipas.roles/privileges`; frontend launcher behind
+  `check-privilege` (same pattern as `HelpManageButton`); 6h JWT bake accepted.
+- Per-user sliding-window message cap + daily token budget in the endpoint.
+- Context contains only the user's own scope + currently-viewed public site;
+  logs store trimmed context; user ids hashed in `assistant-logs`.
+- Gemini key lives server-side only.
+
+## Grounding & deep links
+
+- Help pages become addressable via URL-synced query param (`?ohje=osio/sivu`)
+  so links compose with any view (dialog opens over the map, no navigation).
+  Requires: dialog-state ↔ URL sync + help data loaded at app init (today it
+  loads only via the map route controller).
+- Citation chips ("Lähteet") under each answer open the help dialog at the
+  page, the YouTube video at timestamp, or the type-code explorer entry.
+
+## KB freshness
+
+1. **CMS hook**: `core/save-help-data` enqueues `sync-help-kb` on the jobs
+   queue after successful publish → deterministic transform, content-hash
+   diff, embed changed only, delete-by-query orphans.
+2. **Code-derived regeneration**: same job, at deploy/startup + nightly.
+3. **Nightly integrity job**: deep links resolve, re-embed stale
+   embedding-model, flag aged one-off docs.
+4. **Migration**: alias flip (`lipas-kb-v2` + full sync + move alias).
+
+Prerequisite: CMS draft/publish split (only `active` syncs) — also version
+history UI + rollback (storage is already append-only).
+
+## app-db context injection
+
+**Always**: current route + params, locale, user's editing scope (role names,
+allowed city-codes/type-codes/orgs). **Per-view**: map (selected site
+{lipas-id, name, type-code, status, last event-date}, edit mode, active tool,
+new-site type), search (filters + result count), analysis (tool + params),
+PTV (org + sync summary), help dialog (open section/page).
+
+Mechanism: each feature ns exposes an `::assistant-context` re-frame sub
+returning a compact map; a route → subs registry; root `::assistant/context`
+composes static + active-view parts. Widget snapshots the sub **per message**
+(context tracks navigation mid-chat), sends as `context` field, server
+validates against a closed Malli schema, size-caps (~2 KB), injects into the
+system prompt as a structured block.
+
+## CMS prerequisites (phase 1)
+
+- Markdown rendering for `:text` blocks; language fallback (se/en → fi)
+  instead of blank.
+- Draft/publish via `versioned_data.status`; history list + rollback.
+- Help deep links + app-init data load.
+- Known bugfixes: `::save-success` resets `[:ptv :save-in-progress]`
+  (manage.cljs:329); `::get-help-data` sets `[:help :save-in-progress]` and
+  never clears it.
+
+## Build order
+
+1. Prereqs: help deep links + init load; CMS markdown + draft/publish;
+   `lipas.backend.llm` extraction + `embed` fn.
+2. KB: index mappings, code-data generator, CMS sync job, hybrid `search_kb`
+   — retrieval eval against golden set **before any agent exists**.
+3. Ingestion: jyu PDFs + YouTube through the multi-pass pipeline, human review.
+4. Agent + widget: tool loop, gating, citations, context sub, logs/limits.
+   Admin dogfood → all registered users.
+
+## Open items (need humans)
+
+- YouTube corpus boundary confirmation + the Google Drive-hosted
+  *Melonnan sisällönsyötön ohje*.
+- Who at Lipasinfo owns `review-status` triage.
+- PM/DPO decision on email-history harvesting (design accommodates it).
+- Later (v1.5+): public-data search tools over site descriptions,
+  anchor-seeded chat openers, related-articles via kNN.

--- a/webapp/docs/wip/reitti-ohjeet-konsolidointi.md
+++ b/webapp/docs/wip/reitti-ohjeet-konsolidointi.md
@@ -1,0 +1,144 @@
+# Reitti-ohjeet: konsolidoitu luonnos (video + PDF → ohjeet-artikkelit)
+
+Experiment: extracted with Gemini 3.1 Pro native YouTube video understanding
+(2026-07-16), consolidated from three Lipasinfo videos and the 23.11.2023
+jyu.fi route guide PDF, then grounded against the current codebase.
+
+Sources:
+- Video [XcZrIepjYe0](https://www.youtube.com/watch?v=XcZrIepjYe0) — Reittimäisen liikuntapaikan lisääminen (2024-02-22, 7:39)
+- Video [DUa_aMbg9k0](https://www.youtube.com/watch?v=DUa_aMbg9k0) — Reittigeometrian tuonti tiedostosta (2024-02-22, 3:28)
+- Video [M3tmvCVyoD4](https://www.youtube.com/watch?v=M3tmvCVyoD4) — Reitin katkaisu ja reittijäljen yksinkertaistaminen (2024-03-18, 7:44)
+- PDF: Reittimäisen liikuntapaikan lisääminen, muokkaaminen ja poistaminen (JYU, 23.11.2023)
+
+Grounding notes (video/PDF vs. current code):
+- "Lisää reittiosa", "Poista reittiosa", "Katkaise reittiosa" — unchanged (`i18n/fi/map.edn`)
+- Simplify dialog is now **"Yksinkertaista geometrioita"** (video showed "Yksinkertaista reittiosaa"); slider 0–10, step 0.5 (`map/views.cljs`)
+- Self-intersection warning text is now: *"Muuta reitin kulkua niin, että reittiosa ei risteä itsensä kanssa. Voit tarvittaessa katkaista reitin useampaan osaan."* (video/PDF had older wording mentioning Retkikartta)
+- Alt+klik vertex deletion — still current (OL `Modify` defaults, `map/editing.cljs:132`)
+- **New since videos:** file imports are auto-simplified by default (`map/events.cljs` `process-imports`, turf-simplify level 3)
+- Import formats: `.zip` (Shapefile), `.kml`, `.gpx`, `.json`, `.geojson` (`map/import.cljs:20`)
+- "Laske reitin pituus automaattisesti" calculator — still current (`sports_sites/views.cljs:404`)
+- Delete reasons: Poistettu käytöstä pysyvästi / väliaikaisesti / Väärä tieto (`i18n/fi/status.edn`)
+
+Proposed CMS structure: split the current single page
+(`reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen`, today only PDF+video
+embeds, zero text → nearly invisible to the assistant KB) into four task-sized
+pages. One page = one KB doc, so task-sized pages retrieve better.
+
+---
+
+## Sivu 1: Reittimäisen liikuntapaikan lisääminen (slug: reittimaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen)
+
+**Summary:** Miten uusi reittimäinen liikuntapaikka (esim. kuntorata, latu, ulkoilureitti) lisätään LIPAS-järjestelmään piirtämällä reitti kartalle, ja mitä tietoja reitistä tallennetaan.
+
+### Yleistä reittien tallentamisesta
+
+LIPAS-tietokantaan kerätään tiedot Suomen liikuntaan ja ulkoiluun varustetuista reiteistä. Tallennettavien reittien tulee olla hoidettuja, niiden käyttöön tulee olla mahdolliset maanomistajien luvat tai sopimukset, ja reitillä on oltava omistaja sekä ylläpitäjä. Lisäksi reitin tulee olla opastettu maastomerkeillä tai sen käyttö on muilla tavoin ohjeistettua. Pelkästään jokaisenoikeuksin käytettäviä polkuja ei tallenneta LIPAS-tietokantaan.
+
+Erityinen painopiste on kuntien ja virkistysalueyhdistysten ylläpitämissä liikunta- ja ulkoilureiteissä. Metsähallituksen ylläpitämiä reittejä ei erityisesti kerätä, sillä Metsähallitus huolehtii oman reittiverkostonsa tiedoista omissa järjestelmissään.
+
+Reitit on luokiteltu useisiin liikuntapaikkatyyppeihin (esim. 4401 Kuntorata, 4402 Latu, 4403 Kävelyreitti/ulkoilureitti, 4405 Retkeilyreitti, 4411 Maastopyöräilyreitti). Yksi fyysinen reitti voidaan kuvata useamman tyypin avulla: tyypillisesti sama ura on talvella latu ja kesällä kuntorata. Tyyppiluokittelun kuvaukset löydät Ohjeet-osion Tyyppiluokkaselaimesta.
+
+### Reitin piirtäminen kartalle
+
+**Esitiedot:** Kirjautuminen (lipas.fi/kirjaudu) ja muokkausoikeudet kyseisen kunnan liikuntapaikkoihin. Jos sinulla ei ole tunnusta, rekisteröidy ja määritä mihin tietoihin haluat muokkausoikeudet — ylläpitäjät vahvistavat tunnuksesi.
+
+1. Napsauta karttanäkymän vasemman alakulman **+**-painiketta (Uusi liikuntapaikka).
+2. Valitse **Liikuntapaikkatyyppi** — voit hakea tyyppiä kirjoittamalla tai valita listasta. Tyypin lyhyt kuvaus näytetään valinnan yhteydessä. Napsauta **OK**.
+3. Kohdista kartta reitin alueelle siirtämällä, zoomaamalla tai osoitehaulla. Jos näet tekstin *"Kartta täytyy zoomata lähemmäs"*, lähennä karttaa kunnes **Lisää kartalle** -painike aktivoituu.
+4. Napsauta **Lisää kartalle** ja piirrä reitti: jokainen hiiren napsautus lisää yhden reittipisteen, ja pisteiden välille piirtyy viiva. Päätä reittiosa **kaksoisnapsauttamalla**.
+5. Jos reitti koostuu useista erillisistä osista, valitse **Lisää reittiosa** ja piirrä seuraava osa samalla tavalla.
+6. Napsauta **Valmis**.
+7. Täytä reitin tiedot ja napsauta **Tallenna**. Onnistuneesta tallennuksesta näytetään ilmoitus *"Tallennus onnistui"*.
+
+**Vinkki:** Piirrä reitti myötäilemään maastossa olevaa uraa mahdollisimman tarkasti. Voit hyödyntää taustakartan lisäksi muita karttatasoja (esim. ilmakuvaa).
+
+**Huom:** Reittiviiva ei saisi leikata itseään. Jos reitti risteää itsensä kanssa, ongelmakohta osoitetaan punaisella merkillä: *"Muuta reitin kulkua niin, että reittiosa ei risteä itsensä kanssa. Voit tarvittaessa katkaista reitin useampaan osaan."* Katso ohje reittigeometrian korjaamisesta.
+
+### Reitin tiedot
+
+**Perustiedot:** Liikuntapaikan tilan oletusvalinta on *Toiminnassa*; muut vaihtoehdot ovat *Suunniteltu* ja *Poistettu käytöstä väliaikaisesti*. Pakolliset kentät on merkitty tähdellä, ja ne on täytettävä ennen tallennusta. Katuosoite on pakollinen — jos reitillä ei ole selkeää osoitetta, käytä lähintä mahdollista osoitetta, esimerkiksi lähtöpisteen tai parkkipaikan osoitetta. Reitin nimen lisäksi voit antaa erillisen markkinointinimen; jos erityistä markkinointinimeä ei ole, täytä vain tavallinen nimikenttä. Yhteystiedot-kenttään voit määrittää, kuka vastaa liikuntapaikan asiakaspalvelusta tai palautteista.
+
+**Lisätiedot:** Lisätiedot-välilehden kentät vaihtuvat liikuntapaikkatyypin mukaan. Pintamateriaali ja reitin leveys koskevat oletuksena koko reittiä — jos reittiosilla on eri ominaisuudet, määritä tiedot kullekin reittiosalle erikseen. Reitin pituuden voit syöttää käsin tai antaa järjestelmän laskea sen automaattisesti (laskin-kuvake, *"Laske reitin pituus automaattisesti"*).
+
+---
+
+## Sivu 2: Reittigeometrian tuonti tiedostosta (slug-ehdotus: reittigeometrian-tuonti-tiedostosta)
+
+**Summary:** Reitin geometrian voi piirtämisen sijaan tuoda valmiista tiedostosta (GPX, GeoJSON, KML, Shapefile), esimerkiksi GPS-laitteen tai urheilusovelluksen tallentamasta jäljestä.
+
+**Esitiedot:** Kirjautuminen ja muokkausoikeudet sekä reittitiedosto tuetussa muodossa: **GPX**, **GeoJSON** (.json/.geojson), **KML** tai **Shapefile** (zip-pakattuna). GPX-tiedoston koordinaatiston on oltava WGS84 (GPS-laitteiden ja sovellusten vakiomuoto).
+
+1. Kohdista kartta reitin alueelle esimerkiksi **Hae kartan alueelta** -haulla.
+2. Napsauta vasemman alakulman **+**-painiketta, valitse liikuntapaikkatyyppi ja napsauta **OK**.
+3. Valitse **Tuo tiedostosta** -välilehti (Piirrä-välilehden vieressä). Jos näet varoituksen *"Kartta täytyy zoomata lähemmäs"*, lähennä karttaa kunnes se poistuu.
+4. Napsauta **Tuo geometriat tiedostosta** -painiketta. *"Tuo geometriat"* -ikkuna aukeaa.
+5. Valitse tiedosto koneeltasi (Valitse tiedosto / Choose File).
+6. Ikkunaan listautuvat tiedostosta tunnistetut reittiosat. Valitse tuotavat osat valintaruuduista ja napsauta **Tuo valitut**. Reitti piirtyy kartalle.
+7. Tarkista, että geometria näyttää oikealta, ja napsauta **Valmis**. Täytä sitten reitin tiedot ja tallenna.
+
+**Vinkit:**
+- Jos tiedostossa on useita erillisiä reittiosia, ne kaikki listautuvat tuonti-ikkunaan ja voit valita niistä haluamasi.
+- Tuonti-ikkunassa voi näkyä ylimääräisiä tai oudosti nimettyjä rivejä tiedoston merkistökoodauksen takia — valitse vain selkeästi nimetyt reittiosat.
+- Järjestelmä yksinkertaistaa tuotua reittijälkeä automaattisesti kevyesti, sillä esimerkiksi GPS-jäljet sisältävät usein tarpeettoman tiheästi pisteitä. Jos jälki on silti liian tiheä, käytä Yksinkertaista-työkalua (katso ohje reittigeometrian korjaamisesta).
+- Voit tuoda geometrian myös olemassa olevaan reittiin: avaa reitti muokkaustilaan ja valitse työkaluvalikosta *"Tuo geometriat tiedostosta"*.
+
+---
+
+## Sivu 3: Reittigeometrian korjaaminen ja yksinkertaistaminen (slug-ehdotus: reittigeometrian-korjaaminen-ja-yksinkertaistaminen)
+
+**Summary:** Miten reittiviivan virheet (itsensä kanssa risteävä reitti, päällekkäiset pisteet) korjataan ja miten liian tiheä reittijälki yksinkertaistetaan.
+
+**Esitiedot:** Reitti on valittuna ja muokkaustila on päällä (kynäkuvake **Muokkaa**). Muokkaustilassa reittiviivan pisteet tulevat näkyviin.
+
+### Reittipisteiden siirtäminen, lisääminen ja poistaminen
+
+- **Siirrä** reittipistettä tarttumalla siihen hiirellä ja raahaamalla se uuteen kohtaan.
+- **Lisää** uusi piste napsauttamalla reittiviivaa kohdasta, johon haluat pisteen.
+- **Poista** piste pitämällä **Alt-näppäin** pohjassa ja napsauttamalla pistettä.
+
+### Itsensä kanssa risteävän reitin korjaaminen
+
+Jos reittiviiva leikkaa itsensä, ongelmakohdassa näytetään punainen huomiomerkki: *"Muuta reitin kulkua niin, että reittiosa ei risteä itsensä kanssa. Voit tarvittaessa katkaista reitin useampaan osaan."* LIPAS sallii tallentamisen, mutta risteävä reitti voi estää tietojen hyödyntämisen muissa palveluissa.
+
+1. Valitse työkaluvalikosta **Katkaise reittiosa** (saksikuvake).
+2. Napsauta reittiviivaa risteyskohdassa. Katkaisu jakaa reitin kahdeksi reittiosaksi, jolloin virhemerkki poistuu.
+3. Varmista katkaisu viemällä hiiri viivan päälle: erillinen reittiosa korostuu omana viivanaan.
+
+Jos ongelmakohdassa on tiheä sumppu päällekkäisiä pisteitä (esim. GPS-jäljen "sykerö"), älä katkaise sokkona: poista ensin turhat päällekkäiset pisteet **Alt + napsautus** -toiminnolla yksi kerrallaan, kunnes reitin kulku selkeytyy, ja katkaise vasta sitten tarvittaessa.
+
+### Reittijäljen yksinkertaistaminen
+
+Tuodussa GPS-jäljessä on usein pisteitä tarpeettoman tiheästi, mikä tekee reitistä raskaan käsitellä.
+
+1. Valitse työkaluvalikosta **Yksinkertaista**. Kartan alareunaan avautuu *"Yksinkertaista geometrioita"* -säädin.
+2. Vedä liukusäädintä (asteikko 0–10) oikealle: järjestelmä vähentää reittipisteitä ja näyttää tuloksen kartalla reaaliajassa.
+3. Zoomaa lähemmäs ja tarkista, että yksinkertaistettu viiva seuraa yhä maastossa kulkevaa uraa. Jos viiva oikoo liikaa, pienennä säätöä tai korjaa yksittäisiä pisteitä raahaamalla.
+4. Hyväksy napsauttamalla **OK**, tai hylkää napsauttamalla **Peruuta**.
+5. Voit perua yksinkertaistamisen **Kumoa**-painikkeella (nuolikuvake työkaluvalikossa).
+
+**Varoitus:** Yksinkertaistaminen on kompromissi tarkkuuden ja käsiteltävyyden välillä — tarkista tulos aina kartalta. Jos hyväksyt maksimiyksinkertaistuksen, työkalu ei enää vähennä pisteitä samasta osasta uudelleen; loput pisteet on poistettava käsin (Alt + napsautus).
+
+### Reittiosan poistaminen
+
+Kokonaisen reittiosan voit poistaa valitsemalla työkaluvalikosta **Poista reittiosa** (roskakorikuvake) ja napsauttamalla poistettavaa osaa.
+
+Muista lopuksi tallentaa muutokset (**Tallenna**).
+
+---
+
+## Sivu 4: Reittimäisen liikuntapaikan poistaminen (slug-ehdotus: reittimaisen-liikuntapaikan-poistaminen)
+
+**Summary:** Miten reitti poistetaan LIPAS-järjestelmästä ja mitä eri poistosyyt tarkoittavat.
+
+**Esitiedot:** Poistettava reitti on valittuna kartalta ja sinulla on muokkausoikeudet siihen.
+
+1. Napsauta työkalurivin **roskakorikuvaketta** (Poista liikuntapaikka).
+2. Valitse aukeavassa ikkunassa **Poiston syy**:
+   - *Poistettu käytöstä pysyvästi* — reitti ei ole enää käytössä. Kohde arkistoituu, mutta se löytyy edelleen liikuntapaikkahaulla.
+   - *Poistettu käytöstä väliaikaisesti* — reitti on tilapäisesti pois käytöstä. Kohde arkistoituu vastaavasti.
+   - *Väärä tieto* — kohde on virheellinen (esim. kahteen kertaan tallennettu). Reitti poistetaan lopullisesti, eikä se näy enää hauissa eikä kartalla.
+3. Valitse tarvittaessa **Vuosi**, jolloin poisto tapahtui.
+4. Vahvista napsauttamalla **Poista**. Onnistumisesta näytetään ilmoitus.
+
+**Vinkki:** Jos reitti on pois käytöstä vain määräajan (esim. reittimuutos tai kunnostus), käytä tilaa *Poistettu käytöstä väliaikaisesti* — näin reitin historia ja tiedot säilyvät.

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -37,6 +37,7 @@
         "rc-slider": "^11.1.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
         "react-use": "^17.6.0",
         "react-window": "^2.2.7",
         "recharts": "^3.0.0",
@@ -1111,16 +1112,64 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
@@ -1160,11 +1209,23 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
@@ -1220,6 +1281,16 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/base64-js": {
@@ -1357,6 +1428,56 @@
         "node": ">=6"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -1370,6 +1491,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-stream": {
@@ -1641,6 +1772,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1657,6 +1801,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-helpers": {
@@ -1763,6 +1929,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -1778,6 +1954,12 @@
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1983,6 +2165,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -2006,6 +2228,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
@@ -2072,6 +2304,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/inline-style-prefixer": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
@@ -2088,6 +2326,30 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-arguments": {
@@ -2141,6 +2403,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -2159,6 +2431,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -2345,6 +2639,16 @@
       "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2367,6 +2671,159 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdi-material-ui": {
       "version": "7.9.4",
       "resolved": "https://registry.npmjs.org/mdi-material-ui/-/mdi-material-ui-7.9.4.tgz",
@@ -2387,6 +2844,448 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
       "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/minimist": {
@@ -2517,6 +3416,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-headers": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
@@ -2636,6 +3560,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -2739,6 +3673,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -2898,6 +3859,39 @@
       "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
       "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
       "license": "MIT"
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -3117,6 +4111,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -3180,6 +4184,38 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -3279,6 +4315,26 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-easing": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
@@ -3296,6 +4352,93 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unzipit": {
       "version": "1.4.3",
@@ -3343,6 +4486,34 @@
       "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
       "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -3500,6 +4671,16 @@
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
       "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
       "license": "MIT AND BSD-3-Clause"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -44,6 +44,7 @@
     "rc-slider": "^11.1.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "react-use": "^17.6.0",
     "react-window": "^2.2.7",
     "recharts": "^3.0.0",

--- a/webapp/resources/migrations/20260723120000-help-v1-to-v2.edn
+++ b/webapp/resources/migrations/20260723120000-help-v1-to-v2.edn
@@ -1,0 +1,4 @@
+{:ns lipas.migrations.help-v1-to-v2
+ :up-fn migrate-up
+ :down-fn migrate-down
+ :transaction? true}

--- a/webapp/resources/sql/versioned_data.sql
+++ b/webapp/resources/sql/versioned_data.sql
@@ -24,3 +24,21 @@ FROM public.versioned_data
 WHERE status = :status AND type = :type
 ORDER BY event_date DESC
 LIMIT 1
+
+-- :name list-by-type
+-- :command :query
+-- :result :many
+-- :doc Lists version metadata (without body) for given type, newest first
+SELECT id, event_date, status, type
+FROM public.versioned_data
+WHERE type = :type
+ORDER BY event_date DESC
+LIMIT :limit
+
+-- :name get-by-id
+-- :command :query
+-- :result :one
+-- :doc Returns a single version by id
+SELECT *
+FROM public.versioned_data
+WHERE id = :id

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -48,7 +48,12 @@
      [:status {:optional true} [:string {:max 50}]]]]
    [:edit-mode? {:optional true} :boolean]
    [:active-tool {:optional true} [:string {:max 100}]]
-   [:search-filters {:optional true} [:string {:max 500}]]])
+   [:search-filters {:optional true} [:string {:max 500}]]
+   [:help {:optional true} ; open help-center page ("about this topic" questions)
+    [:map {:closed true}
+     [:section {:optional true} [:string {:max 200}]]
+     [:page {:optional true} [:string {:max 200}]]
+     [:title {:optional true} [:string {:max 300}]]]]])
 
 (def max-tool-iterations 6)
 (def max-history-messages 12)

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -526,6 +526,11 @@ USER CONTEXT:
 
 (def max-actions-per-answer 3)
 
+(def ^:private action-tool-names
+  "Propose-only tools: calling one produces a button, not information.
+   A turn that pairs answer text with only these calls is a final answer."
+  #{"apply_search" "show_site_on_map" "pan_map_to_location" "navigate_to_view"})
+
 (defn- collect-actions
   "Validated UI actions proposed via the action tools this turn."
   [actions results]
@@ -563,19 +568,25 @@ USER CONTEXT:
            ;; First turn must ground itself in a tool call.
            mode "ANY"
            sources []
-           actions []]
+           actions []
+           ;; Last non-blank text seen alongside tool calls. The model often
+           ;; emits its final answer and an action-tool call in the SAME
+           ;; turn; the follow-up turn then comes back empty. This keeps the
+           ;; real answer from degrading to a canned fallback.
+           pending-text ""]
       (let [resp (gemini-chat system contents mode)
             parts (or (-> resp :candidates first :content :parts) [])
             fcalls (keep :functionCall parts)
-            text (->> parts (keep :text) (str/join))]
+            text (->> parts (keep :text) (str/join))
+            best-text (if (str/blank? text) pending-text text)]
         (cond
           ;; Escalation proposed: stop, let the user confirm in the UI.
           (some #(= "escalate_to_support" (:name %)) fcalls)
           (let [fc (first (filter #(= "escalate_to_support" (:name %)) fcalls))
                 summary (-> fc :args :summary)]
-            {:answer-md (if (str/blank? text)
+            {:answer-md (if (str/blank? best-text)
                           "Voin lähettää kysymyksesi LIPAS-tuelle. Tarkista ja täydennä alla oleva tiivistelmä ja paina **Lähetä tukipyyntö** — saat vastauksen sähköpostiisi."
-                          (sanitize-answer-links text sources))
+                          (sanitize-answer-links best-text sources))
              :sources (vec (distinct sources))
              :actions (->> actions distinct (take max-actions-per-answer) vec)
              ;; A blank draft renders a confusing empty card — fall back to
@@ -586,24 +597,36 @@ USER CONTEXT:
           (let [results (mapv (fn [fc] (run-tool ctx (:name fc) (:args fc))) fcalls)
                 sources' (reduce (fn [acc [fc r]] (collect-sources acc (:name fc) r))
                                  sources
-                                 (map vector fcalls results))]
-            (recur (into contents
-                         [{:role "model" :parts (vec parts)}
-                          {:role "user"
-                           :parts (mapv (fn [fc r]
-                                          {:functionResponse
-                                           {:name (:name fc)
-                                            :response {:result r}}})
-                                        fcalls results)}])
-                   (inc iter)
-                   "AUTO"
-                   sources'
-                   (collect-actions actions results)))
+                                 (map vector fcalls results))
+                actions' (collect-actions actions results)]
+            (if (and (not (str/blank? text))
+                     (every? (comp action-tool-names :name) fcalls)
+                     (every? :client-action results))
+              ;; The model wrote its answer and proposed buttons in one
+              ;; turn. Every action validated — asking again only yields an
+              ;; empty follow-up, so this text IS the answer.
+              {:answer-md (sanitize-answer-links text sources')
+               :sources (vec (distinct sources'))
+               :actions (->> actions' distinct (take max-actions-per-answer) vec)
+               :escalation nil}
+              (recur (into contents
+                           [{:role "model" :parts (vec parts)}
+                            {:role "user"
+                             :parts (mapv (fn [fc r]
+                                            {:functionResponse
+                                             {:name (:name fc)
+                                              :response {:result r}}})
+                                          fcalls results)}])
+                     (inc iter)
+                     "AUTO"
+                     sources'
+                     actions'
+                     best-text)))
 
           :else
           (let [actions' (->> actions distinct (take max-actions-per-answer) vec)]
             {:answer-md (cond
-                          (not (str/blank? text)) (sanitize-answer-links text sources)
+                          (not (str/blank? best-text)) (sanitize-answer-links best-text sources)
                           ;; The model sometimes treats a proposed button as
                           ;; the whole answer and returns no text — an apology
                           ;; would contradict the working button below it.

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -18,6 +18,7 @@
             [clj-http.client :as http]
             [clojure.java.io :as io]
             [clojure.string :as str]
+            [lipas.backend.gis :as gis]
             [lipas.backend.kb :as kb]
             [lipas.backend.search :as search]
             [lipas.backend.llm :as llm]
@@ -48,6 +49,22 @@
      [:status {:optional true} [:string {:max 50}]]]]
    [:edit-mode? {:optional true} :boolean]
    [:active-tool {:optional true} [:string {:max 100}]]
+   [:edit {:optional true} ; live map-editor state (drawing/editing geometry)
+    [:map {:closed true}
+     [:new-site? {:optional true} :boolean]
+     [:sub-mode {:optional true} [:string {:max 30}]]
+     [:geometry-type {:optional true} [:string {:max 20}]]
+     [:segments {:optional true} :int]
+     [:vertices {:optional true} :int]
+     [:length-km {:optional true} number?]
+     [:self-intersections {:optional true} :int]
+     [:problem-locations {:optional true}
+      [:vector {:max 5}
+       [:map {:closed true}
+        [:lon number?]
+        [:lat number?]]]]
+     [:invalid-fields {:optional true}
+      [:vector {:max 10} [:string {:max 60}]]]]]
    [:search-filters {:optional true} [:string {:max 500}]]
    [:help {:optional true} ; open help-center page ("about this topic" questions)
     [:map {:closed true}
@@ -61,7 +78,12 @@
      [:tab {:optional true} [:string {:max 100}]]
      [:wizard-step {:optional true} [:string {:max 100}]]]]])
 
-(def max-tool-iterations 6)
+;; Cap on tool-calling ROUNDS (one round can carry several parallel
+;; calls). A complex route-editing answer legitimately uses 5-6 rounds
+;; (search → geometry check → doc fetches → work-saving search →
+;; buttons); 8 leaves slack without inviting rephrasing loops. Tune from
+;; assistant_logs :tool-rounds / :budget-exhausted?.
+(def max-tool-iterations 8)
 (def max-history-messages 12)
 (def chat-rate-limit {:window-ms (* 60 60 1000) :max 30})
 (def escalation-rate-limit {:window-ms (* 24 60 60 1000) :max 5})
@@ -232,6 +254,23 @@
                               :view {:type "string"
                                      :enum (vec (sort (keys assistant-schema/views)))}}
                  :required ["label" "view"]}}
+
+   {:name "check_route_geometry"
+    :description "Analyze the geometry quality of a SAVED route-type sports site (latu, kuntorata, ulkoilureitti, pyöräilyreitti…): self-intersections, duplicate vertices, gaps between route segments, vertex density and total length, with problem locations as lon/lat. Use when the user reports red warning markers, asks why a route looks wrong or whether it is OK, or asks about simplification. Offer zoom_map_to_coordinates buttons for the returned problem locations. Only works on saved sites — an UNSAVED draft is summarized in USER CONTEXT under :edit instead."
+    :parameters {:type "object"
+                 :properties {:lipas-id {:type "integer"}}
+                 :required ["lipas-id"]}}
+
+   {:name "zoom_map_to_coordinates"
+    :description "Propose a UI action: zoom the map to exact WGS84 coordinates (button; the user clicks to run it). Use ONLY with coordinates from tool results or USER CONTEXT — e.g. geometry problem locations — never coordinates you inferred yourself. Unlike other action buttons this one stays usable while the user is editing."
+    :parameters {:type "object"
+                 :properties {:label {:type "string"
+                                      :description "Button text in the user's language, e.g. 'Näytä ongelmakohta 1'"}
+                              :lon {:type "number"}
+                              :lat {:type "number"}
+                              :zoom {:type "integer"
+                                     :description "Map zoom level 12–18, default 16"}}
+                 :required ["label" "lon" "lat"]}}
 
    {:name "escalate_to_support"
     :description "When you cannot answer from the knowledge base, or the user asks for something requiring human support (account issues, data corrections you cannot guide, bugs, wanting to talk to a human): draft a support request. The user confirms before anything is sent. ALWAYS write answer text alongside this call: tell the user an editable draft appears below your message and that pressing 'Lähetä tukipyyntö' sends it. If the user asked for a human without describing their issue, ask them to add what it concerns into the draft before sending."
@@ -440,6 +479,36 @@
                       :label (str (:label args))
                       :view (str (:view args))})
 
+    "check_route_geometry"
+    (let [idx (get-in search [:indices :sports-site :search])
+          src (try (-> (search/fetch-document (:client search) idx (:lipas-id args))
+                       :body :_source)
+                   (catch Exception _ nil))
+          fcoll (-> src :location :geometries)
+          geom-type (-> fcoll :features first :geometry :type)]
+      (cond
+        (nil? src)
+        {:error "Site not found"}
+
+        (not= "LineString" geom-type)
+        {:error (str "Site " (:lipas-id args) " is not a route (geometry: "
+                     (or geom-type "missing")
+                     ") — this tool only analyzes route geometries.")}
+
+        :else
+        (assoc (gis/route-geometry-report fcoll)
+               :lipas-id (:lipas-id args)
+               :name (:name src)
+               :note "Explain problems in plain language, fetch fix instructions from the knowledge base, and offer zoom_map_to_coordinates buttons for problem locations.")))
+
+    "zoom_map_to_coordinates"
+    (->client-action
+     (cond-> {:type "pan-to-coordinates"
+              :label (str (:label args))
+              :lon (double (:lon args))
+              :lat (double (:lat args))}
+       (:zoom args) (assoc :zoom (int (:zoom args)))))
+
     "escalate_to_support"
     ;; Marker result only: answer! short-circuits on this tool and the
     ;; widget renders a confirmation card. Nothing is sent here.
@@ -473,6 +542,7 @@ RULES:
 - ADAPT guides to the user's situation. The user is always logged in (this assistant requires it) — never include registration or login steps. USER CONTEXT below tells you where they are right now: omit steps they have already completed (e.g. skip \"avaa karttanäkymä\" when the route shows they are on the map; skip \"valitse kohde\" when a site is already selected) and start from the first step that is actually left to do. Adapting means OMITTING or briefly acknowledging completed steps — never adding steps or details that are not in the sources.
 - For data-maintenance questions (\"mitkä kohteet kaipaavat päivitystä?\") use the listing tools; present results as a compact markdown list with links.
 - PERMISSIONS: the user's roles (official names + scopes) are in USER CONTEXT. For any question about editing rights on a specific site (\"miksi en voi muokata\", \"saanko muokata\") call check_site_permission — its verdict comes from the real permission engine and overrides your own reasoning. Never guess what a role allows: if the KB has no entry about it, say so.
+- ROUTE EDITING: while the user is drawing or editing geometry, USER CONTEXT :app-context :edit carries live editor state — segment/vertex counts, length-km, self-intersection count with up to 5 problem locations (lon/lat), and invalid-fields blocking save. Ground answers to 'miksi tallennus ei onnistu' or 'mitä punaiset merkit ovat' in this state: name the concrete problems, fetch the fix steps from the knowledge base, and offer zoom_map_to_coordinates buttons to the problem locations (label like 'Näytä ongelmakohta 1'). For a SAVED route, check_route_geometry gives the full report. zoom_map_to_coordinates buttons work during editing; other action buttons are disabled until the user closes edit mode.
 - NAMES FROM DATA ONLY: municipality, facility-type and role names must come from context or tool results — NEVER infer a name from a bare code using world knowledge.
 - Never write a support email address into an answer — escalation via the confirmation card handles delivery.
 - Help deep-links (?ohje=...) must be copied verbatim from tool results; never construct one yourself.
@@ -535,7 +605,8 @@ USER CONTEXT:
 (def ^:private action-tool-names
   "Propose-only tools: calling one produces a button, not information.
    A turn that pairs answer text with only these calls is a final answer."
-  #{"apply_search" "show_site_on_map" "pan_map_to_location" "navigate_to_view"})
+  #{"apply_search" "show_site_on_map" "pan_map_to_location" "navigate_to_view"
+    "zoom_map_to_coordinates"})
 
 (defn- collect-actions
   "Validated UI actions proposed via the action tools this turn."
@@ -597,7 +668,9 @@ USER CONTEXT:
              :actions (->> actions distinct (take max-actions-per-answer) vec)
              ;; A blank draft renders a confusing empty card — fall back to
              ;; the user's own words.
-             :escalation {:summary (if (str/blank? summary) message summary)}})
+             :escalation {:summary (if (str/blank? summary) message summary)}
+             :tool-rounds iter
+             :budget-exhausted? false})
 
           (and (seq fcalls) (< iter max-tool-iterations))
           (let [results (mapv (fn [fc] (run-tool ctx (:name fc) (:args fc))) fcalls)
@@ -614,7 +687,9 @@ USER CONTEXT:
               {:answer-md (sanitize-answer-links text sources')
                :sources (vec (distinct sources'))
                :actions (->> actions' distinct (take max-actions-per-answer) vec)
-               :escalation nil}
+               :escalation nil
+               :tool-rounds (inc iter)
+               :budget-exhausted? false}
               (recur (into contents
                            [{:role "model" :parts (vec parts)}
                             {:role "user"
@@ -630,7 +705,14 @@ USER CONTEXT:
                      best-text)))
 
           :else
-          (let [actions' (->> actions distinct (take max-actions-per-answer) vec)]
+          (let [;; Tool budget exhausted mid-turn: action-tool calls are
+                ;; local and cheap — salvage them so a button the answer
+                ;; text already promises never goes missing.
+                salvaged (->> fcalls
+                              (filter (comp action-tool-names :name))
+                              (mapv (fn [fc] (run-tool ctx (:name fc) (:args fc)))))
+                actions (collect-actions actions salvaged)
+                actions' (->> actions distinct (take max-actions-per-answer) vec)]
             {:answer-md (cond
                           (not (str/blank? best-text)) (sanitize-answer-links best-text sources)
                           ;; The model sometimes treats a proposed button as
@@ -646,7 +728,11 @@ USER CONTEXT:
                           "Pahoittelut — en osannut muodostaa vastausta. Yritä muotoilla kysymys uudelleen.")
              :sources (vec (distinct sources))
              :actions actions'
-             :escalation nil}))))))
+             :escalation nil
+             :tool-rounds iter
+             ;; True when tool calls were still pending at the cap — the
+             ;; answer is less grounded than the model intended.
+             :budget-exhausted? (boolean (seq fcalls))}))))))
 
 ;;; ——— Rate limiting ————————————————————————————————————————————————
 
@@ -700,8 +786,11 @@ USER CONTEXT:
                       :actions (mapv :type (:actions result))
                       :escalated? (some? (:escalation result))
                       :context (json/encode (:context req))
-                      :took-ms (- (System/currentTimeMillis) start)})
-      {:status 200 :body result})))
+                      :took-ms (- (System/currentTimeMillis) start)
+                      :tool-rounds (:tool-rounds result)
+                      :budget-exhausted? (:budget-exhausted? result)})
+      ;; Telemetry stays in the log; the widget doesn't need it.
+      {:status 200 :body (dissoc result :tool-rounds :budget-exhausted?)})))
 
 (defn escalate!
   "Send a user-confirmed support request to lipasinfo via the email job

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -1,0 +1,462 @@
+(ns lipas.backend.assistant
+  "AI help assistant: a Gemini function-calling loop grounded in the
+   knowledge base (lipas.backend.kb) plus read-only data-maintenance
+   tools over the sports-site search index.
+
+   Design constraints:
+   - Registered users only (:ai-assistant/use privilege, checked at the
+     route). The Gemini key never leaves the backend.
+   - The first model turn is FORCED to call a tool (toolConfig ANY), so
+     answers are grounded in retrieval, not vibes.
+   - All tools are read-only. escalate_to_support only *drafts* a
+     support request — the send happens via a separate endpoint after
+     the user confirms in the UI.
+   - Sports-site data is public open data; the user's editing scope is
+     used as a relevance default for listing tools, not as a security
+     boundary."
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure.string :as str]
+            [lipas.backend.kb :as kb]
+            [lipas.backend.search :as search]
+            [lipas.backend.llm :as llm]
+            [lipas.data.cities :as cities]
+            [lipas.data.prop-types :as prop-types]
+            [lipas.data.types :as types]
+            [lipas.jobs.core :as jobs]
+            [lipas.roles :as roles]
+            [taoensso.timbre :as log]))
+
+(def context-schema
+  "The app-db snapshot the widget sends with each message. Closed map so
+   junk can't flow into the prompt; server-side scope derivation never
+   trusts any of this."
+  [:map {:closed true}
+   [:route {:optional true} [:string {:max 200}]]
+   [:locale {:optional true} [:enum "fi" "se" "en"]]
+   [:view {:optional true} [:string {:max 100}]]
+   [:site {:optional true}
+    [:map {:closed true}
+     [:lipas-id {:optional true} :int]
+     [:name {:optional true} [:string {:max 200}]]
+     [:type-code {:optional true} :int]
+     [:status {:optional true} [:string {:max 50}]]]]
+   [:edit-mode? {:optional true} :boolean]
+   [:active-tool {:optional true} [:string {:max 100}]]
+   [:search-filters {:optional true} [:string {:max 500}]]])
+
+(def max-tool-iterations 6)
+(def max-history-messages 12)
+(def chat-rate-limit {:window-ms (* 60 60 1000) :max 30})
+(def escalation-rate-limit {:window-ms (* 24 60 60 1000) :max 5})
+(def support-email "lipasinfo@jyu.fi")
+
+;;; ——— User scope ————————————————————————————————————————————————————
+
+(defn editable-scope
+  "Union of city/type codes the user's roles allow editing. Approximate
+   by design (union across roles): this drives the *default* filters of
+   listing tools, not authorization — site data is public."
+  [user]
+  (let [entries (->> (get-in user [:permissions :roles])
+                     (map #(update % :role keyword))
+                     (filter #(contains? (get-in roles/roles [(:role %) :privileges] #{})
+                                         :site/create-edit)))]
+    (cond
+      (empty? entries)
+      {:none? true}
+
+      (some #(and (empty? (:city-code %)) (empty? (:type-code %))) entries)
+      {:all? true}
+
+      :else
+      {:city-codes (into #{} (mapcat :city-code) entries)
+       :type-codes (into #{} (mapcat :type-code) entries)})))
+
+;;; ——— Tools ————————————————————————————————————————————————————————
+
+(def tool-declarations
+  [{:name "search_kb"
+    :description "Search the LIPAS help knowledge base (user guides, tool instructions, facility type codes, data-model field definitions). ALWAYS use this before answering a how-to or what-is question."
+    :parameters {:type "object"
+                 :properties {:query {:type "string"
+                                      :description "Natural-language search query, in the user's language"}
+                              :lang {:type "string" :enum ["fi" "se" "en"]
+                                     :description "User's UI language"}}
+                 :required ["query"]}}
+
+   {:name "lookup_type_code"
+    :description "Resolve a sports facility type: by numeric type code or by free-text name (colloquial names work). Returns the official name, description, geometry and allowed properties."
+    :parameters {:type "object"
+                 :properties {:query {:type "string"
+                                      :description "Type code (e.g. '1390') or name (e.g. 'padel')"}}
+                 :required ["query"]}}
+
+   {:name "explain_field"
+    :description "Explain a sports-site data-model field/property: what it means and which facility types use it."
+    :parameters {:type "object"
+                 :properties {:query {:type "string"
+                                      :description "Field name in Finnish or English, e.g. 'pintamateriaali' or 'surface-material'"}}
+                 :required ["query"]}}
+
+   {:name "list_stale_sites"
+    :description "List sports sites that have not been updated since a given date — the user's data-maintenance backlog. Defaults to the user's own municipalities/types when no filters given."
+    :parameters {:type "object"
+                 :properties {:not-updated-since {:type "string"
+                                                  :description "ISO date, e.g. '2023-01-01'"}
+                              :city-names {:type "array" :items {:type "string"}
+                                           :description "Municipality names, e.g. [\"Utajärvi\"] — resolved server-side"}
+                              :city-codes {:type "array" :items {:type "integer"}}
+                              :type-codes {:type "array" :items {:type "integer"}}
+                              :limit {:type "integer"}}
+                 :required ["not-updated-since"]}}
+
+   {:name "list_sites_missing_data"
+    :description "List sports sites missing given data fields (e.g. no www, no surface-material). Defaults to the user's own municipalities/types."
+    :parameters {:type "object"
+                 :properties {:fields {:type "array" :items {:type "string"}
+                                       :description "Field keys, e.g. [\"www\", \"surface-material\"]"}
+                              :city-names {:type "array" :items {:type "string"}
+                                           :description "Municipality names — resolved server-side"}
+                              :city-codes {:type "array" :items {:type "integer"}}
+                              :type-codes {:type "array" :items {:type "integer"}}
+                              :limit {:type "integer"}}
+                 :required ["fields"]}}
+
+   {:name "get_site_summary"
+    :description "Current key data of one sports site by lipas-id."
+    :parameters {:type "object"
+                 :properties {:lipas-id {:type "integer"}}
+                 :required ["lipas-id"]}}
+
+   {:name "escalate_to_support"
+    :description "When you cannot answer from the knowledge base, or the user asks for something requiring human support (account issues, data corrections you cannot guide, bugs): draft a support request. The user confirms before anything is sent."
+    :parameters {:type "object"
+                 :properties {:summary {:type "string"
+                                        :description "Concise summary of the user's problem, in the user's language"}}
+                 :required ["summary"]}}])
+
+;;; — Tool handlers —
+
+(defn- top-level-field? [f]
+  (contains? #{"www" "email" "phone-number" "reservations-link"
+               "construction-year" "renovation-years"} f))
+
+(defn- resolve-city-names
+  [names]
+  (let [wanted (into #{} (map str/lower-case) names)]
+    (->> cities/by-city-code
+         (filter (fn [[_ m]] (contains? wanted (str/lower-case (get-in m [:name :fi] "")))))
+         (mapv first))))
+
+(defn- scope-filters
+  "Explicit request filters win; otherwise fall back to the user's scope."
+  [{:keys [city-codes city-names type-codes]} scope]
+  (let [cities (or (seq (concat city-codes (when (seq city-names)
+                                             (resolve-city-names city-names))))
+                   (seq (:city-codes scope)))
+        types* (or (seq type-codes)
+                   (seq (:type-codes scope)))]
+    (cond-> []
+      cities (conj {:terms {:location.city.city-code (vec cities)}})
+      types* (conj {:terms {:type.type-code (vec types*)}}))))
+
+(defn- site-hit->summary [hit]
+  (let [src (:_source hit)]
+    {:lipas-id (:lipas-id src)
+     :name (:name src)
+     :type (str (-> src :type :type-code) " "
+                (get-in types/all [(-> src :type :type-code) :name :fi]))
+     :city-code (-> src :location :city :city-code)
+     :status (:status src)
+     :last-updated (:event-date src)
+     :link (str "https://www.lipas.fi/liikuntapaikat/" (:lipas-id src))}))
+
+(defn- list-sites [search query-filters extra-clauses limit]
+  (let [idx (get-in search [:indices :sports-site :search])
+        resp (search/search
+              (:client search) idx
+              {:size (min (or limit 20) 50)
+               :sort [{:event-date {:order "asc"}}]
+               :query {:bool (merge {:filter (into [{:terms {:status ["active" "out-of-service-temporarily"]}}]
+                                                   query-filters)}
+                                    extra-clauses)}
+               :_source [:lipas-id :name :type.type-code :location.city.city-code
+                         :status :event-date]})]
+    {:total (-> resp :body :hits :total :value)
+     :sites (mapv site-hit->summary (-> resp :body :hits :hits))}))
+
+(defn- run-tool*
+  [{:keys [db search user scope]} tool-name args]
+  (case tool-name
+    "search_kb"
+    (kb/search-kb search {:query (:query args)
+                          :lang (or (:lang args) "fi")
+                          :limit 5})
+
+    "lookup_type_code"
+    (let [q (str/trim (str (:query args)))
+          code (parse-long q)]
+      (if-let [m (and code (get types/all code))]
+        {:type-code code
+         :name (:name m)
+         :description (:description m)
+         :geometry (:geometry-type m)
+         :status (:status m)
+         :properties (->> (:props m) keys
+                          (keep #(get-in prop-types/all [% :name :fi]))
+                          sort vec)}
+        {:candidates (kb/search-kb search {:query q :lang "fi" :limit 5})}))
+
+    "explain_field"
+    (let [q (str/trim (str (:query args)))
+          k (keyword q)]
+      (if-let [m (get prop-types/all k)]
+        {:field q :name (:name m) :description (:description m)
+         :data-type (:data-type m)}
+        {:candidates (kb/search-kb search {:query q :lang "fi" :limit 5})}))
+
+    "list_stale_sites"
+    (if (:none? scope)
+      {:error "User has no site editing rights; ask which municipality they are interested in and pass explicit city-codes."}
+      (list-sites search
+                  (scope-filters args scope)
+                  {:must_not [{:range {:event-date {:gte (:not-updated-since args)}}}]}
+                  (:limit args)))
+
+    "list_sites_missing_data"
+    (if (:none? scope)
+      {:error "User has no site editing rights; ask which municipality they are interested in and pass explicit city-codes."}
+      (let [paths (map (fn [f] (if (top-level-field? f) f (str "properties." f)))
+                       (:fields args))]
+        (list-sites search
+                    (scope-filters args scope)
+                    {:must_not (mapv (fn [p] {:exists {:field p}}) paths)}
+                    (:limit args))))
+
+    "get_site_summary"
+    (let [idx (get-in search [:indices :sports-site :search])
+          src (-> (search/fetch-document (:client search) idx (:lipas-id args))
+                  :body :_source)]
+      (if src
+        {:lipas-id (:lipas-id src)
+         :name (:name src)
+         :type (str (-> src :type :type-code) " "
+                    (get-in types/all [(-> src :type :type-code) :name :fi]))
+         :city-code (-> src :location :city :city-code)
+         :status (:status src)
+         :last-updated (:event-date src)
+         :construction-year (:construction-year src)
+         :www (:www src)
+         :properties (:properties src)
+         :link (str "https://www.lipas.fi/liikuntapaikat/" (:lipas-id args))}
+        {:error "Site not found"}))
+
+    "escalate_to_support"
+    ;; Marker result only: answer! short-circuits on this tool and the
+    ;; widget renders a confirmation card. Nothing is sent here.
+    {:escalation-proposed true :summary (:summary args)}
+
+    {:error (str "Unknown tool " tool-name)}))
+
+(defn- run-tool [ctx tool-name args]
+  (try
+    (run-tool* ctx tool-name args)
+    (catch Exception e
+      (log/warn e "Assistant tool failed" {:tool tool-name :args args})
+      {:error (str "Tool failed: " (.getMessage e))})))
+
+;;; ——— Prompt ————————————————————————————————————————————————————————
+
+(defn- system-prompt
+  [{:keys [user scope context]}]
+  (str
+   "You are the LIPAS assistant (LIPAS-avustaja), embedded in lipas.fi — Finland's national sports facility database. Users are registered maintainers (municipality employees and other data producers).
+
+RULES:
+- Answer ONLY from tool results. If the knowledge base has nothing relevant, say so honestly and offer to contact support with escalate_to_support. Never invent UI elements, menu names or type codes.
+- PARTIAL INFORMATION: when tool results cover the topic only partially, give exactly what they contain and link the source for the rest. Do NOT fill gaps from imagination — a numbered step, tab name, icon or button label that is not in a tool result must not appear in your answer.
+- NO COVERAGE: when search_kb returns nothing relevant to the question, do not answer from general knowledge — say the guides don't cover it and propose escalate_to_support.
+- Always answer in the user's language (see context; default Finnish).
+- Cite sources: when your answer builds on a knowledge-base entry, link it in markdown using its deep-link and title, e.g. [Reitin lisääminen](?ohje=tallentajille/reitin-lisaaminen). Links starting with ?ohje= open the in-app help; full URLs open in a new tab.
+- Scope: LIPAS usage, sports facility data maintenance, type codes, data model, LIPAS tools. Politely decline anything else.
+- Keep answers short and task-focused; numbered steps for how-tos.
+- For data-maintenance questions (\"mitkä kohteet kaipaavat päivitystä?\") use the listing tools; present results as a compact markdown list with links.
+
+USER CONTEXT:
+"
+   (json/encode
+    {:name (-> user :user-data :firstname)
+     :editing-scope (cond
+                      (:all? scope) "all municipalities and types (admin)"
+                      (:none? scope) "no editing rights"
+                      :else scope)
+     :app-context context})))
+
+;;; ——— Gemini chat with tools ———————————————————————————————————————
+
+(defn- gemini-chat
+  [system contents tool-mode]
+  (let [{:keys [base-url api-key]} llm/gemini-config
+        model (:model llm/gemini-default-params)
+        body {:systemInstruction {:parts [{:text system}]}
+              :contents contents
+              :tools [{:functionDeclarations tool-declarations}]
+              :toolConfig {:functionCallingConfig {:mode tool-mode}}
+              :generationConfig {:temperature 0.2
+                                 :maxOutputTokens 4096
+                                 :thinkingConfig {:thinkingLevel "minimal"}}}]
+    (-> (http/post (str base-url "/models/" model ":generateContent")
+                   {:headers {"x-goog-api-key" api-key
+                              "Content-Type" "application/json"}
+                    :body (json/encode body)
+                    :content-type :json
+                    :socket-timeout 120000
+                    :connection-timeout 10000})
+        :body
+        (json/decode keyword))))
+
+(defn- history->contents [history]
+  (mapv (fn [{:keys [role text]}]
+          {:role (if (= role "assistant") "model" "user")
+           :parts [{:text text}]})
+        (take-last max-history-messages history)))
+
+(defn- collect-sources
+  "KB docs retrieved during the conversation → citation candidates."
+  [sources tool-name result]
+  (if (and (= tool-name "search_kb") (sequential? result))
+    (into sources (map #(select-keys % [:id :title :deep-link :source-type :lang]) result))
+    sources))
+
+(defn answer!
+  "Run the assistant loop for one user message. Returns
+   {:answer-md ... :sources [...] :escalation nil|{:summary ...}}."
+  [{:keys [db search user message history context] :as _req}]
+  (let [scope (editable-scope user)
+        ctx {:db db :search search :user user :scope scope}
+        system (system-prompt {:user user :scope scope :context context})]
+    (loop [contents (conj (history->contents history)
+                          {:role "user" :parts [{:text message}]})
+           iter 0
+           ;; First turn must ground itself in a tool call.
+           mode "ANY"
+           sources []]
+      (let [resp (gemini-chat system contents mode)
+            parts (or (-> resp :candidates first :content :parts) [])
+            fcalls (keep :functionCall parts)
+            text (->> parts (keep :text) (str/join))]
+        (cond
+          ;; Escalation proposed: stop, let the user confirm in the UI.
+          (some #(= "escalate_to_support" (:name %)) fcalls)
+          (let [fc (first (filter #(= "escalate_to_support" (:name %)) fcalls))]
+            {:answer-md (if (str/blank? text)
+                          "Voin lähettää kysymyksesi LIPAS-tuelle. Saat vastauksen sähköpostiisi."
+                          text)
+             :sources (vec (distinct sources))
+             :escalation {:summary (-> fc :args :summary)}})
+
+          (and (seq fcalls) (< iter max-tool-iterations))
+          (let [results (mapv (fn [fc] (run-tool ctx (:name fc) (:args fc))) fcalls)
+                sources' (reduce (fn [acc [fc r]] (collect-sources acc (:name fc) r))
+                                 sources
+                                 (map vector fcalls results))]
+            (recur (into contents
+                         [{:role "model" :parts (vec parts)}
+                          {:role "user"
+                           :parts (mapv (fn [fc r]
+                                          {:functionResponse
+                                           {:name (:name fc)
+                                            :response {:result r}}})
+                                        fcalls results)}])
+                   (inc iter)
+                   "AUTO"
+                   sources'))
+
+          :else
+          {:answer-md (if (str/blank? text)
+                        "Pahoittelut — en osannut muodostaa vastausta. Yritä muotoilla kysymys uudelleen."
+                        text)
+           :sources (vec (distinct sources))
+           :escalation nil})))))
+
+;;; ——— Rate limiting ————————————————————————————————————————————————
+
+(defonce ^:private rate-state (atom {}))
+
+(defn rate-limited?
+  "Sliding-window limiter keyed by [kind user-id]. Mutates state."
+  [kind user-id {:keys [window-ms max]}]
+  (let [now (System/currentTimeMillis)
+        k [kind user-id]
+        stamps (->> (get @rate-state k [])
+                    (filterv #(> % (- now window-ms))))]
+    (if (>= (count stamps) max)
+      (do (swap! rate-state assoc k stamps) true)
+      (do (swap! rate-state assoc k (conj stamps now)) false))))
+
+(defn- sha-256 [^String s]
+  (->> (.digest (java.security.MessageDigest/getInstance "SHA-256")
+                (.getBytes s "UTF-8"))
+       (map #(format "%02x" %))
+       (apply str)))
+
+;;; ——— Logging ———————————————————————————————————————————————————————
+
+(defn- log-exchange!
+  [search doc]
+  (future
+    (try
+      (search/index! (:client search)
+                     (get-in search [:indices :assistant :logs])
+                     (fn [_] (str (random-uuid)))
+                     doc)
+      (catch Exception e
+        (log/warn e "Failed to index assistant log")))))
+
+;;; ——— Public entrypoints (called from handler) —————————————————————
+
+(defn chat!
+  [{:keys [db search user] :as req}]
+  (if (rate-limited? :chat (:id user) chat-rate-limit)
+    {:status 429
+     :body {:error "Viestiraja täynnä. Yritä myöhemmin uudelleen."}}
+    (let [start (System/currentTimeMillis)
+          result (answer! req)]
+      (log-exchange! search
+                     {:user-hash (sha-256 (str (:id user)))
+                      :created-at (str (java.time.Instant/now))
+                      :question (:message req)
+                      :answer (:answer-md result)
+                      :sources (mapv :id (:sources result))
+                      :escalated? (some? (:escalation result))
+                      :context (json/encode (:context req))
+                      :took-ms (- (System/currentTimeMillis) start)})
+      {:status 200 :body result})))
+
+(defn escalate!
+  "Send a user-confirmed support request to lipasinfo via the email job
+   queue. The user's address goes into the body — support replies
+   directly to them."
+  [{:keys [db user summary transcript context]}]
+  (if (rate-limited? :escalation (:id user) escalation-rate-limit)
+    {:status 429
+     :body {:error "Tukipyyntöraja täynnä tälle päivälle."}}
+    (let [conversation-id (str (random-uuid))
+          body (str "LIPAS-avustajan välittämä tukipyyntö\n"
+                    "Tunniste: " conversation-id "\n"
+                    "Käyttäjä: " (:email user)
+                    " (" (-> user :user-data :firstname) " "
+                    (-> user :user-data :lastname) ")\n"
+                    "Vastaa suoraan käyttäjän osoitteeseen.\n\n"
+                    "ONGELMA:\n" summary "\n\n"
+                    "SOVELLUSKONTEKSTI:\n" (json/encode context) "\n\n"
+                    "KESKUSTELU:\n"
+                    (->> (take-last 10 transcript)
+                         (map (fn [{:keys [role text]}] (str role ": " text)))
+                         (str/join "\n\n")))]
+      (jobs/enqueue-job! db "email"
+                         {:to support-email
+                          :subject (str "[LIPAS-avustaja] " (subs summary 0 (min 80 (count summary))))
+                          :body body})
+      {:status 200 :body {:sent true :conversation-id conversation-id}})))

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -85,6 +85,13 @@
                                      :description "User's UI language"}}
                  :required ["query"]}}
 
+   {:name "get_kb_document"
+    :description "Fetch the FULL text of a knowledge-base entry by its id. search_kb returns truncated snippets — always fetch the full entry before answering a how-to question based on it."
+    :parameters {:type "object"
+                 :properties {:id {:type "string"
+                                   :description "Entry id from search_kb results"}}
+                 :required ["id"]}}
+
    {:name "lookup_type_code"
     :description "Resolve a sports facility type: by numeric type code or by free-text name (colloquial names work). Returns the official name, description, geometry and allowed properties."
     :parameters {:type "object"
@@ -194,6 +201,10 @@
                           :lang (or (:lang args) "fi")
                           :limit 5})
 
+    "get_kb_document"
+    (or (kb/get-doc search (:id args))
+        {:error "No entry with that id"})
+
     "lookup_type_code"
     (let [q (str/trim (str (:query args)))
           code (parse-long q)]
@@ -275,6 +286,7 @@
 
 RULES:
 - Answer ONLY from tool results. If the knowledge base has nothing relevant, say so honestly and offer to contact support with escalate_to_support. Never invent UI elements, menu names or type codes.
+- search_kb returns TRUNCATED snippets. Before answering a how-to question, fetch the most relevant entries in full with get_kb_document — the snippet alone is not grounds to conclude the guides lack the answer.
 - PARTIAL INFORMATION: when tool results cover the topic only partially, give exactly what they contain and link the source for the rest. Do NOT fill gaps from imagination — a numbered step, tab name, icon or button label that is not in a tool result must not appear in your answer.
 - NO COVERAGE: when search_kb returns nothing relevant to the question, do not answer from general knowledge — say the guides don't cover it and propose escalate_to_support.
 - Always answer in the user's language (see context; default Finnish).

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -53,7 +53,13 @@
     [:map {:closed true}
      [:section {:optional true} [:string {:max 200}]]
      [:page {:optional true} [:string {:max 200}]]
-     [:title {:optional true} [:string {:max 300}]]]]])
+     [:title {:optional true} [:string {:max 300}]]]]
+   [:ptv {:optional true} ; open PTV export dialog (covers the map view)
+    [:map {:closed true}
+     [:open? {:optional true} :boolean]
+     [:org {:optional true} [:string {:max 200}]]
+     [:tab {:optional true} [:string {:max 100}]]
+     [:wizard-step {:optional true} [:string {:max 100}]]]]])
 
 (def max-tool-iterations 6)
 (def max-history-messages 12)

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -16,6 +16,7 @@
      boundary."
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [lipas.backend.kb :as kb]
             [lipas.backend.search :as search]
@@ -25,6 +26,10 @@
             [lipas.data.types :as types]
             [lipas.jobs.core :as jobs]
             [lipas.roles :as roles]
+            [lipas.schema.assistant :as assistant-schema]
+            [lipas.schema.sports-sites.types :as types-schema]
+            [malli.core :as m]
+            [malli.error :as me]
             [taoensso.timbre :as log]))
 
 (def context-schema
@@ -50,6 +55,38 @@
 (def chat-rate-limit {:window-ms (* 60 60 1000) :max 30})
 (def escalation-rate-limit {:window-ms (* 24 60 60 1000) :max 5})
 (def support-email "lipasinfo@jyu.fi")
+
+;;; ——— Names for codes ———————————————————————————————————————————————
+;;
+;; The model decorates bare codes with names from its world knowledge —
+;; and gets them wrong (city 320 is Kemijärvi, not Muurame). Every code
+;; that reaches the prompt or a tool result carries its name.
+
+(def ^:private role-i18n
+  "Official Finnish role names; single source: the UI translation file."
+  (delay (-> (io/resource "lipas/i18n/fi/lipas_user_permissions_roles.edn")
+             slurp
+             read-string)))
+
+(defn- city-label [code]
+  (str code " " (get-in cities/by-city-code [code :name :fi] "?")))
+
+(defn- type-label [code]
+  (str code " " (get-in types/all [code :name :fi] "?")))
+
+(defn- describe-roles
+  "The user's roles with official names and resolved scopes."
+  [user]
+  (->> (get-in user [:permissions :roles])
+       (mapv (fn [{:keys [role] :as r}]
+               (let [role-kw (keyword role)]
+                 (cond-> {:role (str (get-in @role-i18n [:role-names role-kw] (name role-kw))
+                                     " (" (name role-kw) ")")}
+                   (seq (:city-code r)) (assoc :cities (mapv city-label (sort (:city-code r))))
+                   (seq (:type-code r)) (assoc :types (mapv type-label (sort (:type-code r))))
+                   (seq (:lipas-id r)) (assoc :sites (vec (sort (:lipas-id r))))
+                   (seq (:activity r)) (assoc :activities (vec (sort (:activity r))))
+                   (seq (:org-id r)) (assoc :org-ids (vec (:org-id r)))))))))
 
 ;;; ——— User scope ————————————————————————————————————————————————————
 
@@ -136,8 +173,57 @@
                  :properties {:lipas-id {:type "integer"}}
                  :required ["lipas-id"]}}
 
+   {:name "check_site_permission"
+    :description "Authoritative check from the LIPAS permission engine: can the CURRENT user edit a given sports site? ALWAYS use this for questions like 'miksi en voi muokata tätä kohdetta' or 'saanko muokata kohteen X' — its verdict overrides any reasoning of your own. Also returns the user's roles with official names."
+    :parameters {:type "object"
+                 :properties {:lipas-id {:type "integer"}}
+                 :required ["lipas-id"]}}
+
+   {:name "apply_search"
+    :description "Propose a UI action: run a sports-site search in the map view on the user's behalf. The call does NOT execute anything — the user gets a button and clicks to run it. Use when the user asks to find/see/list sites (e.g. 'mitä liikuntapaikkoja on Äänekoskella?', 'näytä kohteet joita voin muokata'). Resolve free-text type names to codes with lookup_type_code first. The map also pans to the results."
+    :parameters {:type "object"
+                 :properties {:label {:type "string"
+                                      :description "Button text in the user's language, short and imperative, e.g. 'Hae: uimahallit Äänekoski'"}
+                              :search-text {:type "string"
+                                            :description "Free-text search words, only when searching by name/keyword"}
+                              :city-names {:type "array" :items {:type "string"}
+                                           :description "Municipality names, e.g. [\"Äänekoski\"] — resolved server-side"}
+                              :type-codes {:type "array" :items {:type "integer"}
+                                           :description "Facility type codes from lookup_type_code"}
+                              :only-editable {:type "boolean"
+                                              :description "true = only sites the user has rights to edit"}}
+                 :required ["label"]}}
+
+   {:name "show_site_on_map"
+    :description "Propose a UI action: open one sports site on the map (button; the user clicks to run it). Use when the conversation concerns a specific site whose lipas-id you know from a tool result."
+    :parameters {:type "object"
+                 :properties {:label {:type "string"
+                                      :description "Button text in the user's language, e.g. 'Näytä kartalla: Ounasvaaran latu'"}
+                              :lipas-id {:type "integer"}}
+                 :required ["label" "lipas-id"]}}
+
+   {:name "pan_map_to_location"
+    :description "Propose a UI action: pan/zoom the map to a named place — an address, area or municipality — without filtering the search (button; the user clicks to run it). For 'what sites are in X' prefer apply_search, which also fits the map to its results."
+    :parameters {:type "object"
+                 :properties {:label {:type "string"
+                                      :description "Button text in the user's language"}
+                              :location {:type "string"
+                                         :description "Place name or address to geocode, e.g. 'Äänekoski' or 'Nallikari, Oulu'"}}
+                 :required ["label" "location"]}}
+
+   {:name "navigate_to_view"
+    :description (str "Propose a UI action: open another view of the LIPAS app (button; the user clicks to run it). Use for 'missä näen/mistä löydän' navigation questions. Views: "
+                      (str/join "; " (map (fn [[k v]] (str k " = " v))
+                                          (sort assistant-schema/views))))
+    :parameters {:type "object"
+                 :properties {:label {:type "string"
+                                      :description "Button text in the user's language, e.g. 'Avaa tilastot'"}
+                              :view {:type "string"
+                                     :enum (vec (sort (keys assistant-schema/views)))}}
+                 :required ["label" "view"]}}
+
    {:name "escalate_to_support"
-    :description "When you cannot answer from the knowledge base, or the user asks for something requiring human support (account issues, data corrections you cannot guide, bugs): draft a support request. The user confirms before anything is sent."
+    :description "When you cannot answer from the knowledge base, or the user asks for something requiring human support (account issues, data corrections you cannot guide, bugs, wanting to talk to a human): draft a support request. The user confirms before anything is sent. ALWAYS write answer text alongside this call: tell the user an editable draft appears below your message and that pressing 'Lähetä tukipyyntö' sends it. If the user asked for a human without describing their issue, ask them to add what it concerns into the draft before sending."
     :parameters {:type "object"
                  :properties {:summary {:type "string"
                                         :description "Concise summary of the user's problem, in the user's language"}}
@@ -172,9 +258,8 @@
   (let [src (:_source hit)]
     {:lipas-id (:lipas-id src)
      :name (:name src)
-     :type (str (-> src :type :type-code) " "
-                (get-in types/all [(-> src :type :type-code) :name :fi]))
-     :city-code (-> src :location :city :city-code)
+     :type (type-label (-> src :type :type-code))
+     :city (city-label (-> src :location :city :city-code))
      :status (:status src)
      :last-updated (:event-date src)
      :link (str "https://www.lipas.fi/liikuntapaikat/" (:lipas-id src))}))
@@ -192,6 +277,17 @@
                          :status :event-date]})]
     {:total (-> resp :body :hits :total :value)
      :sites (mapv site-hit->summary (-> resp :body :hits :hits))}))
+
+(defn- ->client-action
+  "Validate a candidate UI action against the closed vocabulary in
+   lipas.schema.assistant. Valid → marker result the answer! loop
+   collects into the response; invalid → error the model can act on."
+  [action]
+  (if (assistant-schema/valid? action)
+    {:client-action action
+     :note "Offered to the user as a button they can click. Refer to it briefly in your answer; never claim it already ran."}
+    {:error (str "Invalid action: "
+                 (pr-str (me/humanize (assistant-schema/explain action))))}))
 
 (defn- run-tool*
   [{:keys [db search user scope]} tool-name args]
@@ -252,9 +348,8 @@
       (if src
         {:lipas-id (:lipas-id src)
          :name (:name src)
-         :type (str (-> src :type :type-code) " "
-                    (get-in types/all [(-> src :type :type-code) :name :fi]))
-         :city-code (-> src :location :city :city-code)
+         :type (type-label (-> src :type :type-code))
+         :city (city-label (-> src :location :city :city-code))
          :status (:status src)
          :last-updated (:event-date src)
          :construction-year (:construction-year src)
@@ -262,6 +357,77 @@
          :properties (:properties src)
          :link (str "https://www.lipas.fi/liikuntapaikat/" (:lipas-id args))}
         {:error "Site not found"}))
+
+    "check_site_permission"
+    (let [idx (get-in search [:indices :sports-site :search])
+          src (try (-> (search/fetch-document (:client search) idx (:lipas-id args))
+                       :body :_source)
+                   (catch Exception _ nil))]
+      (if src
+        (let [;; DB-loaded roles may carry string role keys; the engine
+              ;; looks roles up by keyword.
+              user* (update-in user [:permissions :roles]
+                               (fn [rs] (mapv #(update % :role keyword) rs)))
+              can-edit? (boolean (roles/check-privilege
+                                  user* (roles/site-roles-context src) :site/create-edit))]
+          {:can-edit? can-edit?
+           :site {:lipas-id (:lipas-id src)
+                  :name (:name src)
+                  :city (city-label (-> src :location :city :city-code))
+                  :type (type-label (-> src :type :type-code))}
+           :user-roles (describe-roles user)
+           :note (if can-edit?
+                   "Verdict from the permission engine: the user CAN edit this site."
+                   "Verdict from the permission engine: the user CANNOT edit this site. They can request access via escalate_to_support.")})
+        {:error "Site not found"}))
+
+    "apply_search"
+    (let [{:keys [label search-text city-names type-codes only-editable]} args
+          city-codes (when (seq city-names) (resolve-city-names city-names))
+          resolved (into #{} (map #(str/lower-case (get-in cities/by-city-code [% :name :fi] "")))
+                         city-codes)
+          unresolved (into [] (remove #(contains? resolved (str/lower-case %))) city-names)
+          bad-types (into [] (remove #(m/validate types-schema/active-type-code %)) type-codes)]
+      (cond
+        (seq unresolved)
+        {:error (str "Unknown municipalities: " (str/join ", " unresolved)
+                     ". Use official Finnish municipality names.")}
+
+        (seq bad-types)
+        {:error (str "Unknown or retired type codes: " (str/join ", " bad-types)
+                     ". Resolve them with lookup_type_code first.")}
+
+        :else
+        (->client-action
+         (cond-> {:type "apply-search" :label (str label)}
+           search-text (assoc :search-text search-text)
+           (seq city-codes) (assoc :city-codes (vec city-codes))
+           (seq type-codes) (assoc :type-codes (vec type-codes))
+           only-editable (assoc :only-editable true)))))
+
+    "show_site_on_map"
+    (let [idx (get-in search [:indices :sports-site :search])
+          exists? (try (some-> (search/fetch-document (:client search) idx (:lipas-id args))
+                               :body :found)
+                       ;; ES GET throws on 404 — a dead button is worse
+                       ;; than telling the model the id is wrong.
+                       (catch Exception _ false))]
+      (if exists?
+        (->client-action {:type "show-site"
+                          :label (str (:label args))
+                          :lipas-id (:lipas-id args)})
+        {:error (str "No sports site with lipas-id " (:lipas-id args)
+                     " — only offer this for ids seen in tool results.")}))
+
+    "pan_map_to_location"
+    (->client-action {:type "pan-to-location"
+                      :label (str (:label args))
+                      :location (str (:location args))})
+
+    "navigate_to_view"
+    (->client-action {:type "navigate-to-view"
+                      :label (str (:label args))
+                      :view (str (:view args))})
 
     "escalate_to_support"
     ;; Marker result only: answer! short-circuits on this tool and the
@@ -282,7 +448,7 @@
 (defn- system-prompt
   [{:keys [user scope context]}]
   (str
-   "You are the LIPAS assistant (LIPAS-avustaja), embedded in lipas.fi — Finland's national sports facility database. Users are registered maintainers (municipality employees and other data producers).
+   "You are Lipastaja, the LIPAS assistant embedded in lipas.fi — Finland's national sports facility database. Users are registered maintainers (municipality employees and other data producers).
 
 RULES:
 - Answer ONLY from tool results. If the knowledge base has nothing relevant, say so honestly and offer to contact support with escalate_to_support. Never invent UI elements, menu names or type codes.
@@ -295,6 +461,12 @@ RULES:
 - Keep answers short and task-focused; numbered steps for how-tos.
 - ADAPT guides to the user's situation. The user is always logged in (this assistant requires it) — never include registration or login steps. USER CONTEXT below tells you where they are right now: omit steps they have already completed (e.g. skip \"avaa karttanäkymä\" when the route shows they are on the map; skip \"valitse kohde\" when a site is already selected) and start from the first step that is actually left to do. Adapting means OMITTING or briefly acknowledging completed steps — never adding steps or details that are not in the sources.
 - For data-maintenance questions (\"mitkä kohteet kaipaavat päivitystä?\") use the listing tools; present results as a compact markdown list with links.
+- PERMISSIONS: the user's roles (official names + scopes) are in USER CONTEXT. For any question about editing rights on a specific site (\"miksi en voi muokata\", \"saanko muokata\") call check_site_permission — its verdict comes from the real permission engine and overrides your own reasoning. Never guess what a role allows: if the KB has no entry about it, say so.
+- NAMES FROM DATA ONLY: municipality, facility-type and role names must come from context or tool results — NEVER infer a name from a bare code using world knowledge.
+- Never write a support email address into an answer — escalation via the confirmation card handles delivery.
+- Help deep-links (?ohje=...) must be copied verbatim from tool results; never construct one yourself.
+- WORK-SAVING FEATURES: when your answer requires the user to do repetitive manual work (e.g. creating several similar sites, entering the same data twice), run ONE extra search_kb asking whether a LIPAS feature eases that work, BEFORE writing your answer. Mention such a feature ONLY if a retrieved entry documents it, cite that entry, and base every detail of the tip on it. Found nothing → no tip.
+- UI ACTIONS: apply_search, show_site_on_map, pan_map_to_location and navigate_to_view do NOT run anything — each successful call becomes a BUTTON the user may click. Offer one whenever the user asks to find/see sites, to locate a place on the map, or where something is in the app. Write label in the user's language, short and imperative. In your answer refer to the button briefly (\"paina alla olevaa painiketta\") — never claim the search/navigation already happened. The UI renders the button below your message: do not write the button label, any [bracketed pseudo-button], a link imitating a tool call, or a table of actions into the answer text — navigation/search happens ONLY by calling the action tools. At most 2 actions per answer. After your action tool calls return, ALWAYS still write a short normal answer — a button must never arrive with empty answer text.
 
 USER CONTEXT:
 "
@@ -303,7 +475,12 @@ USER CONTEXT:
      :editing-scope (cond
                       (:all? scope) "all municipalities and types (admin)"
                       (:none? scope) "no editing rights"
-                      :else scope)
+                      :else (cond-> {}
+                              (seq (:city-codes scope))
+                              (assoc :cities (mapv city-label (sort (:city-codes scope))))
+                              (seq (:type-codes scope))
+                              (assoc :types (mapv type-label (sort (:type-codes scope))))))
+     :roles (describe-roles user)
      :app-context context})))
 
 ;;; ——— Gemini chat with tools ———————————————————————————————————————
@@ -342,6 +519,32 @@ USER CONTEXT:
     (into sources (map #(select-keys % [:id :title :deep-link :source-type :lang]) result))
     sources))
 
+(def max-actions-per-answer 3)
+
+(defn- collect-actions
+  "Validated UI actions proposed via the action tools this turn."
+  [actions results]
+  (into actions (keep :client-action) results))
+
+(defn- sanitize-answer-links
+  "Keep only link targets the widget can handle: ?ohje= deep-links the
+   model actually retrieved this conversation, and normal web/mail
+   links. Everything else — invented ?ohje= slugs, fabricated tool-call
+   schemes like (navigate_to_view:profile) — degrades to plain text."
+  [answer-md sources]
+  (let [valid-ohje? (into #{} (keep :deep-link) sources)]
+    (str/replace (str answer-md)
+                 #"\[([^\]]*)\]\(([^)]*)\)"
+                 (fn [[_ title link]]
+                   (cond
+                     (str/starts-with? link "?ohje=")
+                     (if (valid-ohje? link) (str "[" title "](" link ")") title)
+
+                     (re-matches #"(?i)(https?://|mailto:).*" link)
+                     (str "[" title "](" link ")")
+
+                     :else title)))))
+
 (defn answer!
   "Run the assistant loop for one user message. Returns
    {:answer-md ... :sources [...] :escalation nil|{:summary ...}}."
@@ -354,7 +557,8 @@ USER CONTEXT:
            iter 0
            ;; First turn must ground itself in a tool call.
            mode "ANY"
-           sources []]
+           sources []
+           actions []]
       (let [resp (gemini-chat system contents mode)
             parts (or (-> resp :candidates first :content :parts) [])
             fcalls (keep :functionCall parts)
@@ -362,12 +566,16 @@ USER CONTEXT:
         (cond
           ;; Escalation proposed: stop, let the user confirm in the UI.
           (some #(= "escalate_to_support" (:name %)) fcalls)
-          (let [fc (first (filter #(= "escalate_to_support" (:name %)) fcalls))]
+          (let [fc (first (filter #(= "escalate_to_support" (:name %)) fcalls))
+                summary (-> fc :args :summary)]
             {:answer-md (if (str/blank? text)
-                          "Voin lähettää kysymyksesi LIPAS-tuelle. Saat vastauksen sähköpostiisi."
-                          text)
+                          "Voin lähettää kysymyksesi LIPAS-tuelle. Tarkista ja täydennä alla oleva tiivistelmä ja paina **Lähetä tukipyyntö** — saat vastauksen sähköpostiisi."
+                          (sanitize-answer-links text sources))
              :sources (vec (distinct sources))
-             :escalation {:summary (-> fc :args :summary)}})
+             :actions (->> actions distinct (take max-actions-per-answer) vec)
+             ;; A blank draft renders a confusing empty card — fall back to
+             ;; the user's own words.
+             :escalation {:summary (if (str/blank? summary) message summary)}})
 
           (and (seq fcalls) (< iter max-tool-iterations))
           (let [results (mapv (fn [fc] (run-tool ctx (:name fc) (:args fc))) fcalls)
@@ -384,14 +592,27 @@ USER CONTEXT:
                                         fcalls results)}])
                    (inc iter)
                    "AUTO"
-                   sources'))
+                   sources'
+                   (collect-actions actions results)))
 
           :else
-          {:answer-md (if (str/blank? text)
-                        "Pahoittelut — en osannut muodostaa vastausta. Yritä muotoilla kysymys uudelleen."
-                        text)
-           :sources (vec (distinct sources))
-           :escalation nil})))))
+          (let [actions' (->> actions distinct (take max-actions-per-answer) vec)]
+            {:answer-md (cond
+                          (not (str/blank? text)) (sanitize-answer-links text sources)
+                          ;; The model sometimes treats a proposed button as
+                          ;; the whole answer and returns no text — an apology
+                          ;; would contradict the working button below it.
+                          (= 1 (count actions'))
+                          "Voit jatkaa painamalla alla olevaa painiketta."
+
+                          (seq actions')
+                          "Voit jatkaa painamalla alla olevia painikkeita."
+
+                          :else
+                          "Pahoittelut — en osannut muodostaa vastausta. Yritä muotoilla kysymys uudelleen.")
+             :sources (vec (distinct sources))
+             :actions actions'
+             :escalation nil}))))))
 
 ;;; ——— Rate limiting ————————————————————————————————————————————————
 
@@ -442,6 +663,7 @@ USER CONTEXT:
                       :question (:message req)
                       :answer (:answer-md result)
                       :sources (mapv :id (:sources result))
+                      :actions (mapv :type (:actions result))
                       :escalated? (some? (:escalation result))
                       :context (json/encode (:context req))
                       :took-ms (- (System/currentTimeMillis) start)})
@@ -456,7 +678,7 @@ USER CONTEXT:
     {:status 429
      :body {:error "Tukipyyntöraja täynnä tälle päivälle."}}
     (let [conversation-id (str (random-uuid))
-          body (str "LIPAS-avustajan välittämä tukipyyntö\n"
+          body (str "Lipastajan (LIPAS-avustajan) välittämä tukipyyntö\n"
                     "Tunniste: " conversation-id "\n"
                     "Käyttäjä: " (:email user)
                     " (" (-> user :user-data :firstname) " "
@@ -470,6 +692,6 @@ USER CONTEXT:
                          (str/join "\n\n")))]
       (jobs/enqueue-job! db "email"
                          {:to support-email
-                          :subject (str "[LIPAS-avustaja] " (subs summary 0 (min 80 (count summary))))
+                          :subject (str "[Lipastaja] " (subs summary 0 (min 80 (count summary))))
                           :body body})
       {:status 200 :body {:sent true :conversation-id conversation-id}})))

--- a/webapp/src/clj/lipas/backend/assistant.clj
+++ b/webapp/src/clj/lipas/backend/assistant.clj
@@ -293,6 +293,7 @@ RULES:
 - Cite sources: when your answer builds on a knowledge-base entry, link it in markdown using its deep-link and title, e.g. [Reitin lisääminen](?ohje=tallentajille/reitin-lisaaminen). Links starting with ?ohje= open the in-app help; full URLs open in a new tab.
 - Scope: LIPAS usage, sports facility data maintenance, type codes, data model, LIPAS tools. Politely decline anything else.
 - Keep answers short and task-focused; numbered steps for how-tos.
+- ADAPT guides to the user's situation. The user is always logged in (this assistant requires it) — never include registration or login steps. USER CONTEXT below tells you where they are right now: omit steps they have already completed (e.g. skip \"avaa karttanäkymä\" when the route shows they are on the map; skip \"valitse kohde\" when a site is already selected) and start from the first step that is actually left to do. Adapting means OMITTING or briefly acknowledging completed steps — never adding steps or details that are not in the sources.
 - For data-maintenance questions (\"mitkä kohteet kaipaavat päivitystä?\") use the listing tools; present results as a compact markdown list with links.
 
 USER CONTEXT:

--- a/webapp/src/clj/lipas/backend/config.clj
+++ b/webapp/src/clj/lipas/backend/config.clj
@@ -45,7 +45,9 @@
       :population-high-def "vaestoruutu_250m"
       :diversity "diversity"}
      :kb
-     {:kb "lipas_kb_v1"}}}
+     {:kb "lipas_kb_v1"}
+     :assistant
+     {:logs "assistant_logs"}}}
    :mailchimp
    {:api-key (env! :mailchimp-api-key)
     :api-url (env! :mailchimp-api-url)

--- a/webapp/src/clj/lipas/backend/config.clj
+++ b/webapp/src/clj/lipas/backend/config.clj
@@ -43,7 +43,9 @@
      {:schools "schools"
       :population "vaestoruutu_1km"
       :population-high-def "vaestoruutu_250m"
-      :diversity "diversity"}}}
+      :diversity "diversity"}
+     :kb
+     {:kb "lipas_kb_v1"}}}
    :mailchimp
    {:api-key (env! :mailchimp-api-key)
     :api-url (env! :mailchimp-api-url)

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1609,8 +1609,21 @@
   (db/get-versioned-data db "help" "active"))
 
 (defn save-help-data
+  "Publishes help content: becomes immediately visible to all users."
   [db help-data]
   (db/add-versioned-data! db "help" "active" help-data))
+
+(defn save-help-draft
+  [db help-data]
+  (db/add-versioned-data! db "help" "draft" help-data))
+
+(defn get-help-versions
+  [db]
+  (db/list-versioned-data db "help" 100))
+
+(defn get-help-version
+  [db id]
+  (db/get-versioned-data-by-id db id))
 
 (comment
   (get-categories)

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1609,9 +1609,13 @@
   (db/get-versioned-data db "help" "active"))
 
 (defn save-help-data
-  "Publishes help content: becomes immediately visible to all users."
+  "Publishes help content: becomes immediately visible to all users.
+   Enqueues a knowledge-base sync so the AI assistant sees the new
+   content."
   [db help-data]
-  (db/add-versioned-data! db "help" "active" help-data))
+  (let [result (db/add-versioned-data! db "help" "active" help-data)]
+    (jobs/enqueue-job! db "help-kb-sync" {})
+    result))
 
 (defn save-help-draft
   [db help-data]

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1602,32 +1602,8 @@
   [type-code]
   (types/->type (types/active type-code)))
 
-;;; Help ;;;
-
-(defn get-help-data
-  [db]
-  (db/get-versioned-data db "help" "active"))
-
-(defn save-help-data
-  "Publishes help content: becomes immediately visible to all users.
-   Enqueues a knowledge-base sync so the AI assistant sees the new
-   content."
-  [db help-data]
-  (let [result (db/add-versioned-data! db "help" "active" help-data)]
-    (jobs/enqueue-job! db "help-kb-sync" {})
-    result))
-
-(defn save-help-draft
-  [db help-data]
-  (db/add-versioned-data! db "help" "draft" help-data))
-
-(defn get-help-versions
-  [db]
-  (db/list-versioned-data db "help" 100))
-
-(defn get-help-version
-  [db id]
-  (db/get-versioned-data-by-id db id))
+;; Help content lives in lipas.backend.help (v2: one versioned_data
+;; document per locale).
 
 (comment
   (get-categories)

--- a/webapp/src/clj/lipas/backend/db/db.clj
+++ b/webapp/src/clj/lipas/backend/db/db.clj
@@ -308,6 +308,27 @@
        (versioned-data/insert! db-spec)
        (versioned-data/unmarshall)))
 
+(defn list-versioned-data
+  "Version metadata (id, event-date, status, type) without bodies,
+   newest first."
+  [db-spec type limit]
+  (->> (versioned-data/list-by-type db-spec {:type type :limit limit})
+       (mapv (fn [row]
+               {:id         (str (:id row))
+                :event-date (str (:event_date row))
+                :status     (:status row)
+                :type       (:type row)}))))
+
+(defn get-versioned-data-by-id
+  "Single version with body, or nil. Returns
+   {:id ... :event-date ... :status ... :body <unmarshalled>}."
+  [db-spec id]
+  (when-let [row (versioned-data/get-by-id db-spec {:id id})]
+    {:id         (str (:id row))
+     :event-date (str (:event_date row))
+     :status     (:status row)
+     :body       (versioned-data/unmarshall row)}))
+
 ;; DB connection pooling ;;
 
 (defn- ->hikari-opts [{:keys [dbtype dbname host user port password]}]

--- a/webapp/src/clj/lipas/backend/db/versioned_data.clj
+++ b/webapp/src/clj/lipas/backend/db/versioned_data.clj
@@ -32,6 +32,33 @@
                          pages)))))
         body))
 
+(defn- unmarshall-help-v2-tree
+  ;; JSONB roundtrip stringifies keywords; only block :type/:provider
+  ;; need re-keywordizing (v2 slugs are plain strings by design).
+  [tree]
+  (mapv
+   (fn [section]
+     (update section :pages
+             (fn [pages]
+               (mapv (fn [page]
+                       (update page :blocks
+                               (fn [blocks]
+                                 (mapv (fn [{:keys [type] :as block}]
+                                         (cond-> (update block :type keyword)
+                                           (= "video" type) (update :provider keyword)))
+                                       blocks))))
+                     pages))))
+   tree))
+
+(defmethod unmarshall "help-v2-fi" [{:keys [body]}]
+  (unmarshall-help-v2-tree body))
+
+(defmethod unmarshall "help-v2-se" [{:keys [body]}]
+  (unmarshall-help-v2-tree body))
+
+(defmethod unmarshall "help-v2-en" [{:keys [body]}]
+  (unmarshall-help-v2-tree body))
+
 (defmethod unmarshall :default [{:keys [body]}]
   body)
 

--- a/webapp/src/clj/lipas/backend/gis.clj
+++ b/webapp/src/clj/lipas/backend/gis.clj
@@ -4,8 +4,10 @@
     [clojure.string :as str]
     [taoensso.timbre :as log])
   (:import
+    [org.locationtech.jts.algorithm RobustLineIntersector]
     [org.locationtech.jts.algorithm.hull ConcaveHull]
-    [org.locationtech.jts.geom Coordinate CoordinateFilter Geometry GeometryFactory PrecisionModel]
+    [org.locationtech.jts.geom Coordinate CoordinateFilter Envelope Geometry GeometryFactory PrecisionModel]
+    [org.locationtech.jts.index.strtree STRtree]
     [org.locationtech.jts.geom.util GeometryCombiner]
     [org.locationtech.jts.io WKTReader]
     [org.locationtech.jts.operation.buffer BufferOp]
@@ -298,6 +300,148 @@
      (catch Exception ex
        (log/warn ex "Failed to simplify fcoll" fcoll)
        fcoll))))
+
+;;; Route geometry quality analysis ;;;
+;;
+;; Diagnosis for the AI assistant's check_route_geometry tool — a
+;; human-explainable report, not a validator. All input is WGS84
+;; GeoJSON; distances via haversine so no projection round-trips.
+
+(defn- round-6 ^double [x] (/ (Math/round (* (double x) 1e6)) 1e6))
+(defn- round-2 ^double [x] (/ (Math/round (* (double x) 100.0)) 100.0))
+
+(defn- dist-m
+  "Haversine distance in meters between [lon lat] pairs."
+  [[lon1 lat1] [lon2 lat2]]
+  (let [la1 (Math/toRadians lat1)
+        la2 (Math/toRadians lat2)
+        sin-dlat (Math/sin (/ (- la2 la1) 2))
+        sin-dlon (Math/sin (/ (- (Math/toRadians lon2) (Math/toRadians lon1)) 2))
+        a (+ (* sin-dlat sin-dlat)
+             (* (Math/cos la1) (Math/cos la2) sin-dlon sin-dlon))]
+    (* 2 earth-mean-radius-m (Math/asin (Math/sqrt (min 1.0 a))))))
+
+(defn- line-length-m [coords]
+  (reduce + 0.0 (map dist-m coords (rest coords))))
+
+(defn- self-intersection-points
+  "Points where a linestring crosses itself. Pairwise robust check of
+   non-adjacent segments over an STRtree, so GPS tracks with thousands
+   of points stay fast. A shared endpoint between the first and last
+   segment (a closed loop) is legitimate and not reported. Returns at
+   most `cap` [lon lat] points."
+  [coords cap]
+  (let [segs (mapv (fn [i c1 c2] [i (Coordinate. (first c1) (second c1))
+                                  (Coordinate. (first c2) (second c2))])
+                   (range) coords (rest coords))
+        tree (STRtree.)
+        _ (doseq [[i ^Coordinate c1 ^Coordinate c2] segs]
+            (.insert tree (doto (Envelope. c1) (.expandToInclude c2)) i))
+        _ (.build tree)
+        li (RobustLineIntersector.)
+        seg (fn [i] (nth segs i))
+        hit (fn [i j]
+              (let [[_ ^Coordinate a1 ^Coordinate a2] (seg i)
+                    [_ ^Coordinate b1 ^Coordinate b2] (seg j)]
+                (.computeIntersection li a1 a2 b1 b2)
+                (when (.hasIntersection li)
+                  (let [^Coordinate p (.getIntersection li 0)]
+                    ;; Adjacent segments always meet at their shared
+                    ;; vertex; only a crossing elsewhere is a problem.
+                    (when-not (and (= 1 (.getIntersectionNum li))
+                                   (or (.equals2D p a1) (.equals2D p a2))
+                                   (or (.equals2D p b1) (.equals2D p b2)))
+                      [(.-x p) (.-y p)])))))]
+    (->> (for [[i ^Coordinate c1 ^Coordinate c2] segs
+               j (.query tree (doto (Envelope. c1) (.expandToInclude c2)))
+               :let [j (int j)]
+               :when (> j (inc i))]
+           (hit i j))
+         (keep identity)
+         (map (fn [[lon lat]] [(round-6 lon) (round-6 lat)]))
+         distinct
+         (take cap)
+         vec)))
+
+(defn- duplicate-vertex-points
+  "Consecutive vertices closer than 1 m — leftovers of GPS noise or
+   double clicks that make editing tools misbehave."
+  [coords cap]
+  (->> (map (fn [c1 c2] (when (< (dist-m c1 c2) 1.0) c1)) coords (rest coords))
+       (keep identity)
+       (map (fn [[lon lat]] [(round-6 lon) (round-6 lat)]))
+       distinct
+       (take cap)
+       vec))
+
+(defn- endpoint-gaps
+  "Pairs of segment (feature) endpoints from different linestrings that
+   almost touch (0.5–25 m apart) — routes that probably should connect
+   but don't quite."
+  [lines cap]
+  (let [ends (for [[i coords] (map-indexed vector lines)
+                   c [(first coords) (last coords)]]
+               [i c])]
+    (->> (for [[[i c1] & more] (iterate rest ends)
+               :while more
+               [j c2] more
+               :when (not= i j)
+               :let [d (dist-m c1 c2)]
+               :when (< 0.5 d 25.0)]
+           {:features [i j]
+            :distance-m (Math/round ^double d)
+            :location {:lon (round-6 (first c1)) :lat (round-6 (second c1))}})
+         (take cap)
+         vec)))
+
+(def ^:private dense-vertices-per-km
+  "Above this the track is raw GPS output that begs simplification;
+   hand-drawn routes run 10–50 vertices/km."
+  120)
+
+(defn route-geometry-report
+  "Quality report of a route FeatureCollection (WGS84 GeoJSON with
+   LineString features): totals, self-intersections, duplicate
+   consecutive vertices, near-miss gaps between features, vertex
+   density. Locations are bounded (max ~8 per problem type) and rounded
+   so the report stays prompt-sized."
+  [fcoll]
+  (let [lines (->> (:features fcoll)
+                   (filter #(= "LineString" (get-in % [:geometry :type])))
+                   (mapv #(mapv strip-z (get-in % [:geometry :coordinates]))))
+        cap 8
+        per-line (mapv (fn [i coords]
+                         {:feature i
+                          :vertices (count coords)
+                          :length-m (Math/round ^double (line-length-m coords))
+                          :self-intersections (self-intersection-points coords cap)
+                          :duplicate-vertices (duplicate-vertex-points coords cap)})
+                       (range) lines)
+        length-km (/ (reduce + 0 (map :length-m per-line)) 1000.0)
+        vertices (reduce + 0 (map :vertices per-line))
+        kinks (vec (mapcat (fn [{:keys [feature self-intersections]}]
+                             (map (fn [[lon lat]]
+                                    {:feature feature :lon lon :lat lat})
+                                  self-intersections))
+                           per-line))
+        dupes (vec (mapcat (fn [{:keys [feature duplicate-vertices]}]
+                             (map (fn [[lon lat]]
+                                    {:feature feature :lon lon :lat lat})
+                                  duplicate-vertices))
+                           per-line))
+        gaps (endpoint-gaps lines cap)
+        vpk (when (pos? length-km) (Math/round ^double (/ vertices length-km)))]
+    {:feature-count (count lines)
+     :vertex-count vertices
+     :length-km (round-2 length-km)
+     :vertices-per-km vpk
+     :needs-simplification? (boolean (and vpk (> vpk dense-vertices-per-km)))
+     :self-intersections {:count (count kinks) :locations (vec (take cap kinks))}
+     :duplicate-vertices {:count (count dupes) :locations (vec (take cap dupes))}
+     :endpoint-gaps {:count (count gaps) :locations gaps}
+     :ok? (and (zero? (count kinks))
+               (zero? (count dupes))
+               (zero? (count gaps)))}))
 
 (defn ->jts-multi-point [coords]
   (.createMultiPointFromCoords

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -8,6 +8,7 @@
             [lipas.backend.bulk-operations.handler :as bulk-ops-handler]
             [lipas.backend.assistant :as assistant]
             [lipas.backend.core :as core]
+            [lipas.backend.help :as help]
             [lipas.backend.search :as search*]
             [lipas.backend.jwt :as jwt]
             [lipas.backend.middleware :as mw]
@@ -1319,43 +1320,44 @@
              {:status 200
               :body (core/search-lois-with-params search body-params)})}}]
 
-        ["/actions/save-help-data"
-         {:post
-          {:no-doc true
-           :require-privilege :help/manage
-           :parameters {:body help-schema/HelpData}
-           :handler
-           (fn [{:keys [body-params]}]
-             {:status 200
-              :body (core/save-help-data db body-params)})}}]
+      ["/actions/save-help-data"
+       {:post
+        {:no-doc true
+         :require-privilege :help/manage
+         :parameters {:body help-schema/SaveHelpDataBody}
+         :handler
+         (fn [{:keys [body-params]}]
+           {:status 200
+            :body (help/save-help-data db (:locale body-params) (:data body-params))})}}]
 
-        ["/actions/get-help-data"
-         {:post
-          {:no-doc true
-           :responses {200 {:body help-schema/HelpData}}
-           :handler
-           (fn [_]
-             {:status 200
-              :body (core/get-help-data db)})}}]
+      ["/actions/get-help-data"
+       {:post
+        {:no-doc true
+         :responses {200 {:body help-schema/HelpData}}
+         :handler
+         (fn [_]
+           {:status 200
+            :body (help/get-help-data db)})}}]
 
       ["/actions/save-help-draft"
        {:post
         {:no-doc true
          :require-privilege :help/manage
-         :parameters {:body help-schema/HelpData}
+         :parameters {:body help-schema/SaveHelpDataBody}
          :handler
          (fn [{:keys [body-params]}]
            {:status 200
-            :body (core/save-help-draft db body-params)})}}]
+            :body (help/save-help-draft db (:locale body-params) (:data body-params))})}}]
 
       ["/actions/get-help-versions"
        {:post
         {:no-doc true
          :require-privilege :help/manage
+         :parameters {:body help-schema/HelpVersionsBody}
          :handler
-         (fn [_]
+         (fn [{:keys [body-params]}]
            {:status 200
-            :body (core/get-help-versions db)})}}]
+            :body (help/get-help-versions db (:locale body-params))})}}]
 
       ["/actions/get-help-version"
        {:post
@@ -1364,7 +1366,7 @@
          :parameters {:body [:map [:id :string]]}
          :handler
          (fn [{:keys [body-params]}]
-           (if-let [version (core/get-help-version
+           (if-let [version (help/get-help-version
                               db (java.util.UUID/fromString (:id body-params)))]
              {:status 200 :body version}
              {:status 404 :body {:error "Version not found"}}))}}]

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -5,6 +5,8 @@
             [lipas.backend.api.v1.routes :as v1]
             [lipas.backend.api.v2 :as v2]
             [lipas.backend.bulk-operations.core :as bulk-ops]
+            [lipas.backend.bulk-operations.handler :as bulk-ops-handler]
+            [lipas.backend.assistant :as assistant]
             [lipas.backend.core :as core]
             [lipas.backend.search :as search*]
             [lipas.backend.jwt :as jwt]
@@ -1366,6 +1368,49 @@
                               db (java.util.UUID/fromString (:id body-params)))]
              {:status 200 :body version}
              {:status 404 :body {:error "Version not found"}}))}}]
+
+      ["/actions/assistant-chat"
+       {:post
+        {:no-doc true
+         :require-privilege :ai-assistant/use
+         :parameters {:body [:map
+                             [:message [:string {:min 1 :max 2000}]]
+                             [:history {:optional true}
+                              [:vector
+                               [:map
+                                [:role [:enum "user" "assistant"]]
+                                [:text :string]]]]
+                             [:context {:optional true} assistant/context-schema]]}
+         :handler
+         (fn [req]
+           (let [{:keys [message history context]} (:body-params req)]
+             (assistant/chat! {:db db
+                               :search search
+                               :user (:identity req)
+                               :message message
+                               :history (or history [])
+                               :context context})))}}]
+
+      ["/actions/assistant-escalate"
+       {:post
+        {:no-doc true
+         :require-privilege :ai-assistant/use
+         :parameters {:body [:map
+                             [:summary [:string {:min 1 :max 2000}]]
+                             [:transcript {:optional true}
+                              [:vector
+                               [:map
+                                [:role [:enum "user" "assistant"]]
+                                [:text :string]]]]
+                             [:context {:optional true} assistant/context-schema]]}
+         :handler
+         (fn [req]
+           (let [{:keys [summary transcript context]} (:body-params req)]
+             (assistant/escalate! {:db db
+                                   :user (:identity req)
+                                   :summary summary
+                                   :transcript (or transcript [])
+                                   :context context})))}}]
 
       ;; Heatmap analysis
         ["/actions/create-heatmap"

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -1336,6 +1336,37 @@
              {:status 200
               :body (core/get-help-data db)})}}]
 
+      ["/actions/save-help-draft"
+       {:post
+        {:no-doc true
+         :require-privilege :help/manage
+         :parameters {:body help-schema/HelpData}
+         :handler
+         (fn [{:keys [body-params]}]
+           {:status 200
+            :body (core/save-help-draft db body-params)})}}]
+
+      ["/actions/get-help-versions"
+       {:post
+        {:no-doc true
+         :require-privilege :help/manage
+         :handler
+         (fn [_]
+           {:status 200
+            :body (core/get-help-versions db)})}}]
+
+      ["/actions/get-help-version"
+       {:post
+        {:no-doc true
+         :require-privilege :help/manage
+         :parameters {:body [:map [:id :string]]}
+         :handler
+         (fn [{:keys [body-params]}]
+           (if-let [version (core/get-help-version
+                              db (java.util.UUID/fromString (:id body-params)))]
+             {:status 200 :body version}
+             {:status 404 :body {:error "Version not found"}}))}}]
+
       ;; Heatmap analysis
         ["/actions/create-heatmap"
          {:post

--- a/webapp/src/clj/lipas/backend/help.clj
+++ b/webapp/src/clj/lipas/backend/help.clj
@@ -1,0 +1,143 @@
+(ns lipas.backend.help
+  "Help content v2 storage: one versioned_data document per locale
+   (help-v2-fi / help-v2-se / help-v2-en) so each language drafts,
+   publishes and rolls back independently. See lipas.schema.help for
+   the shape and the v1→v2 rationale."
+  (:require [clojure.string :as str]
+            [lipas.backend.db.db :as db]
+            [lipas.jobs.core :as jobs]
+            [lipas.schema.help :as help-schema]
+            [lipas.utils :as utils]
+            [malli.core :as m]))
+
+(def locale->type
+  {:fi "help-v2-fi"
+   :se "help-v2-se"
+   :en "help-v2-en"})
+
+(defn get-help-data
+  "Every locale's published tree; a locale with no published content
+   maps to []."
+  [db]
+  (into {}
+        (for [[locale type] locale->type]
+          [locale (or (db/get-versioned-data db type "active") [])])))
+
+(defn save-help-data
+  "Publishes one locale's tree: becomes immediately visible to all
+   users. Enqueues a knowledge-base sync so the AI assistant sees the
+   new content."
+  [db locale data]
+  (let [result (db/add-versioned-data! db (locale->type locale) "active" data)]
+    (jobs/enqueue-job! db "help-kb-sync" {})
+    result))
+
+(defn save-help-draft
+  [db locale data]
+  (db/add-versioned-data! db (locale->type locale) "draft" data))
+
+(defn get-help-versions
+  [db locale]
+  (db/list-versioned-data db (locale->type locale) 100))
+
+(defn get-help-version
+  [db id]
+  (db/get-versioned-data-by-id db id))
+
+;;; ——— v1 → v2 migration ———————————————————————————————————————————————
+
+(defn- unique-slug
+  [title fallback taken]
+  (let [base (let [s (utils/->slug title)]
+               (if (str/blank? s) (utils/->slug fallback) s))
+        base (if (str/blank? base) "osio" base)]
+    (->> (cons base (map #(str base "-" %) (iterate inc 2)))
+         (remove taken)
+         first)))
+
+(defn- v1-block->v2
+  "Collapses a v1 block's {:fi :se :en} leaves to locale's plain
+   strings. Text blocks with no content in the locale are dropped;
+   media blocks are kept (the media itself is the content)."
+  [locale block]
+  (let [loc #(get % locale)]
+    (case (:type block)
+      :text (when-not (str/blank? (loc (:content block)))
+              {:block-id (:block-id block)
+               :type :text
+               :content (loc (:content block))})
+      :image (cond-> {:block-id (:block-id block)
+                      :type :image
+                      :url (:url block)
+                      :alt (or (loc (:alt block)) "")}
+               (not (str/blank? (loc (:caption block))))
+               (assoc :caption (loc (:caption block))))
+      :video (cond-> {:block-id (:block-id block)
+                      :type :video
+                      :provider (:provider block)
+                      :video-id (:video-id block)}
+               (not (str/blank? (loc (:title block))))
+               (assoc :title (loc (:title block))))
+      :pdf (cond-> {:block-id (:block-id block)
+                    :type :pdf
+                    :url (:url block)}
+             (not (str/blank? (loc (:title block))))
+             (assoc :title (loc (:title block)))
+             (not (str/blank? (loc (:caption block))))
+             (assoc :caption (loc (:caption block))))
+      {:block-id (:block-id block)
+       :type (:type block)})))
+
+(defn v1->v2-tree
+  "One locale's independent tree from the v1 shared-structure data.
+   Slugs are regenerated from the locale's titles (v1 slugs are
+   new-page-<timestamp> junk); the old slug is kept in :aliases so
+   published ?ohje= links and KB citations keep resolving."
+  [v1-data locale]
+  (let [section-slugs (atom #{})]
+    (vec
+     (for [section v1-data
+           :let [old-slug (name (:slug section))
+                 title (get-in section [:title locale])
+                 slug (unique-slug title old-slug @section-slugs)
+                 _ (swap! section-slugs conj slug)
+                 page-slugs (atom #{})]]
+       {:id (str (random-uuid))
+        :slug slug
+        :title (or title "")
+        :aliases (vec (distinct (remove #{slug} [old-slug])))
+        :pages (vec
+                (for [page (:pages section)
+                      :let [old-page-slug (name (:slug page))
+                            page-title (get-in page [:title locale])
+                            page-slug (unique-slug page-title old-page-slug @page-slugs)
+                            _ (swap! page-slugs conj page-slug)]]
+                  {:id (str (random-uuid))
+                   :slug page-slug
+                   :title (or page-title "")
+                   :aliases (vec (distinct (remove #{page-slug} [old-page-slug])))
+                   :blocks (vec (keep (partial v1-block->v2 locale)
+                                      (:blocks page)))}))}))))
+
+(defn migrate-v1->v2!
+  "One-shot migration: publishes the v1 active document as the fi v2
+   tree and empty se/en trees (prod se/en content is placeholder junk —
+   translations start from a clean slate). v1 history is untouched.
+   Refuses to run when v2 content already exists unless :force? true."
+  [db & {:keys [force?]}]
+  (let [v1 (db/get-versioned-data db "help" "active")]
+    (when (nil? v1)
+      (throw (ex-info "No v1 help data to migrate" {})))
+    (when (and (not force?)
+               (some #(seq (db/get-versioned-data db % "active"))
+                     (vals locale->type)))
+      (throw (ex-info "help-v2 content already exists; pass :force? true to overwrite"
+                      {})))
+    (let [fi-tree (v1->v2-tree v1 :fi)]
+      (when-not (m/validate help-schema/LocaleTree fi-tree)
+        (throw (ex-info "Migrated fi tree does not validate"
+                        {:explain (m/explain help-schema/LocaleTree fi-tree)})))
+      (db/add-versioned-data! db "help-v2-fi" "active" fi-tree)
+      (db/add-versioned-data! db "help-v2-se" "active" [])
+      (db/add-versioned-data! db "help-v2-en" "active" [])
+      {:fi (count fi-tree) :se 0 :en 0})))

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -9,13 +9,15 @@
 
    Index mapping lives in lipas.backend.search/kb-mapping and the index
    is created by system startup like every other index."
-  (:require [clojure.set :as set]
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
             [clojure.string :as str]
             [lipas.backend.db.db :as db]
             [lipas.backend.llm :as llm]
             [lipas.backend.search :as search]
             [lipas.data.prop-types :as prop-types]
             [lipas.data.types :as types]
+            [lipas.roles :as roles]
             [taoensso.timbre :as log]))
 
 (def langs [:fi :se :en])
@@ -153,9 +155,92 @@
                            (mapv first))
        :review-status "reviewed"})))
 
+(def ^:private nav-docs
+  "Where-is-what map of the app. Hand-written but lives in code so it
+   stays next to the route definitions it describes (lipas.ui.*.routes);
+   update it when top-level navigation changes. Grounds the assistant's
+   'mistä löydän / missä näen' answers and its navigate_to_view tool."
+  [{:id "nav:structure:fi"
+    :title "Mistä löydän eri toiminnot? LIPAS-palvelun näkymät ja navigointi"
+    :body (str "LIPAS-palvelun päänäkymät:\n\n"
+               "- Etusivu (/etusivu): ajankohtaiset uutiset ja yleistä tietoa palvelusta.\n"
+               "- Liikuntapaikat eli karttanäkymä (/liikuntapaikat): liikuntapaikkojen haku, "
+               "tarkastelu ja tietojen muokkaus kartalla. Liikuntapaikkatietojen ylläpito "
+               "tapahtuu tässä näkymässä.\n"
+               "- Tilastot (/tilastot): valmiit tilastonäkymät, alavälilehdet: "
+               "Liikuntapaikat (/tilastot/liikuntapaikat), Rakennusvuodet "
+               "(/tilastot/rakennusvuodet), Kuntien vertailu (/tilastot/kunta), "
+               "Talous (/tilastot/talous) ja Avustukset (/tilastot/avustukset).\n"
+               "- Omat tiedot (/profiili): omat käyttäjätiedot ja käyttöoikeudet.\n"
+               "- Organisaatiot (/organisaatiot): oman organisaation tietojen hallinta "
+               "organisaation jäsenille.\n"
+               "- Ohjeet: ohjekeskus avautuu omaan ikkunaansa mistä tahansa näkymästä "
+               "(?ohje-linkit).")
+    :lang "fi"
+    :source-type "code-data"
+    :source-ref "nav:structure"
+    :deep-link nil
+    :type-codes []
+    :review-status "reviewed"}
+   {:id "nav:structure:en"
+    :title "Where do I find things? LIPAS views and navigation"
+    :body (str "Main views of the LIPAS service:\n\n"
+               "- Front page (/etusivu): news and general information about the service.\n"
+               "- Sports facilities i.e. the map view (/liikuntapaikat): search, view and "
+               "edit sports facility data on the map. Data maintenance happens in this view.\n"
+               "- Statistics (/tilastot): ready-made statistics views, tabs: "
+               "Sports facilities (/tilastot/liikuntapaikat), Construction years "
+               "(/tilastot/rakennusvuodet), City comparison (/tilastot/kunta), "
+               "Finance (/tilastot/talous) and Subsidies (/tilastot/avustukset).\n"
+               "- Profile (/profiili): your own user data and permissions.\n"
+               "- Organizations (/organisaatiot): organization management for its members.\n"
+               "- Help: the help center opens in its own dialog from any view (?ohje links).")
+    :lang "en"
+    :source-type "code-data"
+    :source-ref "nav:structure"
+    :deep-link nil
+    :type-codes []
+    :review-status "reviewed"}])
+
+(def ^:private role-i18n
+  "Official Finnish role and scoping names; single source: the UI
+   translation file."
+  (delay (-> (io/resource "lipas/i18n/fi/lipas_user_permissions_roles.edn")
+             slurp
+             read-string)))
+
+(defn- role->doc
+  "One doc per assignable role: what the role allows (privilege docs
+   from lipas.roles) and how it is scoped. Regenerated on every sync so
+   role changes in code can't go stale here."
+  [[role-kw {:keys [privileges required-context-keys assignable]}]]
+  (when assignable
+    (let [nm (get-in @role-i18n [:role-names role-kw] (name role-kw))
+          scope-names (keep #(get-in @role-i18n [:context-keys %]) required-context-keys)
+          privs (->> privileges
+                     (keep #(get-in roles/privileges [% :doc]))
+                     sort)]
+      {:id (str "role:" (name role-kw) ":fi")
+       :title (str "Käyttäjärooli " nm " — mitä se sallii?")
+       :body (str "Rooli " nm " (" (name role-kw) ") antaa seuraavat oikeudet:\n"
+                  (str/join "\n" (map #(str "- " %) privs))
+                  (if (seq scope-names)
+                    (str "\n\nRooli myönnetään rajattuna: "
+                         (str/join ", " scope-names)
+                         ". Oikeudet koskevat vain rajauksen mukaisia kohteita.")
+                    "\n\nRooli ei ole kunta- tai tyyppirajattu."))
+       :lang "fi"
+       :source-type "code-data"
+       :source-ref (str "role:" (name role-kw))
+       :deep-link nil
+       :type-codes []
+       :review-status "reviewed"})))
+
 (defn code-data->docs
   []
   (concat
+   nav-docs
+   (keep role->doc roles/roles)
    (for [lang langs, entry types/active
          :let [doc (type->doc lang entry)] :when doc]
      doc)

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -1,0 +1,222 @@
+(ns lipas.backend.kb
+  "Knowledge base for the AI help assistant.
+
+   One ES document = one task/question-sized entry in one language.
+   Sources: the help CMS (published content, synced continuously) and
+   code-derived docs regenerated from lipas.data.* on every sync — those
+   can never go stale. Embeddings via lipas.backend.llm; documents carry
+   a content hash so unchanged entries are never re-embedded.
+
+   Index mapping lives in lipas.backend.search/kb-mapping and the index
+   is created by system startup like every other index."
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [lipas.backend.db.db :as db]
+            [lipas.backend.llm :as llm]
+            [lipas.backend.search :as search]
+            [lipas.data.prop-types :as prop-types]
+            [lipas.data.types :as types]
+            [taoensso.timbre :as log]))
+
+(def langs [:fi :se :en])
+
+(def embedding-model (:model llm/embedding-defaults))
+
+(defn- sha-256
+  [^String s]
+  (let [digest (.digest (java.security.MessageDigest/getInstance "SHA-256")
+                        (.getBytes s "UTF-8"))]
+    (apply str (map #(format "%02x" %) digest))))
+
+(defn- content-hash
+  [{:keys [id title body lang source-type deep-link type-codes]}]
+  (sha-256 (str/join "\n" [id title body lang source-type deep-link
+                           (str/join "," (sort type-codes))])))
+
+;;; ——— Help CMS → docs ———————————————————————————————————————————————
+
+(defn- block->text
+  [lang block]
+  (case (:type block)
+    :text  (get-in block [:content lang])
+    :video (str "Video: " (get-in block [:title lang] "")
+                " https://www.youtube.com/watch?v=" (:video-id block))
+    :image (get-in block [:caption lang])
+    :pdf   (when-let [title (get-in block [:title lang])]
+             (str "PDF: " title " " (:url block)))
+    nil))
+
+(defn help-cms->docs
+  "One doc per page per language. Languages whose title or entire body is
+   blank are skipped — retrieval should never surface an empty entry."
+  [help-data]
+  (for [section help-data
+        page    (:pages section)
+        lang    langs
+        :let [slug-path (str (name (:slug section)) "/" (name (:slug page)))
+              title     (get-in page [:title lang])
+              body      (->> (:blocks page)
+                             (keep (partial block->text lang))
+                             (map str/trim)
+                             (remove str/blank?)
+                             (str/join "\n\n"))]
+        :when (and (not (str/blank? title))
+                   (not (str/blank? body)))]
+    {:id            (str "help-cms:" slug-path ":" (name lang))
+     :title         title
+     :body          body
+     :lang          (name lang)
+     :source-type   "help-cms"
+     :source-ref    slug-path
+     :deep-link     (str "?ohje=" slug-path)
+     :type-codes    []
+     :review-status "reviewed"}))
+
+;;; ——— Code-derived docs ————————————————————————————————————————————
+
+(def ^:private labels
+  {:main-category {:fi "Pääluokka" :se "Huvudkategori" :en "Main category"}
+   :sub-category  {:fi "Alaluokka" :se "Underkategori" :en "Sub category"}
+   :geometry      {:fi "Geometria kartalla" :se "Geometri på kartan" :en "Geometry on map"}
+   :props         {:fi "Ominaisuustiedot" :se "Egenskaper" :en "Properties"}
+   :data-type     {:fi "Tietotyyppi" :se "Datatyp" :en "Data type"}
+   :used-by       {:fi "Käytössä liikuntapaikkatyypeillä"
+                   :se "Används av idrottsplatstyper"
+                   :en "Used by sports facility types"}})
+
+(def ^:private geometry-names
+  {"Point"      {:fi "piste" :se "punkt" :en "point"}
+   "LineString" {:fi "reitti" :se "rutt" :en "route"}
+   "Polygon"    {:fi "alue" :se "område" :en "area"}})
+
+(defn- type->doc
+  [lang [type-code m]]
+  (let [type-name (get-in m [:name lang])
+        prop-names (->> (:props m)
+                        keys
+                        (keep #(get-in prop-types/all [% :name lang]))
+                        sort)
+        body (->> [(get-in m [:description lang])
+                   (str (get-in labels [:main-category lang]) ": "
+                        (get-in types/main-categories [(:main-category m) :name lang])
+                        ". " (get-in labels [:sub-category lang]) ": "
+                        (get-in types/sub-categories [(:sub-category m) :name lang]) ".")
+                   (str (get-in labels [:geometry lang]) ": "
+                        (get-in geometry-names [(:geometry-type m) lang]
+                                (:geometry-type m)) ".")
+                   (when (seq prop-names)
+                     (str (get-in labels [:props lang]) ": "
+                          (str/join ", " prop-names) "."))]
+                  (remove str/blank?)
+                  (str/join "\n\n"))]
+    (when-not (str/blank? type-name)
+      {:id            (str "type:" type-code ":" (name lang))
+       :title         (str type-code " — " type-name)
+       :body          body
+       :lang          (name lang)
+       :source-type   "code-data"
+       :source-ref    (str "type:" type-code)
+       :deep-link     nil
+       :type-codes    [type-code]
+       :review-status "reviewed"})))
+
+(defn- prop->doc
+  [lang [prop-k m]]
+  (let [prop-name (get-in m [:name lang])
+        used-by (->> types/active
+                     (filter (fn [[_ t]] (contains? (:props t) prop-k)))
+                     (keep (fn [[tc t]]
+                             (when-let [n (get-in t [:name lang])]
+                               (str tc " " n))))
+                     sort)
+        body (->> [(get-in m [:description lang])
+                   (str (get-in labels [:data-type lang]) ": " (:data-type m) ".")
+                   (when (seq used-by)
+                     (str (get-in labels [:used-by lang]) ": "
+                          (str/join ", " used-by) "."))]
+                  (remove str/blank?)
+                  (str/join "\n\n"))]
+    (when-not (str/blank? prop-name)
+      {:id            (str "prop:" (name prop-k) ":" (name lang))
+       :title         prop-name
+       :body          body
+       :lang          (name lang)
+       :source-type   "code-data"
+       :source-ref    (str "prop:" (name prop-k))
+       :deep-link     nil
+       :type-codes    (->> types/active
+                           (filter (fn [[_ t]] (contains? (:props t) prop-k)))
+                           (mapv first))
+       :review-status "reviewed"})))
+
+(defn code-data->docs
+  []
+  (concat
+   (for [lang langs, entry types/active
+         :let [doc (type->doc lang entry)] :when doc]
+     doc)
+   (for [lang langs, entry prop-types/all
+         :let [doc (prop->doc lang entry)] :when doc]
+     doc)))
+
+;;; ——— Sync —————————————————————————————————————————————————————————
+
+(defn- existing-doc-hashes
+  "Map of doc id → {:content-hash ... :embedding-model ...} for everything
+   currently in the index."
+  [client idx]
+  (->> (search/search client idx
+                      {:size    10000
+                       :query   {:match_all {}}
+                       :_source [:content-hash :embedding-model]})
+       :body :hits :hits
+       (map (fn [hit] [(:_id hit) (:_source hit)]))
+       (into {})))
+
+(defn- unchanged?
+  [existing doc]
+  (when-let [e (get existing (:id doc))]
+    (and (= (:content-hash e) (:content-hash doc))
+         (= (:embedding-model e) (:embedding-model doc)))))
+
+(defn sync!
+  "Rebuild the knowledge base: published help CMS content + code-derived
+   docs. Embeds only new/changed docs (content-hash diff), deletes docs
+   whose source entry no longer exists. Idempotent; safe to run any time."
+  [db search]
+  (let [client    (:client search)
+        idx       (get-in search [:indices :kb :kb])
+        now       (str (java.time.Instant/now))
+        docs      (->> (concat (help-cms->docs (db/get-versioned-data db "help" "active"))
+                               (code-data->docs))
+                       (map #(assoc %
+                                    :content-hash (content-hash %)
+                                    :embedding-model embedding-model
+                                    :updated-at now)))
+        existing  (existing-doc-hashes client idx)
+        changed   (remove (partial unchanged? existing) docs)
+        orphans   (set/difference (set (keys existing))
+                                  (set (map :id docs)))]
+    (when (seq changed)
+      (let [vectors (llm/embed llm/gemini-config
+                               (mapv :body changed)
+                               :titles (mapv :title changed))
+            with-embeddings (mapv (fn [doc v] (assoc doc :embedding v))
+                                  changed vectors)]
+        (search/bulk-index-sync!
+         client (search/->bulk idx :id with-embeddings))))
+    (doseq [id orphans]
+      (search/delete! client idx id))
+    (let [result {:total    (count docs)
+                  :embedded (count changed)
+                  :deleted  (count orphans)}]
+      (log/info "KB sync complete" result)
+      result)))
+
+(comment
+  (require '[integrant.repl.state :as state])
+  (def db* (:lipas/db state/system))
+  (def search* (:lipas/search state/system))
+  (sync! db* search*)
+  (count (code-data->docs))
+  (take 2 (help-cms->docs (db/get-versioned-data db* "help" "active"))))

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -312,6 +312,17 @@
                           body)))
       (dissoc :body :score)))
 
+(defn get-doc
+  "Full KB entry (including untruncated body) by id, or nil."
+  [search id]
+  (let [idx (get-in search [:indices :kb :kb])
+        resp (search/search (:client search) idx
+                            {:size 1
+                             :query {:term {:id id}}
+                             :_source [:id :title :body :lang :source-type
+                                       :source-ref :deep-link :type-codes]})]
+    (-> resp :body :hits :hits first :_source)))
+
 (defn search-kb
   "Retrieve KB entries for a natural-language query. Hybrid BM25 + kNN
    with client-side reciprocal rank fusion by default; :method :bm25 or

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -13,6 +13,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [lipas.backend.db.db :as db]
+            [lipas.backend.help :as help]
             [lipas.backend.llm :as llm]
             [lipas.backend.search :as search]
             [lipas.data.prop-types :as prop-types]
@@ -38,28 +39,37 @@
 ;;; ——— Help CMS → docs ———————————————————————————————————————————————
 
 (defn- block->text
-  [lang block]
+  ;; A block contributes only when it has real text — bare URLs
+  ;; (video/pdf) would otherwise make every page look non-blank and
+  ;; defeat the skip rule in help-cms->docs.
+  [block]
   (case (:type block)
-    :text  (get-in block [:content lang])
-    :video (str "Video: " (get-in block [:title lang] "")
-                " https://www.youtube.com/watch?v=" (:video-id block))
-    :image (get-in block [:caption lang])
-    :pdf   (when-let [title (get-in block [:title lang])]
-             (str "PDF: " title " " (:url block)))
+    :text  (:content block)
+    :video (when-not (str/blank? (:title block))
+             (str "Video: " (:title block)
+                  " https://www.youtube.com/watch?v=" (:video-id block)))
+    :image (:caption block)
+    :pdf   (when-not (str/blank? (:title block))
+             (str "PDF: " (:title block) " " (:url block)))
     nil))
 
 (defn help-cms->docs
-  "One doc per page per language. Languages whose title or entire body is
-   blank are skipped — retrieval should never surface an empty entry."
+  "One doc per page per language, from the v2 per-locale trees
+   ({:fi tree :se tree :en tree}). Pages whose title or entire body is
+   blank are skipped — retrieval should never surface an empty entry.
+   The language tag is trustworthy by construction: each locale's tree
+   contains only that locale's content."
   [help-data]
-  (for [section help-data
-        page    (:pages section)
-        lang    langs
-        :let [slug-path (str (name (:slug section)) "/" (name (:slug page)))
-              title     (get-in page [:title lang])
+  (for [[lang tree] help-data
+        section     tree
+        page        (:pages section)
+        :let [slug-path (str (:slug section) "/" (:slug page))
+              title     (:title page)
               body      (->> (:blocks page)
-                             (keep (partial block->text lang))
+                             (keep block->text)
                              (map str/trim)
+                             (remove str/blank?)
+                             (cons (:summary page))
                              (remove str/blank?)
                              (str/join "\n\n"))]
         :when (and (not (str/blank? title))
@@ -292,7 +302,7 @@
   (let [client    (:client search)
         idx       (get-in search [:indices :kb :kb])
         now       (str (java.time.Instant/now))
-        docs      (->> (concat (help-cms->docs (db/get-versioned-data db "help" "active"))
+        docs      (->> (concat (help-cms->docs (help/get-help-data db))
                                (code-data->docs)
                                (ingested->docs db))
                        (map #(assoc %
@@ -439,6 +449,6 @@
   (def search* (:lipas/search state/system))
   (sync! db* search*)
   (count (code-data->docs))
-  (take 2 (help-cms->docs (db/get-versioned-data db* "help" "active")))
+  (take 2 (help-cms->docs (help/get-help-data db*)))
   (search-kb search* {:query "mikä tyyppikoodi padel-kentälle?"})
   (search-kb search* {:query "how do I add a route?" :lang "en"}))

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -97,6 +97,10 @@
                         (keep #(get-in prop-types/all [% :name lang]))
                         sort)
         body (->> [(get-in m [:description lang])
+                   ;; Colloquial synonyms — often the only bridge from how
+                   ;; users phrase things to the official type name.
+                   (when-let [tags (seq (get-in m [:tags lang]))]
+                     (str/join ", " tags))
                    (str (get-in labels [:main-category lang]) ": "
                         (get-in types/main-categories [(:main-category m) :name lang])
                         ". " (get-in labels [:sub-category lang]) ": "
@@ -213,10 +217,115 @@
       (log/info "KB sync complete" result)
       result)))
 
+;;; ——— Retrieval ————————————————————————————————————————————————————
+
+(def ^:private retrieval-source-fields
+  [:id :title :body :lang :source-type :source-ref :deep-link :type-codes])
+
+(def ^:private rrf-k
+  "Reciprocal-rank-fusion constant; the standard default. Higher values
+   flatten the difference between rank positions."
+  60)
+
+(defn- bm25-hits
+  [client idx query k]
+  (-> (search/search client idx
+                     {:size    k
+                      :query   {:multi_match
+                                {:query  query
+                                 :fields ["title^2" "title.se^2" "title.en^2"
+                                          "body" "body.se" "body.en"]}}
+                      :_source retrieval-source-fields})
+      :body :hits :hits))
+
+(defn- knn-hits
+  [client idx query-vector k]
+  (-> (search/search client idx
+                     {:knn     {:field          "embedding"
+                                :query_vector   query-vector
+                                :k              k
+                                :num_candidates 200}
+                      :size    k
+                      :_source retrieval-source-fields})
+      :body :hits :hits))
+
+(defn- rrf-merge
+  "Reciprocal rank fusion over one or more ranked hit lists.
+   Returns _source docs with :score, best first."
+  [hit-lists]
+  (->> hit-lists
+       (mapcat (fn [hits]
+                 (map-indexed (fn [i hit]
+                                {:id    (:_id hit)
+                                 :score (/ 1.0 (+ rrf-k i 1))
+                                 :doc   (:_source hit)})
+                              hits)))
+       (group-by :id)
+       vals
+       (map (fn [entries]
+              (assoc (:doc (first entries))
+                     :score (reduce + (map :score entries)))))
+       (sort-by :score >)))
+
+(defn- dedup-by-source-ref
+  "The same entry exists once per language; keep one doc per source-ref
+   (they rank adjacently), preferring the requested language."
+  [lang docs]
+  (let [{:keys [seen order]}
+        (reduce (fn [{:keys [seen order] :as acc} doc]
+                  (let [ref (:source-ref doc)]
+                    (if-let [kept (get seen ref)]
+                      (if (and (= lang (:lang doc))
+                               (not= lang (:lang kept)))
+                        (assoc-in acc [:seen ref]
+                                  (assoc doc :score (:score kept)))
+                        acc)
+                      {:seen  (assoc seen ref doc)
+                       :order (conj order ref)})))
+                {:seen {} :order []}
+                docs)]
+    (mapv seen order)))
+
+(defn- ->result
+  [doc]
+  (-> doc
+      (assoc :snippet (let [body (:body doc)]
+                        (if (> (count body) 400)
+                          (str (subs body 0 400) "…")
+                          body)))
+      (dissoc :body :score)))
+
+(defn search-kb
+  "Retrieve KB entries for a natural-language query. Hybrid BM25 + kNN
+   with client-side reciprocal rank fusion by default; :method :bm25 or
+   :knn restricts to one ranker (used by the retrieval eval).
+
+   kNN runs without a language filter — embeddings are cross-lingual, so
+   a Swedish question finds the Finnish-only entry; duplicates across
+   languages collapse in dedup, preferring `lang`."
+  [search {:keys [query lang limit method]
+           :or   {lang "fi" limit 5 method :hybrid}}]
+  (let [client (:client search)
+        idx    (get-in search [:indices :kb :kb])
+        k      20
+        lists  (cond-> []
+                 (#{:hybrid :bm25} method)
+                 (conj (bm25-hits client idx query k))
+                 (#{:hybrid :knn} method)
+                 (conj (knn-hits client idx
+                                 (llm/embed-one llm/gemini-config query)
+                                 k)))]
+    (->> (rrf-merge lists)
+         (dedup-by-source-ref lang)
+         (take limit)
+         (mapv ->result))))
+
 (comment
   (require '[integrant.repl.state :as state])
   (def db* (:lipas/db state/system))
   (def search* (:lipas/search state/system))
   (sync! db* search*)
   (count (code-data->docs))
-  (take 2 (help-cms->docs (db/get-versioned-data db* "help" "active"))))
+  (take 2 (help-cms->docs (db/get-versioned-data db* "help" "active")))
+  (search-kb search* {:query "mikä tyyppikoodi padel-kentälle?"})
+  (search-kb search* {:query "how do I add a route?" :lang "en"}))

--- a/webapp/src/clj/lipas/backend/kb.clj
+++ b/webapp/src/clj/lipas/backend/kb.clj
@@ -163,6 +163,22 @@
          :let [doc (prop->doc lang entry)] :when doc]
      doc)))
 
+;;; ——— Ingested docs (jyu.fi PDFs, YouTube transcripts) ————————————
+;;
+;; One-off ingestion (dev/lipas/kb_ingest.clj) writes finished,
+;; doc-shaped entries into versioned_data as type "kb-ingest", so the
+;; index stays a deterministic function of Postgres + code and can be
+;; rebuilt from scratch at any time.
+
+(def ^:private ingested-doc-keys
+  [:id :title :body :lang :source-type :source-ref :deep-link
+   :type-codes :review-status])
+
+(defn ingested->docs
+  [db]
+  (->> (db/get-versioned-data db "kb-ingest" "active")
+       (map #(select-keys % ingested-doc-keys))))
+
 ;;; ——— Sync —————————————————————————————————————————————————————————
 
 (defn- existing-doc-hashes
@@ -192,7 +208,8 @@
         idx       (get-in search [:indices :kb :kb])
         now       (str (java.time.Instant/now))
         docs      (->> (concat (help-cms->docs (db/get-versioned-data db "help" "active"))
-                               (code-data->docs))
+                               (code-data->docs)
+                               (ingested->docs db))
                        (map #(assoc %
                                     :content-hash (content-hash %)
                                     :embedding-model embedding-model

--- a/webapp/src/clj/lipas/backend/llm.clj
+++ b/webapp/src/clj/lipas/backend/llm.clj
@@ -1,0 +1,308 @@
+(ns lipas.backend.llm
+  "Generic LLM provider plumbing: provider/model registry, chat completion
+   for OpenAI and Gemini (with retry and cross-provider fallback), and
+   Gemini embeddings.
+
+   Prompt content, response schemas and domain defaults belong to feature
+   namespaces (e.g. lipas.backend.ptv.ai); this namespace stays
+   feature-agnostic."
+  (:require [cheshire.core :as json]
+            [clj-http.client :as client]
+            [lipas.backend.config :as config]
+            [taoensso.timbre :as log]))
+
+;;; ——— Provider & model registry ———————————————————————————————————————
+;;
+;; Single source of truth for all provider/model configuration.
+;;
+;; :models          — set of model IDs this provider supports
+;; :default-params  — workbench defaults sent to the frontend
+;; :new-api-models  — (OpenAI) models using max_completion_tokens
+;; :no-sampling     — (OpenAI) models that reject top_p / presence_penalty
+
+(def providers
+  {:openai
+   {:models         #{"gpt-4.1-nano" "gpt-4.1-mini" "gpt-4.1" "gpt-4o-mini" "gpt-4o"
+                      "gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
+                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
+    :new-api-models #{"gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
+                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
+    :no-sampling    #{"gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
+                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
+    :default-params {:model            "gpt-4.1-mini"
+                     :top-p            0.5
+                     :presence-penalty -2
+                     :max-tokens       4096
+                     :temperature      nil}}
+   :gemini
+   {:models         #{"gemini-3-flash-preview"}
+    :default-params {:model          "gemini-3-flash-preview"
+                     :top-p          0.90
+                     :temperature    1.0
+                     :max-tokens     8192
+                     :thinking-level "minimal"}}})
+
+(def model->provider
+  "Reverse lookup: model-id → provider keyword. Derived from `providers`."
+  (into {}
+        (for [[provider {:keys [models]}] providers
+              model models]
+          [model provider])))
+
+(def default-params
+  "Default workbench params (OpenAI). Sent to frontend on preview-data load."
+  (-> providers :openai :default-params))
+
+(def gemini-default-params
+  "Default Gemini model params. Use this instead of hardcoding model names."
+  (-> providers :gemini :default-params))
+
+;;; ——— API credentials ——————————————————————————————————————————————————
+
+(def openai-config
+  (get-in config/default-config [:open-ai]))
+
+(def gemini-config
+  (get-in config/default-config [:gemini]))
+
+(def default-headers
+  {:Authorization (str "Bearer " (:api-key openai-config))
+   :Content-Type  "application/json"})
+
+;;; ——— Schema helpers ———————————————————————————————————————————————————
+
+(defn localized-string-schema
+  "Malli schema for a closed {:fi :se :en} string map — the standard shape
+   for multilingual LLM output fields."
+  [string-props]
+  [:map
+   {:closed true}
+   [:fi [:string string-props]]
+   [:se [:string string-props]]
+   [:en [:string string-props]]])
+
+;;; ——— Chat completion ——————————————————————————————————————————————————
+
+(defn complete-raw
+  "Calls OpenAI chat completions. Returns the full response including
+   :choices, :usage, and :model. When :message-format is absent no
+   response_format is sent and the model returns plain text."
+  [{:keys [completions-url model n temperature top-p presence-penalty message-format max-tokens]
+    :or   {n                1
+           top-p            0.5
+           presence-penalty -2
+           max-tokens       4096}}
+   system-instruction
+   prompt]
+  (let [{:keys [new-api-models no-sampling]} (providers :openai)
+        new-api? (new-api-models model)
+        body   (cond-> {:model    model
+                        :n        n
+                        :messages [{:role "system" :content system-instruction}
+                                   {:role "user" :content prompt}]}
+                 message-format       (assoc :response_format message-format)
+                 new-api?             (assoc :max_completion_tokens max-tokens)
+                 (not new-api?)       (assoc :max_tokens max-tokens)
+                 (not (no-sampling model))
+                 (-> (assoc :top_p top-p)
+                     (assoc :presence_penalty presence-penalty))
+                 temperature (assoc :temperature temperature))
+        _ (log/debugf "OpenAI prompt (%s, %d chars): %s" model (count prompt) prompt)
+        params {:headers default-headers
+                :body    (json/encode body)}]
+    (-> (client/post completions-url params)
+        :body
+        (json/decode keyword))))
+
+(defn gemini-complete-raw
+  "Calls Gemini API and normalizes the response to match OpenAI's shape.
+   When :response-schema is absent the model returns plain text instead of
+   structured JSON."
+  [{:keys [base-url api-key model n temperature top-p max-tokens thinking-level response-schema]
+    :or   {n              1
+           top-p          0.90
+           temperature    1.0
+           max-tokens     8192
+           thinking-level "minimal"}}
+   system-instruction
+   prompt]
+  (let [url  (str base-url "/models/" model ":generateContent")
+        body {:systemInstruction {:parts [{:text system-instruction}]}
+              :contents          [{:role "user" :parts [{:text prompt}]}]
+              :generationConfig  (cond-> {:topP            top-p
+                                          :temperature     temperature
+                                          :maxOutputTokens max-tokens
+                                          :candidateCount  n
+                                          :thinkingConfig  {:thinkingLevel thinking-level}}
+                                   response-schema
+                                   (assoc :responseMimeType "application/json"
+                                          :responseSchema response-schema))}
+        _      (log/debugf "Gemini prompt (%s, %d chars): %s" model (count prompt) prompt)
+        params {:headers      {"x-goog-api-key" api-key
+                               "Content-Type"   "application/json"}
+                :body         (json/encode body)
+                :content-type :json}
+        resp   (-> (client/post url params)
+                   :body
+                   (json/decode keyword))
+        usage  (:usageMetadata resp)]
+    ;; Normalize to OpenAI shape
+    {:model   model
+     :choices (mapv (fn [candidate]
+                      (let [text (-> candidate :content :parts first :text)
+                            ;; Parse JSON content server-side so callers receive
+                            ;; a proper nested map. Falls back to raw string if
+                            ;; the model returned plain text or invalid JSON.
+                            content (if response-schema
+                                      (try
+                                        (json/decode text keyword)
+                                        (catch Exception e
+                                          (log/warnf "Failed to parse Gemini JSON content: %s" (.getMessage e))
+                                          text))
+                                      text)]
+                        {:message {:content content}}))
+                    (:candidates resp))
+     :usage   {:prompt_tokens     (:promptTokenCount usage 0)
+               :completion_tokens (:candidatesTokenCount usage 0)
+               :total_tokens      (:totalTokenCount usage 0)}}))
+
+(defn complete
+  [{:keys [model message-format] :as config-map}
+   system-instruction
+   prompt]
+  (let [result (-> (complete-raw config-map system-instruction prompt)
+                   :choices
+                   first
+                   (update-in [:message :content]
+                              (fn [content]
+                                (if message-format
+                                  (try
+                                    (json/decode content keyword)
+                                    (catch Exception e
+                                      (log/warnf "Failed to parse OpenAI JSON content: %s" (.getMessage e))
+                                      content))
+                                  content))))]
+    (log/infof "OpenAI complete (%s): %d tokens" model (get-in result [:usage :total_tokens] 0))
+    (log/debugf "OpenAI result: %s" result)
+    result))
+
+(defn- gemini-unavailable?
+  "True if the exception is a 503 (or 429) from Gemini indicating capacity issues."
+  [e]
+  (when-let [status (:status (ex-data e))]
+    (contains? #{503 429} status)))
+
+(defn gemini-complete
+  "Like `complete` but uses Gemini. Returns {:message {:content <map>}}.
+   Merges provider defaults for any missing params.
+   On 503/429 errors, retries once after 2s, then falls back to OpenAI using
+   :fallback-message-format as the response_format when provided."
+  [config system-instruction prompt]
+  (let [config (merge gemini-default-params config)
+        openai-fallback
+        (fn []
+          (let [fallback-model (:model default-params)]
+            (log/warnf "Gemini still unavailable, falling back to OpenAI %s" fallback-model)
+            (let [openai-cfg (cond-> (merge default-params openai-config)
+                               (:fallback-message-format config)
+                               (assoc :message-format (:fallback-message-format config)))
+                  result (complete openai-cfg system-instruction prompt)]
+              (log/infof "OpenAI fallback complete (%s)" fallback-model)
+              result)))]
+    (try
+      (let [result (-> (gemini-complete-raw config system-instruction prompt)
+                       :choices
+                       first)]
+        (log/infof "Gemini complete (%s)" (:model config))
+        (log/debugf "Gemini result: %s" result)
+        result)
+      (catch Exception e
+        (if (gemini-unavailable? e)
+          (do
+            (log/warnf "Gemini unavailable (%s), retrying in 2s..." (.getMessage e))
+            (Thread/sleep 2000)
+            (try
+              (let [result (-> (gemini-complete-raw config system-instruction prompt)
+                               :choices
+                               first)]
+                (log/infof "Gemini retry succeeded (%s)" (:model config))
+                (log/debugf "Gemini result: %s" result)
+                result)
+              (catch Exception e2
+                (if (gemini-unavailable? e2)
+                  (openai-fallback)
+                  (throw e2)))))
+          (throw e))))))
+
+;;; ——— Embeddings ———————————————————————————————————————————————————————
+
+(def embedding-defaults
+  {:model "gemini-embedding-001"
+   :dims  768})
+
+(def ^:private embed-batch-size
+  "Gemini batchEmbedContents accepts at most 100 requests per call."
+  100)
+
+(defn- l2-normalize
+  "MRL-truncated vectors (dims < the model's native 3072) are not
+   unit-length; cosine kNN quality degrades without re-normalization."
+  [values]
+  (let [norm (Math/sqrt (double (reduce (fn [acc v] (+ acc (* v v))) 0.0 values)))]
+    (if (zero? norm)
+      values
+      (mapv #(/ % norm) values))))
+
+(defn embed
+  "Embed a collection of texts with Gemini. Returns a vector of L2-normalized
+   float vectors aligned with the input order.
+
+   config — gemini-config, optionally with :model / :dims overrides
+   opts:
+   :task-type — \"RETRIEVAL_DOCUMENT\" (default), \"RETRIEVAL_QUERY\",
+                \"SEMANTIC_SIMILARITY\", ...
+   :titles    — optional coll aligned with texts; only meaningful with
+                RETRIEVAL_DOCUMENT"
+  [{:keys [base-url api-key model dims]
+    :or   {model (:model embedding-defaults)
+           dims  (:dims embedding-defaults)}}
+   texts
+   & {:keys [task-type titles] :or {task-type "RETRIEVAL_DOCUMENT"}}]
+  (let [url (str base-url "/models/" model ":batchEmbedContents")]
+    (->> (map vector texts (concat (or titles []) (repeat nil)))
+         (partition-all embed-batch-size)
+         (mapcat (fn [chunk]
+                   (let [requests (mapv (fn [[text title]]
+                                          (cond-> {:model                (str "models/" model)
+                                                   :content              {:parts [{:text text}]}
+                                                   :taskType             task-type
+                                                   :outputDimensionality dims}
+                                            title (assoc :title title)))
+                                        chunk)
+                         resp (-> (client/post url {:headers      {"x-goog-api-key" api-key
+                                                                   "Content-Type"   "application/json"}
+                                                    :body         (json/encode {:requests requests})
+                                                    :content-type :json})
+                                  :body
+                                  (json/decode keyword))]
+                     (log/debugf "Gemini embed (%s): %d texts" model (count chunk))
+                     (mapv (comp l2-normalize :values) (:embeddings resp)))))
+         vec)))
+
+(defn embed-one
+  "Embed a single text — convenience for query-time embedding.
+   Returns one L2-normalized float vector."
+  [config text & {:keys [task-type] :or {task-type "RETRIEVAL_QUERY"}}]
+  (first (embed config [text] :task-type task-type)))
+
+(defn get-models
+  [{:keys [_api-key models-url]}]
+  (let [params {:headers default-headers}]
+    (-> (client/get models-url params)
+        :body
+        (json/decode keyword))))
+
+(comment
+  (get-models openai-config)
+  (embed gemini-config ["uimahalli" "jäähalli"] :task-type "SEMANTIC_SIMILARITY")
+  (embed-one gemini-config "miten lisään reitin?"))

--- a/webapp/src/clj/lipas/backend/ptv/ai.clj
+++ b/webapp/src/clj/lipas/backend/ptv/ai.clj
@@ -1,70 +1,13 @@
 (ns lipas.backend.ptv.ai
+  "PTV-specific AI content generation: prompts, response schemas and
+   sports-site → prompt-doc shaping. Generic LLM plumbing (providers,
+   completion calls, retry/fallback, embeddings) lives in lipas.backend.llm."
   (:require [cheshire.core :as json]
-            [clj-http.client :as client]
             [clojure.string :as str]
-            [lipas.backend.config :as config]
+            [lipas.backend.llm :as llm]
             [lipas.data.ptv-service-guidance :as service-guidance]
             [malli.json-schema :as json-schema]
-            [malli.util :as mu]
-            [taoensso.timbre :as log]))
-
-;;; ——— Provider & model registry ———————————————————————————————————————
-;;
-;; Single source of truth for all provider/model configuration.
-;;
-;; :models          — set of model IDs this provider supports
-;; :default-params  — workbench defaults sent to the frontend
-;; :new-api-models  — (OpenAI) models using max_completion_tokens
-;; :no-sampling     — (OpenAI) models that reject top_p / presence_penalty
-
-(def providers
-  {:openai
-   {:models         #{"gpt-4.1-nano" "gpt-4.1-mini" "gpt-4.1" "gpt-4o-mini" "gpt-4o"
-                      "gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
-                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
-    :new-api-models #{"gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
-                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
-    :no-sampling    #{"gpt-5-nano" "gpt-5-mini" "gpt-5" "gpt-5.4"
-                      "o3-mini" "o4-mini" "o3" "o1" "o1-pro"}
-    :default-params {:model            "gpt-4.1-mini"
-                     :top-p            0.5
-                     :presence-penalty -2
-                     :max-tokens       4096
-                     :temperature      nil}}
-   :gemini
-   {:models         #{"gemini-3-flash-preview"}
-    :default-params {:model          "gemini-3-flash-preview"
-                     :top-p          0.90
-                     :temperature    1.0
-                     :max-tokens     8192
-                     :thinking-level "minimal"}}})
-
-(def model->provider
-  "Reverse lookup: model-id → provider keyword. Derived from `providers`."
-  (into {}
-        (for [[provider {:keys [models]}] providers
-              model models]
-          [model provider])))
-
-(def default-params
-  "Default workbench params (OpenAI). Sent to frontend on preview-data load."
-  (-> providers :openai :default-params))
-
-(def gemini-default-params
-  "Default Gemini model params. Use this instead of hardcoding model names."
-  (-> providers :gemini :default-params))
-
-;;; ——— API credentials ——————————————————————————————————————————————————
-
-(def openai-config
-  (get-in config/default-config [:open-ai]))
-
-(def gemini-config
-  (get-in config/default-config [:gemini]))
-
-(def default-headers
-  {:Authorization (str "Bearer " (:api-key openai-config))
-   :Content-Type  "application/json"})
+            [malli.util :as mu]))
 
 (def ptv-system-instruction-v2
   "You are an assistant who helps users produce content for the Service Information Repository (Palvelutietovaranto). You will be asked questions and should primarily use source material and secondarily your own knowledge to provide answers. Follow these style guidelines in your responses:
@@ -246,22 +189,15 @@ Source data:
 (comment
   (println ptv-system-instruction-v2))
 
-(defn localized-string-schema [string-props]
-  [:map
-   {:closed true}
-   [:fi [:string string-props]]
-   [:se [:string string-props]]
-   [:en [:string string-props]]])
-
 (def response-schema
   [:map
    {:closed true}
-   [:description (localized-string-schema nil)]
+   [:description (llm/localized-string-schema nil)]
    ;; Structured Outputs doesn't support maxLength
    ;; https://platform.openai.com/docs/guides/structured-outputs#some-type-specific-keywords-are-not-yet-supported
    ;; The prompt mentions summary should be max 150 chars
-   [:summary (localized-string-schema nil #_{:max 150})]
-   [:user-instruction (localized-string-schema nil)]])
+   [:summary (llm/localized-string-schema nil #_{:max 150})]
+   [:user-instruction (llm/localized-string-schema nil)]])
 
 (def Response
   (json-schema/transform response-schema))
@@ -271,142 +207,23 @@ Source data:
    which Gemini's API does not support."
   (json-schema/transform (mu/open-schema response-schema)))
 
-(defn complete-raw
-  "Returns the full OpenAI response including :choices, :usage, and :model."
-  [{:keys [completions-url model n temperature top-p presence-penalty message-format max-tokens]
-    :or   {n                1
-           top-p            0.5
-           presence-penalty -2
-           max-tokens       4096}}
-   system-instruction
-   prompt]
-  (let [message-format (or message-format
-                           {:type "json_schema"
-                            :json_schema {:name "Response"
-                                          :strict true
-                                          :schema Response}})
-        {:keys [new-api-models no-sampling]} (providers :openai)
-        new-api? (new-api-models model)
-        body   (cond-> {:model            model
-                        :n                n
-                        :response_format  message-format
-                        :messages         [{:role "system" :content system-instruction}
-                                           {:role "user" :content prompt}]}
-                 new-api?             (assoc :max_completion_tokens max-tokens)
-                 (not new-api?)       (assoc :max_tokens max-tokens)
-                 (not (no-sampling model))
-                 (-> (assoc :top_p top-p)
-                     (assoc :presence_penalty presence-penalty))
-                 temperature (assoc :temperature temperature))
-        _ (log/debugf "OpenAI prompt (%s, %d chars): %s" model (count prompt) prompt)
-        params {:headers default-headers
-                :body    (json/encode body)}]
-    (-> (client/post completions-url params)
-        :body
-        (json/decode keyword))))
-
-(defn gemini-complete-raw
-  "Calls Gemini API and normalizes the response to match OpenAI's shape."
-  [{:keys [base-url api-key model n temperature top-p max-tokens thinking-level response-schema]
-    :or   {n               1
-           top-p           0.90
-           temperature     1.0
-           max-tokens      8192
-           thinking-level  "minimal"
-           response-schema GeminiResponse}}
-   system-instruction
-   prompt]
-  (let [url  (str base-url "/models/" model ":generateContent")
-        body {:systemInstruction {:parts [{:text system-instruction}]}
-              :contents          [{:role "user" :parts [{:text prompt}]}]
-              :generationConfig  {:topP             top-p
-                                  :temperature      temperature
-                                  :maxOutputTokens  max-tokens
-                                  :candidateCount   n
-                                  :responseMimeType "application/json"
-                                  :responseSchema   response-schema
-                                  :thinkingConfig   {:thinkingLevel thinking-level}}}
-        _      (log/debugf "Gemini prompt (%s, %d chars): %s" model (count prompt) prompt)
-        params {:headers      {"x-goog-api-key" api-key
-                               "Content-Type"   "application/json"}
-                :body         (json/encode body)
-                :content-type :json}
-        resp   (-> (client/post url params)
-                   :body
-                   (json/decode keyword))
-        usage  (:usageMetadata resp)]
-    ;; Normalize to OpenAI shape
-    {:model   model
-     :choices (mapv (fn [candidate]
-                      (let [text (-> candidate :content :parts first :text)
-                            ;; Parse JSON content server-side so the frontend receives
-                            ;; a proper nested map. Falls back to raw string if Gemini
-                            ;; truncated the output or returned invalid JSON.
-                            content (try
-                                      (json/decode text keyword)
-                                      (catch Exception e
-                                        (log/warnf "Failed to parse Gemini JSON content: %s" (.getMessage e))
-                                        text))]
-                        {:message {:content content}}))
-                    (:candidates resp))
-     :usage   {:prompt_tokens     (:promptTokenCount usage 0)
-               :completion_tokens (:candidatesTokenCount usage 0)
-               :total_tokens      (:totalTokenCount usage 0)}}))
-
-(defn complete
-  [{:keys [completions-url model n #_temperature top-p presence-penalty message-format max-tokens]
-    :as config-map}
-   system-instruction
-   prompt]
-  (let [result (-> (complete-raw config-map system-instruction prompt)
-                   :choices
-                   first
-                   (update-in [:message :content] #(json/decode % keyword)))]
-    (log/infof "OpenAI complete (%s): %d tokens" model (get-in result [:usage :total_tokens] 0))
-    (log/debugf "OpenAI result: %s" result)
-    result))
-
-(defn- gemini-unavailable?
-  "True if the exception is a 503 (or 429) from Gemini indicating capacity issues."
-  [e]
-  (when-let [status (:status (ex-data e))]
-    (contains? #{503 429} status)))
+(def openai-response-format
+  "OpenAI response_format equivalent of GeminiResponse, used both by the
+   workbench and as the Gemini→OpenAI fallback format."
+  {:type "json_schema"
+   :json_schema {:name   "Response"
+                 :strict true
+                 :schema Response}})
 
 (defn gemini-complete
-  "Like `complete` but uses Gemini. Returns {:message {:content <map>}}.
-   Merges provider defaults for any missing params.
-   On 503/429 errors, retries once after 2s, then falls back to OpenAI."
+  "PTV-flavored llm/gemini-complete: defaults to the PTV response schema and
+   keeps the OpenAI fallback on the equivalent JSON schema."
   [config system-instruction prompt]
-  (let [config (merge gemini-default-params config)]
-    (try
-      (let [result (-> (gemini-complete-raw config system-instruction prompt)
-                       :choices
-                       first)]
-        (log/infof "Gemini complete (%s)" (:model config))
-        (log/debugf "Gemini result: %s" result)
-        result)
-      (catch Exception e
-        (if (gemini-unavailable? e)
-          (do
-            (log/warnf "Gemini unavailable (%s), retrying in 2s..." (.getMessage e))
-            (Thread/sleep 2000)
-            (try
-              (let [result (-> (gemini-complete-raw config system-instruction prompt)
-                               :choices
-                               first)]
-                (log/infof "Gemini retry succeeded (%s)" (:model config))
-                (log/debugf "Gemini result: %s" result)
-                result)
-              (catch Exception e2
-                (if (gemini-unavailable? e2)
-                  (let [fallback-model (:model default-params)]
-                    (log/warnf "Gemini still unavailable, falling back to OpenAI %s" fallback-model)
-                    (let [openai-cfg (merge default-params openai-config)
-                          result (complete openai-cfg system-instruction prompt)]
-                      (log/infof "OpenAI fallback complete (%s)" fallback-model)
-                      result))
-                  (throw e2)))))
-          (throw e))))))
+  (llm/gemini-complete (merge {:response-schema         GeminiResponse
+                               :fallback-message-format openai-response-format}
+                              config)
+                       system-instruction
+                       prompt))
 
 (def generate-utp-descriptions-prompt
   "Based on the JSON structure provided, create two multilingual descriptions (in Finnish, Swedish, and English) of the sports facility:
@@ -570,7 +387,7 @@ Description: %s")
                               (:summary reference)
                               (:description reference))
                       "")]
-    (gemini-complete gemini-config
+    (gemini-complete llm/gemini-config
                      ptv-system-instruction-v5
                      (format generate-utp-descriptions-prompt-v5
                              ref-section
@@ -597,9 +414,9 @@ Description: %s")
       ;; transforms to a JSON-schema $ref, which Gemini structured output
       ;; doesn't support. LLM only echoes the id, so plain :int is fine.
       [:lipas-id :int]
-      [:summary (localized-string-schema nil)]
-      [:description (localized-string-schema nil)]
-      [:user-instruction (localized-string-schema nil)]]]]])
+      [:summary (llm/localized-string-schema nil)]
+      [:description (llm/localized-string-schema nil)]
+      [:user-instruction (llm/localized-string-schema nil)]]]]])
 
 (def BatchGeminiResponse
   (json-schema/transform (mu/open-schema batch-response-schema)))
@@ -650,7 +467,7 @@ Source data:
                             (count prompt-docs)
                             ref-section
                             (json/encode prompt-docs))
-        config      (assoc gemini-config
+        config      (assoc llm/gemini-config
                            :response-schema BatchGeminiResponse
                            :max-tokens 32768)]
     (gemini-complete config ptv-system-instruction-v5 prompt)))
@@ -686,7 +503,7 @@ Source text:
 
 (defn translate-to-other-langs
   [{:keys [from to summary description user-instruction]}]
-  (gemini-complete gemini-config
+  (gemini-complete llm/gemini-config
                    ptv-system-instruction-v5
                    (format translate-to-other-langs-prompt
                            from
@@ -877,17 +694,6 @@ Source data:
                          (:user-instruction guidance)
                          (json/encode doc))
                  (format generate-utp-service-descriptions-prompt-v5 (json/encode doc)))]
-    (gemini-complete gemini-config
+    (gemini-complete llm/gemini-config
                      ptv-system-instruction-v5
                      prompt)))
-
-(defn get-models
-  [{:keys [_api-key models-url]}]
-  (let [params {:headers default-headers}]
-    (-> (client/get models-url params)
-        :body
-        (json/decode keyword))))
-
-(comment
-  (get-models openai-config)
-  (complete openai-config ptv-system-instruction "Why volcanoes erupt?"))

--- a/webapp/src/clj/lipas/backend/ptv/eval.clj
+++ b/webapp/src/clj/lipas/backend/ptv/eval.clj
@@ -20,6 +20,7 @@
                       :system-prompt  my-improved-prompt}))"
   (:require [cheshire.core :as json]
             [clj-http.client :as client]
+            [lipas.backend.llm :as llm]
             [lipas.backend.ptv.ai :as ai]
             [lipas.backend.ptv.core :as ptv-core]
             [lipas.backend.ptv.integration :as ptv-int]
@@ -63,14 +64,14 @@
   "Low-level Gemini API call with custom response schema.
    Returns {:content <parsed-json> :usage {...} :elapsed-ms <int> :model <str>}."
   [{:keys [model thinking-level top-p temperature max-tokens response-schema]
-    :or   {model          (:model ai/gemini-default-params)
-           thinking-level (:thinking-level ai/gemini-default-params)
-           top-p          (:top-p ai/gemini-default-params)
-           temperature    (:temperature ai/gemini-default-params)
-           max-tokens     (:max-tokens ai/gemini-default-params)}}
+    :or   {model          (:model llm/gemini-default-params)
+           thinking-level (:thinking-level llm/gemini-default-params)
+           top-p          (:top-p llm/gemini-default-params)
+           temperature    (:temperature llm/gemini-default-params)
+           max-tokens     (:max-tokens llm/gemini-default-params)}}
    system-prompt
    user-prompt]
-  (let [{:keys [base-url api-key]} ai/gemini-config
+  (let [{:keys [base-url api-key]} llm/gemini-config
         url    (str base-url "/models/" model ":generateContent")
         body   {:systemInstruction {:parts [{:text system-prompt}]}
                 :contents          [{:role "user" :parts [{:text user-prompt}]}]
@@ -383,8 +384,8 @@ Be specific — cite exact problematic phrases.")
   (json-schema/transform (mu/open-schema ai/response-schema)))
 
 (def default-generator-config
-  {:model          (:model ai/gemini-default-params)
-   :thinking-level (:thinking-level ai/gemini-default-params)
+  {:model          (:model llm/gemini-default-params)
+   :thinking-level (:thinking-level llm/gemini-default-params)
    :response-schema generation-schema})
 
 (defn- fetch-prompt-doc
@@ -421,7 +422,7 @@ Be specific — cite exact problematic phrases.")
   (json-schema/transform (mu/open-schema grading-response-schema)))
 
 (def default-grader-config
-  {:model          (:model ai/gemini-default-params)
+  {:model          (:model llm/gemini-default-params)
    :thinking-level "high"
    :temperature    0.5
    :top-p          0.90
@@ -509,7 +510,7 @@ Grade this output against all DVV criteria. Be specific — cite exact problemat
   (json-schema/transform (mu/open-schema grading-response-schema-v2)))
 
 (def grader-config-v2
-  {:model          (:model ai/gemini-default-params)
+  {:model          (:model llm/gemini-default-params)
    :thinking-level "high"
    :temperature    0.5
    :top-p          0.90

--- a/webapp/src/clj/lipas/backend/ptv/workbench.clj
+++ b/webapp/src/clj/lipas/backend/ptv/workbench.clj
@@ -1,5 +1,6 @@
 (ns lipas.backend.ptv.workbench
-  (:require [lipas.backend.ptv.ai :as ai]
+  (:require [lipas.backend.llm :as llm]
+            [lipas.backend.ptv.ai :as ai]
             [lipas.schema.sports-sites :as sports-sites-schema]
             [lipas.backend.ptv.core :as ptv-core]
             [lipas.backend.ptv.integration :as ptv-integration]
@@ -33,7 +34,7 @@
     {:prompt-doc    prompt-doc
      :system-prompt (-> templates :v5 :system-prompt)
      :user-prompt   (-> templates :v5 :user-prompt)
-     :defaults      ai/default-params
+     :defaults      llm/default-params
      :templates     templates}))
 
 (defn preview-service
@@ -53,7 +54,7 @@
     {:prompt-doc    prompt-doc
      :system-prompt (-> templates :v5 :system-prompt)
      :user-prompt   (-> templates :v5 :user-prompt)
-     :defaults      ai/default-params
+     :defaults      llm/default-params
      :templates     templates}))
 
 (defn preview-data
@@ -64,25 +65,23 @@
 
 (defn run-experiment
   [{:keys [system-prompt user-prompt params]}]
-  (let [provider (ai/model->provider (:model params))
+  (let [provider (llm/model->provider (:model params))
         base-cfg (case provider
-                   :gemini ai/gemini-config
-                   ai/openai-config)
+                   :gemini llm/gemini-config
+                   llm/openai-config)
         config   (case provider
                    :gemini (merge base-cfg
+                                  {:response-schema ai/GeminiResponse}
                                   (select-keys params [:model :top-p :max-tokens
                                                        :temperature :thinking-level]))
                    (merge base-cfg
                           (select-keys params [:model :top-p :presence-penalty
                                                :max-tokens :temperature])
-                          {:message-format {:type "json_schema"
-                                            :json_schema {:name   "Response"
-                                                          :strict true
-                                                          :schema ai/Response}}}))
+                          {:message-format ai/openai-response-format}))
         start    (System/currentTimeMillis)
         result   (case provider
-                   :gemini (ai/gemini-complete-raw config system-prompt user-prompt)
-                   (ai/complete-raw config system-prompt user-prompt))
+                   :gemini (llm/gemini-complete-raw config system-prompt user-prompt)
+                   (llm/complete-raw config system-prompt user-prompt))
         elapsed  (- (System/currentTimeMillis) start)]
     (assoc result :elapsed-ms elapsed)))
 

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -317,6 +317,7 @@
      :question   {:type "text" :analyzer "finnish"}
      :answer     {:type "text" :analyzer "finnish"}
      :sources    {:type "keyword"}
+     :actions    {:type "keyword"}
      :escalated? {:type "boolean"}
      :context    {:type "keyword" :index false}
      :took-ms    {:type "integer"}}}})

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -306,11 +306,27 @@
                        :index true
                        :similarity "cosine"}}}})
 
+(def assistant-logs-mapping
+  "One doc per AI-assistant exchange; feeds the Kibana views for
+   most-asked topics and escalation rate."
+  {:mappings
+   {:dynamic "strict"
+    :properties
+    {:user-hash  {:type "keyword"}
+     :created-at {:type "date"}
+     :question   {:type "text" :analyzer "finnish"}
+     :answer     {:type "text" :analyzer "finnish"}
+     :sources    {:type "keyword"}
+     :escalated? {:type "boolean"}
+     :context    {:type "keyword" :index false}
+     :took-ms    {:type "integer"}}}})
+
 (def mappings
   "All Elasticsearch index mappings. Used by system initialization and tests."
   {:sports-site   (generate-explicit-mapping)
    :analytics     (generate-analytics-mapping)
    :kb            kb-mapping
+   :assistant     assistant-logs-mapping
    :lois          {:settings
                    {:max_result_window 50000
                     :index {:analysis folding-analysis}}

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -320,7 +320,12 @@
      :actions    {:type "keyword"}
      :escalated? {:type "boolean"}
      :context    {:type "keyword" :index false}
-     :took-ms    {:type "integer"}}}})
+     :took-ms    {:type "integer"}
+     ;; Tool-loop telemetry: how many tool rounds an answer took and
+     ;; whether it ran into max-tool-iterations — the data for tuning
+     ;; the budget instead of guessing.
+     :tool-rounds        {:type "integer"}
+     :budget-exhausted?  {:type "boolean"}}}})
 
 (def mappings
   "All Elasticsearch index mappings. Used by system initialization and tests."

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -277,10 +277,40 @@
                                 :status      {:type "keyword"}
                                 :permissions {:enabled false}}}})))
 
+(def kb-mapping
+  "Knowledge base for the AI help assistant: task-shaped per-language
+   entries with Gemini embeddings for hybrid BM25 + kNN retrieval.
+   Strict mapping — never let ES guess field types here (see the
+   dense_vector comment on :legacy-sports-site below)."
+  {:mappings
+   {:dynamic "strict"
+    :properties
+    {:id              {:type "keyword"}
+     :title           {:type "text" :analyzer "finnish"
+                       :fields {:se {:type "text" :analyzer "swedish"}
+                                :en {:type "text" :analyzer "english"}}}
+     :body            {:type "text" :analyzer "finnish"
+                       :fields {:se {:type "text" :analyzer "swedish"}
+                                :en {:type "text" :analyzer "english"}}}
+     :lang            {:type "keyword"}
+     :source-type     {:type "keyword"}
+     :source-ref      {:type "keyword"}
+     :deep-link       {:type "keyword" :index false}
+     :type-codes      {:type "integer"}
+     :updated-at      {:type "date"}
+     :content-hash    {:type "keyword"}
+     :embedding-model {:type "keyword"}
+     :review-status   {:type "keyword"}
+     :embedding       {:type "dense_vector"
+                       :dims 768
+                       :index true
+                       :similarity "cosine"}}}})
+
 (def mappings
   "All Elasticsearch index mappings. Used by system initialization and tests."
   {:sports-site   (generate-explicit-mapping)
    :analytics     (generate-analytics-mapping)
+   :kb            kb-mapping
    :lois          {:settings
                    {:max_result_window 50000
                     :index {:analysis folding-analysis}}

--- a/webapp/src/clj/lipas/jobs/dispatcher.clj
+++ b/webapp/src/clj/lipas/jobs/dispatcher.clj
@@ -12,6 +12,7 @@
    [lipas.backend.elevation :as elevation]
    [lipas.backend.email :as email]
    [lipas.backend.gis :as gis]
+   [lipas.backend.kb :as kb]
    [lipas.integration.utp.webhook :as utp-webhook]
    [lipas.jobs.core :as jobs]
    [lipas.jobs.patterns :as patterns]
@@ -88,6 +89,10 @@
 
     ;; Default email handling
     (email/send! emailer payload)))
+
+(defmethod handle-job "help-kb-sync"
+  [{:keys [db search]} _job]
+  (kb/sync! db search))
 
 (defmethod handle-job "webhook"
   [{:keys [db]} {:keys [id payload]}]

--- a/webapp/src/clj/lipas/jobs/registry.clj
+++ b/webapp/src/clj/lipas/jobs/registry.clj
@@ -127,6 +127,17 @@
     :priority 95
     :max-attempts 3}
 
+   "help-kb-sync"
+   {:doc "Sync help CMS + code-derived docs into the lipas_kb search index."
+    :payload-schema [:map]
+    :lane :slow
+    :timeout-min 15
+    :priority 60
+    :max-attempts 3
+    ;; Publishing several times in a row coalesces into one sync.
+    :dedup-key-fn (fn [_] "help-kb-sync")
+    :debounce-sec 10}
+
    ;; NOTE: webhook has no live producers. The enqueue sites are kept
    ;; commented out in lipas.backend.core until UTP (or someone else)
    ;; starts consuming webhooks again. The type stays registered so the

--- a/webapp/src/clj/lipas/jobs/scheduler.clj
+++ b/webapp/src/clj/lipas/jobs/scheduler.clj
@@ -36,6 +36,12 @@
    {:interval-seconds 300
     :task-fn produce-reminder-emails!}
 
+   :nightly-help-kb-sync
+   ;; Code-derived KB docs (types, props) can change with any deploy, so
+   ;; resync daily; content-hash diffing makes a no-change run cheap.
+   {:interval-seconds 86400
+    :task-fn (fn [db] (jobs/enqueue-job! db "help-kb-sync" {}))}
+
    :recover-stuck-jobs
    {:interval-seconds 600
     :task-fn (fn [db] (jobs/recover-stuck-jobs! db jobs/stuck-job-timeout-minutes))}

--- a/webapp/src/clj/lipas/migrations/help_v1_to_v2.clj
+++ b/webapp/src/clj/lipas/migrations/help_v1_to_v2.clj
@@ -1,0 +1,44 @@
+(ns lipas.migrations.help-v1-to-v2
+  "One-shot migration: publishes the v1 shared-structure help document as
+  the fi help-v2 tree (regenerated slugs, old slugs kept as aliases) and
+  empty se/en trees. v1 history is left untouched. See lipas.backend.help
+  for the transform; this just wires it into the migration sequence so it
+  runs automatically instead of via a manual REPL step.
+
+  Safe to run against an environment with no v1 data (nothing to do) or
+  one already migrated (skipped) - both are logged, not thrown."
+  (:require [lipas.backend.db.db :as db]
+            [lipas.backend.help :as help]
+            [taoensso.timbre :as log]))
+
+(defn migrate-up
+  [{:keys [db] :as _config}]
+  (log/info "Starting migration: help-v1-to-v2")
+  (cond
+    (nil? (db/get-versioned-data db "help" "active"))
+    (log/info "No v1 help data found, nothing to migrate")
+
+    (some #(seq (db/get-versioned-data db % "active"))
+          (vals help/locale->type))
+    (log/info "help-v2 content already present, skipping")
+
+    :else
+    (log/info "Migration complete: help-v1-to-v2" (help/migrate-v1->v2! db))))
+
+(defn migrate-down [_config]
+  (log/warn "Rollback not supported for help-v1-to-v2 migration"))
+
+(comment
+  ;; Test locally
+  (require '[user])
+  (def test-db (user/db))
+
+  ;; Dry-run checks the migration itself will make
+  (db/get-versioned-data test-db "help" "active")
+  (some #(seq (db/get-versioned-data test-db % "active")) (vals help/locale->type))
+
+  ;; Run it
+  (migrate-up {:db test-db})
+
+  ;; Verify
+  (help/get-help-data test-db))

--- a/webapp/src/cljc/lipas/i18n/en/help.edn
+++ b/webapp/src/cljc/lipas/i18n/en/help.edn
@@ -1,4 +1,6 @@
-{:headline "Help",
+{:only-in-finnish "This content is currently available only in Finnish.",
+ :available-pages "Pages in this section",
+ :headline "Help",
  :manage-content "Manage help content",
  :privacy-policy "Privacy policy"
  :data-model "Data model"

--- a/webapp/src/cljc/lipas/i18n/en/lipas_user_permissions_roles.edn
+++ b/webapp/src/cljc/lipas/i18n/en/lipas_user_permissions_roles.edn
@@ -26,6 +26,7 @@
   :site-manager "Site Manager",
   :city-manager "City Manager",
   :org-user "Organization user",
+  :assistant-tester "AI Assistant Tester",
   :org-editor "Organization editor"},
  :role-descriptions
  {:type-manager "Editing of sites of the selected type",

--- a/webapp/src/cljc/lipas/i18n/fi/help.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/help.edn
@@ -1,4 +1,5 @@
-{:available-pages "Sivut tässä osiossa",
+{:only-in-finnish "Tämä sisältö on saatavilla vain suomeksi.",
+ :available-pages "Sivut tässä osiossa",
  :headline "Ohjeet",
  :manage-content "Hallitse ohjesisältöä",
  :privacy-policy "Tietosuojailmoitus"

--- a/webapp/src/cljc/lipas/i18n/fi/lipas_user_permissions_roles.edn
+++ b/webapp/src/cljc/lipas/i18n/fi/lipas_user_permissions_roles.edn
@@ -29,6 +29,7 @@
   :city-manager "Kuntakäyttäjä",
   :analysis-experimental-user "Analyysityökalukehittäjä",
   :org-user "Organisaatiokäyttäjä",
+  :assistant-tester "AI-avustajan testaaja",
   :org-editor "Organisaation muokkaaja"},
  :role-descriptions
  {:type-manager "Valitun tyypin liikuntapaikkojen muokkaus",

--- a/webapp/src/cljc/lipas/i18n/se/help.edn
+++ b/webapp/src/cljc/lipas/i18n/se/help.edn
@@ -1,4 +1,5 @@
-{:available-pages "Sidor i detta avsnitt",
+{:only-in-finnish "Detta innehåll är för närvarande endast tillgängligt på finska.",
+ :available-pages "Sidor i detta avsnitt",
  :headline "Hjälp",
  :manage-content "Redigera hjälpinnehåll",
  :privacy-policy "Privacy policy"

--- a/webapp/src/cljc/lipas/i18n/se/lipas_user_permissions_roles.edn
+++ b/webapp/src/cljc/lipas/i18n/se/lipas_user_permissions_roles.edn
@@ -26,6 +26,7 @@
   :site-manager "Platsadministratör",
   :city-manager "Stadsadministratör",
   :org-user "Organisationsanvändare",
+  :assistant-tester "AI-assistenttestare",
   :org-editor "Organisationsredigerare"},
  :role-descriptions
  {:type-manager "Redigering av anläggningar av vald typ",

--- a/webapp/src/cljc/lipas/roles.cljc
+++ b/webapp/src/cljc/lipas/roles.cljc
@@ -40,6 +40,10 @@
 
    :help/manage {:doc "Oikeus muokata ohjeiden sisältöä"}
 
+   ;; Rollout: admin-only for dogfooding (admin holds every privilege
+   ;; automatically). GA for all registered users = add to `basic`.
+   :ai-assistant/use {:doc "Oikeus käyttää AI-avustajaa"}
+
    :ptv/manage {:doc "Oikeus nähdä PTV dialogi ja PTV välilehti paikoilla"}
 
    :ptv/audit {:doc "Oikeus auditoida PTV integraatiossa olevien liikuntapaikkojen kuvauksia"}

--- a/webapp/src/cljc/lipas/roles.cljc
+++ b/webapp/src/cljc/lipas/roles.cljc
@@ -40,8 +40,12 @@
 
    :help/manage {:doc "Oikeus muokata ohjeiden sisältöä"}
 
-   ;; Rollout: admin-only for dogfooding (admin holds every privilege
-   ;; automatically). GA for all registered users = add to `basic`.
+   ;; Rollout: OFF for everyone incl. admin (not ready for prod use, help
+   ;; center v2 is shipping without it) - excluded from `:admin`'s blanket
+   ;; grant below. Assign the standalone `:assistant-tester` role to keep
+   ;; developing/dogfooding against a real backend. Next stage: admin-only
+   ;; (re-add to `:admin`'s privileges). GA for all registered users = add
+   ;; to `basic`.
    :ai-assistant/use {:doc "Oikeus käyttää AI-avustajaa"}
 
    :ptv/manage {:doc "Oikeus nähdä PTV dialogi ja PTV välilehti paikoilla"}
@@ -66,9 +70,11 @@
    ;; all privileges
    ;; Except: org/member, because this is used to list users on
    ;; org pages which belong to the organization.
+   ;; Except: ai-assistant/use, not ready for prod use yet (see comment on
+   ;; the privilege above); use the `:assistant-tester` role instead.
    {:sort 0
     :assignable true
-    :privileges (disj (set (keys privileges)) :org/member)
+    :privileges (disj (set (keys privileges)) :org/member :ai-assistant/use)
     ;; This is kind of duplicated from specs, not sure if needed or
     ;; if the UI can introspect the spec.
     ;; These are also used to get the ORDER of UI fields for edit.
@@ -212,6 +218,16 @@
     :catalog-assignable true
     :privileges basic
     :required-context-keys [:org-id]
+    :optional-context-keys []}
+
+   ;; Assign to specific devs/testers to keep developing the AI assistant
+   ;; against a real backend while it's excluded from :admin (see comment
+   ;; on :ai-assistant/use above).
+   :assistant-tester
+   {:sort 70
+    :assignable true
+    :privileges #{:ai-assistant/use}
+    :required-context-keys []
     :optional-context-keys []}})
 
 (defn role-sort-fn

--- a/webapp/src/cljc/lipas/schema/assistant.cljc
+++ b/webapp/src/cljc/lipas/schema/assistant.cljc
@@ -58,6 +58,17 @@
       [:label label]
       [:location [:string {:min 2 :max 100}]]]]
 
+    ;; Exact-coordinate variant for tool-derived points (e.g. geometry
+    ;; problem locations). Bounds ~cover Finland so the model can't pan
+    ;; the user into the void; safe to run during editing.
+    ["pan-to-coordinates"
+     [:map {:closed true}
+      [:type [:= "pan-to-coordinates"]]
+      [:label label]
+      [:lon [:double {:min 19.0 :max 32.0}]]
+      [:lat [:double {:min 59.0 :max 70.5}]]
+      [:zoom {:optional true} [:int {:min 5 :max 18}]]]]
+
     ["navigate-to-view"
      [:map {:closed true}
       [:type [:= "navigate-to-view"]]

--- a/webapp/src/cljc/lipas/schema/assistant.cljc
+++ b/webapp/src/cljc/lipas/schema/assistant.cljc
@@ -1,0 +1,69 @@
+(ns lipas.schema.assistant
+  "Closed vocabulary of UI actions the AI assistant may propose.
+
+   The model never produces re-frame event vectors: it calls an action
+   tool, the backend resolves and validates the args against these
+   schemas, and the widget renders the surviving actions as buttons the
+   user clicks. The frontend translates each action type to concrete
+   dispatches (lipas.ui.assistant.events/run-action) — an action type
+   missing from that translator is simply inert."
+  (:require [lipas.schema.sports-sites :as sports-sites-schema]
+            [lipas.schema.sports-sites.location :as location-schema]
+            [lipas.schema.sports-sites.types :as types-schema]
+            [malli.core :as m]))
+
+(def views
+  "User-facing views the assistant can navigate to. Descriptions feed
+   the navigate_to_view tool declaration; the frontend maps ids to
+   reitit route names."
+  {"front-page" "Etusivu — service news and general info"
+   "map" "Liikuntapaikat — map view where sports sites are searched, viewed and edited"
+   "stats" "Tilastot — statistics section front page"
+   "stats-sport" "Tilastot: liikuntapaikat — sports facility statistics per municipality"
+   "stats-age-structure" "Tilastot: rakennusvuodet — facility construction year / age structure"
+   "stats-city" "Tilastot: kuntien vertailu — compare municipalities"
+   "stats-finance" "Tilastot: talous — municipal sports finance figures"
+   "stats-subsidies" "Tilastot: avustukset — state subsidies for sports facilities"
+   "profile" "Omat tiedot — user's own profile and permissions"})
+
+(def label
+  "Button text shown to the user, in the user's language."
+  (m/schema [:string {:min 1 :max 60}]))
+
+(def action
+  (m/schema
+   [:multi {:dispatch :type}
+    ["apply-search"
+     [:and
+      [:map {:closed true}
+       [:type [:= "apply-search"]]
+       [:label label]
+       [:search-text {:optional true} [:string {:min 1 :max 200}]]
+       [:city-codes {:optional true} [:vector #'location-schema/city-code]]
+       [:type-codes {:optional true} [:vector #'types-schema/active-type-code]]
+       [:only-editable {:optional true} :boolean]]
+      [:fn {:error/message "apply-search needs at least one of search-text, city-codes, type-codes, only-editable"}
+       (fn [{:keys [search-text city-codes type-codes only-editable]}]
+         (boolean (or search-text (seq city-codes) (seq type-codes) only-editable)))]]]
+
+    ["show-site"
+     [:map {:closed true}
+      [:type [:= "show-site"]]
+      [:label label]
+      [:lipas-id #'sports-sites-schema/lipas-id]]]
+
+    ["pan-to-location"
+     [:map {:closed true}
+      [:type [:= "pan-to-location"]]
+      [:label label]
+      [:location [:string {:min 2 :max 100}]]]]
+
+    ["navigate-to-view"
+     [:map {:closed true}
+      [:type [:= "navigate-to-view"]]
+      [:label label]
+      [:view (into [:enum] (sort (keys views)))]]]]))
+
+(defn valid? [a] (m/validate action a))
+
+(defn explain [a] (m/explain action a))

--- a/webapp/src/cljc/lipas/schema/help.cljc
+++ b/webapp/src/cljc/lipas/schema/help.cljc
@@ -1,55 +1,69 @@
 (ns lipas.schema.help
+  "Help content v2: each locale (fi/se/en) has its own independent tree
+   of sections → pages → blocks, and every leaf string is a plain
+   string. This replaced the v1 model where one shared structure
+   carried {:fi :se :en} maps in every leaf — untranslated locales
+   accumulated placeholder junk (\"New Page\", \"Ny sida\") that leaked
+   into the UI and the assistant knowledge base.
+
+   Storage: one versioned_data document per locale (types help-v2-fi /
+   help-v2-se / help-v2-en) so each language drafts, publishes and
+   rolls back independently.
+
+   Slugs are the ?ohje= deep-link currency. Renames must keep the old
+   slug in :aliases — published links and KB citations resolve through
+   them."
   (:require [lipas.schema.common :as common]
             [malli.core :as m]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Reusable Primitive Schemas
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def locales [:fi :se :en])
 
-(def NonEmptyString
-  (m/schema [:string {:min 1}]))
+(def Locale
+  (m/schema [:enum {:decode/string keyword :decode/json keyword}
+             :fi :se :en]))
 
-(def LocalizedString (m/schema common/localized-string))
+(def Slug
+  "URL-safe identifier, unique among siblings."
+  (m/schema [:re {:error/message "expected lowercase letters, numbers and hyphens"}
+             #"^[a-z0-9][a-z0-9-]*$"]))
 
 (def BlockId (m/schema common/uuid))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Content Block Schemas
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Leaf strings allow "" so drafts can be saved mid-edit.
 
 (def TextBlock
   (m/schema
-   [:map {:closed true} ; Prevent extra keys
+   [:map {:closed true}
     [:block-id BlockId]
     [:type {:decode/string keyword} [:enum :text]]
-    [:content LocalizedString]]))
+    [:content :string]])) ; markdown
 
 (def ImageBlock
   (m/schema
    [:map {:closed true}
     [:block-id BlockId]
     [:type {:decode/string keyword} [:enum :image]]
-    [:url NonEmptyString] ; Assuming URL is a non-empty string
-    [:alt LocalizedString] ; Alt text is mandatory for accessibility
-    [:caption {:optional true} LocalizedString]])) ; Caption is optional
+    [:url :string]
+    [:alt :string] ; mandatory for accessibility
+    [:caption {:optional true} :string]]))
 
 (def VideoBlock
   (m/schema
    [:map {:closed true}
     [:block-id BlockId]
     [:type {:decode/string keyword} [:enum :video]]
-    [:provider [:enum :youtube :vimeo]] ; Allow youtube or vimeo? Or just :youtube?
-    [:video-id NonEmptyString] ; The unique ID from the provider
-    [:title {:optional true} LocalizedString]])) ; Optional title for the video
+    [:provider {:decode/string keyword} [:enum :youtube :vimeo]]
+    [:video-id :string]
+    [:title {:optional true} :string]]))
 
 (def PdfBlock
   (m/schema
    [:map {:closed true}
     [:block-id BlockId]
     [:type {:decode/string keyword} [:enum :pdf]]
-    [:url NonEmptyString] ; Assuming URL is a non-empty string
-    [:caption {:optional true} LocalizedString]
-    [:title {:optional true} LocalizedString]]))
+    [:url :string]
+    [:title {:optional true} :string]
+    [:caption {:optional true} :string]]))
 
 (def TypeCodeExplorerBlock
   (m/schema
@@ -71,56 +85,49 @@
     [:video VideoBlock]
     [:pdf PdfBlock]
     [:type-code-explorer TypeCodeExplorerBlock]
-    [:data-model-excel-download DataModelExcelDownload]
-    ;; Add other block types here in the future
-    ;; [:heading HeadingBlock]
-    ]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Page and Section Schemas
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+    [:data-model-excel-download DataModelExcelDownload]]))
 
 (def Page
   (m/schema
    [:map {:closed true}
-    [:slug :keyword]
-    [:title LocalizedString]
+    [:id common/uuid] ; stable across slug renames
+    [:slug Slug]
+    [:title :string]
+    [:summary {:optional true} :string] ; 1-2 sentences for landing lists + KB
+    [:aliases {:optional true} [:vector :string]] ; old slugs, kept resolvable
+    [:translation-of {:optional true} common/uuid] ; counterpart page id in another locale
     [:blocks [:vector ContentBlock]]]))
 
 (def Section
   (m/schema
    [:map {:closed true}
-    [:slug :keyword]
-    [:title LocalizedString]
-    [:pages [:vector
-             [:map {:closed true}
-              [:slug :keyword]
-              [:title LocalizedString]
-              [:blocks [:vector ContentBlock]]]]]]))
+    [:id common/uuid]
+    [:slug Slug]
+    [:title :string]
+    [:summary {:optional true} :string]
+    [:aliases {:optional true} [:vector :string]]
+    [:pages [:vector Page]]]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Top-Level Schema
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def LocaleTree
+  "One locale's full help content."
+  (m/schema [:vector Section]))
 
 (def HelpData
-  (m/schema [:vector Section])) ; Top level is a vector of sections
+  "The get-help-data response: every locale's published tree. A locale
+   with no published content maps to []."
+  (m/schema
+   [:map {:closed true}
+    [:fi LocaleTree]
+    [:se LocaleTree]
+    [:en LocaleTree]]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Registry (Optional but good practice)
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def SaveHelpDataBody
+  (m/schema
+   [:map {:closed true}
+    [:locale Locale]
+    [:data LocaleTree]]))
 
-#_(def registry
-    {::NonEmptyString NonEmptyString
-     ::LanguageKeyword LanguageKeyword
-     ::LocalizedString LocalizedString
-     ::BlockId BlockId
-     ::TextBlock TextBlock
-     ::ImageBlock ImageBlock
-     ::VideoBlock VideoBlock
-     ::ContentBlock ContentBlock
-     ::Page Page
-     ::Section Section
-     ::HelpData HelpDataSchema})
-
-;; Set the default registry
-#_(mr/set-default-registry! (mr/composite-registry m/default-registry registry))
+(def HelpVersionsBody
+  (m/schema
+   [:map {:closed true}
+    [:locale Locale]]))

--- a/webapp/src/cljc/lipas/schema/users.cljc
+++ b/webapp/src/cljc/lipas/schema/users.cljc
@@ -126,6 +126,7 @@
     [:org-user [:map
                 [:role [:= :org-user]]
                 [:org-id {:optional true} [:set :string]]]]
+    [:assistant-tester [:map [:role [:= :assistant-tester]]]]
     ;; Catch-all for unknown roles - just requires :role keyword
     [::default [:map [:role role-keyword]]]]))
 

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -234,3 +234,13 @@
          (assoc acc activity-k activity-v)))
      {}
      activities)))
+
+(defn localized
+  "Pick `locale` from a localized {:fi ... :se ... :en ...} map, falling
+   back fi → en → se when the requested language is missing or blank."
+  [locale m]
+  (when m
+    (or (not-empty (get m locale))
+        (not-empty (:fi m))
+        (not-empty (:en m))
+        (not-empty (:se m)))))

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -16,6 +16,19 @@
         (str/lower-case)
         (str/replace #"(\"|\(|\))" ""))))
 
+(defn ->slug
+  "URL-friendly slug from a title: lowercase, ä/å→a ö→o, whitespace→-,
+   other non-alphanumerics dropped. Returns \"\" for blank input."
+  [s]
+  (-> (or s "")
+      (str/lower-case)
+      (str/replace #"[äå]" "a")
+      (str/replace #"ö" "o")
+      (str/replace #"[^a-z0-9\s-]" "")
+      (str/trim)
+      (str/replace #"\s+" "-")
+      (str/replace #"-+" "-")))
+
 (defn index-by
   ([idx-fn coll]
    (index-by idx-fn identity coll))

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -34,6 +34,14 @@
   (fn [db [_ v]]
     (assoc-in db [:assistant :input] v)))
 
+(rf/reg-event-db ::new-chat
+  (fn [db _]
+    (update db :assistant merge {:messages []
+                                 :input ""
+                                 :thinking? false
+                                 :pending-escalation nil
+                                 :escalation-in-progress? false})))
+
 (rf/reg-event-fx ::send-message
   (fn [{:keys [db]} _]
     (let [message (str/trim (get-in db [:assistant :input] ""))

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -1,6 +1,8 @@
 (ns lipas.ui.assistant.events
   (:require [ajax.core :as ajax]
             [clojure.string :as str]
+            [lipas.ui.map.events :as map-events]
+            [lipas.ui.utils :as utils]
             [re-frame.core :as rf]))
 
 (defn db->context
@@ -68,13 +70,97 @@
                 :on-failure      [::chat-failure]}]]}))))
 
 (rf/reg-event-db ::receive-answer
-  (fn [db [_ {:keys [answer-md sources escalation]}]]
+  (fn [db [_ {:keys [answer-md sources actions escalation]}]]
     (-> db
         (update-in [:assistant :messages] (fnil conj [])
-                   {:role "assistant" :text answer-md :sources sources})
+                   {:role "assistant" :text answer-md :sources sources
+                    :actions (vec actions)})
         (assoc-in [:assistant :thinking?] false)
         (assoc-in [:assistant :pending-escalation]
                   (when escalation (:summary escalation))))))
+
+;; ——— UI actions proposed by the assistant ————————————————————————————
+;;
+;; The backend validates every action against the closed vocabulary in
+;; lipas.schema.assistant before it reaches the widget; this translator
+;; is the only place an action becomes a re-frame dispatch. The model
+;; never produces event vectors.
+
+(def view->route
+  {"front-page" :lipas.ui.routes/front-page
+   "map" :lipas.ui.routes.map/map
+   "stats" :lipas.ui.routes.stats/front-page
+   "stats-sport" :lipas.ui.routes.stats/sport
+   "stats-age-structure" :lipas.ui.routes.stats/age-structure
+   "stats-city" :lipas.ui.routes.stats/city
+   "stats-finance" :lipas.ui.routes.stats/finance
+   "stats-subsidies" :lipas.ui.routes.stats/subsidies
+   "profile" :lipas.ui.routes/user})
+
+(defn- action->fx
+  "Whitelist translator: action map → dispatch vectors. Unknown action
+   types translate to nothing."
+  [{:keys [type] :as action}]
+  (case type
+    "apply-search"
+    [[:dispatch [:lipas.ui.events/navigate :lipas.ui.routes.map/map]]
+     [:dispatch [:lipas.ui.search.events/replace-filters
+                 {:search-text (:search-text action)
+                  :city-codes (:city-codes action)
+                  :type-codes (:type-codes action)
+                  :edit-permission? (:only-editable action)}]]]
+
+    "show-site"
+    [[:dispatch [:lipas.ui.map.events/show-sports-site (:lipas-id action)]]]
+
+    "pan-to-location"
+    [[:dispatch [:lipas.ui.events/navigate :lipas.ui.routes.map/map]]
+     [:dispatch [::pan-to-location (:location action)]]]
+
+    "navigate-to-view"
+    (when-let [route (view->route (:view action))]
+      [[:dispatch [:lipas.ui.events/navigate route]]])
+
+    nil))
+
+(rf/reg-event-fx ::run-action
+  (fn [{:keys [db]} [_ msg-idx action-idx action]]
+    (if (contains? #{:editing :drawing} (-> db :map :mode :name))
+      ;; Never navigate away from unsaved edits.
+      {:dispatch [:lipas.ui.events/set-active-notification
+                  {:message "Sulje ensin muokkaustila, niin avustaja voi ohjata näkymää."
+                   :success? false}]}
+      (when-let [fx (action->fx action)]
+        {:db (assoc-in db [:assistant :messages msg-idx :actions action-idx :executed?] true)
+         :fx (vec fx)}))))
+
+(rf/reg-event-fx ::pan-to-location
+  (fn [_ [_ location]]
+    {:http-xhrio
+     {:method :get
+      :uri (str "https://" (utils/domain)
+                "/digitransit/geocoding/v1/autocomplete?sources=oa,osm&text="
+                (js/encodeURIComponent location))
+      :response-format (ajax/json-response-format {:keywords? true})
+      :on-success [::pan-to-location-success]
+      :on-failure [::pan-to-location-failure]}}))
+
+(rf/reg-event-fx ::pan-to-location-success
+  (fn [_ [_ resp]]
+    (let [f (-> resp :features first)]
+      (if-let [coords (-> f :geometry :coordinates)]
+        (let [{:keys [lat lon]} (map-events/wgs84->epsg3067 coords)
+              address? (contains? #{"address" "venue" "street"}
+                                  (-> f :properties :layer))]
+          {:fx [[:dispatch [:lipas.ui.map.events/set-center lat lon]]
+                [:dispatch [:lipas.ui.map.events/set-zoom (if address? 14 12)]]]})
+        {:dispatch [::pan-to-location-failure nil]}))))
+
+(rf/reg-event-fx ::pan-to-location-failure
+  (fn [_ _]
+    {:dispatch [:lipas.ui.events/set-active-notification
+                {:message "Paikkaa ei löytynyt kartalta."
+                 :success? false}]}))
 
 (rf/reg-event-db ::chat-failure
   (fn [db [_ resp]]

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -11,11 +11,18 @@
   (let [tr (:translator db)
         locale (when tr (name (tr)))
         route (some-> db :current-route :data :name str)
+        view (when route
+               (cond
+                 (str/includes? route "routes.map") "map view (karttanäkymä)"
+                 (str/includes? route "front-page") "front page"
+                 (str/includes? route "stats") "statistics view"
+                 :else nil))
         lipas-id (-> db :map :mode :lipas-id)
         edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))]
     (cond-> {}
       locale (assoc :locale locale)
       route (assoc :route route)
+      view (assoc :view view)
       lipas-id (assoc :site {:lipas-id lipas-id})
       edit-mode? (assoc :edit-mode? true))))
 

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -1,6 +1,7 @@
 (ns lipas.ui.assistant.events
   (:require [ajax.core :as ajax]
             [clojure.string :as str]
+            [lipas.ui.help.events :as help-events]
             [lipas.ui.map.events :as map-events]
             [lipas.ui.utils :as utils]
             [re-frame.core :as rf]))
@@ -20,13 +21,15 @@
                  (str/includes? route "stats") "statistics view"
                  :else nil))
         lipas-id (-> db :map :mode :lipas-id)
-        edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))]
+        edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))
+        help-ctx (help-events/dialog-context db)]
     (cond-> {}
       locale (assoc :locale locale)
       route (assoc :route route)
       view (assoc :view view)
       lipas-id (assoc :site {:lipas-id lipas-id})
-      edit-mode? (assoc :edit-mode? true))))
+      edit-mode? (assoc :edit-mode? true)
+      (seq help-ctx) (assoc :help help-ctx))))
 
 (rf/reg-event-db ::toggle-panel
   (fn [db _]

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -1,11 +1,81 @@
 (ns lipas.ui.assistant.events
   (:require [ajax.core :as ajax]
             [clojure.string :as str]
+            [lipas.schema.sports-sites :as sports-site-schema]
             [lipas.ui.help.events :as help-events]
             [lipas.ui.map.events :as map-events]
+            [lipas.ui.map.utils :as map-utils]
             [lipas.ui.ptv.events :as ptv-events]
             [lipas.ui.utils :as utils]
+            [malli.core :as m]
             [re-frame.core :as rf]))
+
+(defn- round6 [x]
+  (/ (js/Math.round (* x 1e6)) 1e6))
+
+(defn- fcoll-vertex-count [fcoll]
+  (transduce (map (fn [f]
+                    (let [g (:geometry f)
+                          c (:coordinates g)]
+                      (case (:type g)
+                        "Point" 1
+                        "LineString" (count c)
+                        "Polygon" (reduce + 0 (map count c))
+                        0))))
+             + 0 (:features fcoll)))
+
+(defn- invalid-fields
+  "Top-level field paths failing schema validation for the current
+   edits — the concrete reason the save button is disabled."
+  [schema data]
+  (when data
+    (when-let [errors (:errors (m/explain schema (utils/make-saveable data)))]
+      (->> errors
+           (map (fn [{:keys [in]}]
+                  (->> (take 2 in)
+                       (map #(if (keyword? %) (name %) (str %)))
+                       (str/join "."))))
+           distinct
+           (take 10)
+           vec))))
+
+(defn- edit-context
+  "Live map-editor state: what is being drawn/edited right now, its
+   geometry stats and problems, and what blocks saving. Mirrors the
+   backend's context-schema :edit block. Must never throw — a broken
+   snapshot must not block sending a message."
+  [db]
+  (try
+    (let [mode (-> db :map :mode)
+          new? (= :adding (:name mode))
+          geoms (:geoms mode)
+          problem-fs (-> mode :problems :data :features)
+          geom-type (or (-> geoms :features first :geometry :type)
+                        (some-> (:geom-type mode) str))
+          data (if new?
+                 (-> db :new-sports-site :data)
+                 (get-in db [:sports-sites (:lipas-id mode) :editing]))
+          schema (if new?
+                   sports-site-schema/new-sports-site
+                   sports-site-schema/sports-site)
+          length-km (when (and geoms (= "LineString" geom-type))
+                      (map-utils/calculate-length-km geoms))]
+      (cond-> {}
+        new? (assoc :new-site? true)
+        (:sub-mode mode) (assoc :sub-mode (name (:sub-mode mode)))
+        geom-type (assoc :geometry-type geom-type)
+        geoms (assoc :segments (count (:features geoms))
+                     :vertices (fcoll-vertex-count geoms))
+        length-km (assoc :length-km length-km)
+        problem-fs (assoc :self-intersections (count problem-fs)
+                          :problem-locations
+                          (mapv (fn [f]
+                                  (let [[lon lat] (-> f :geometry :coordinates)]
+                                    {:lon (round6 lon) :lat (round6 lat)}))
+                                (take 5 problem-fs)))
+        data (merge (when-let [inv (invalid-fields schema data)]
+                      {:invalid-fields inv}))))
+    (catch :default _ nil)))
 
 (defn db->context
   "Snapshot of where the user is, sent with every message so the
@@ -26,7 +96,8 @@
                (str/includes? route "stats") "statistics view"
                :else nil)
         lipas-id (-> db :map :mode :lipas-id)
-        edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))
+        edit-mode? (contains? #{:editing :drawing :adding} (-> db :map :mode :name))
+        edit-ctx (when edit-mode? (edit-context db))
         help-ctx (help-events/dialog-context db)]
     (cond-> {}
       locale (assoc :locale locale)
@@ -34,6 +105,7 @@
       view (assoc :view view)
       lipas-id (assoc :site {:lipas-id lipas-id})
       edit-mode? (assoc :edit-mode? true)
+      (seq edit-ctx) (assoc :edit edit-ctx)
       (seq help-ctx) (assoc :help help-ctx)
       (seq ptv-ctx) (assoc :ptv ptv-ctx))))
 
@@ -126,6 +198,14 @@
     [[:dispatch [:lipas.ui.events/navigate :lipas.ui.routes.map/map]]
      [:dispatch [::pan-to-location (:location action)]]]
 
+    ;; Deliberately no navigation: this action is offered during
+    ;; geometry editing (zoom to a problem spot) and navigating would
+    ;; disturb the edit session.
+    "pan-to-coordinates"
+    (let [{:keys [lat lon]} (map-events/wgs84->epsg3067 [(:lon action) (:lat action)])]
+      [[:dispatch [:lipas.ui.map.events/set-center lat lon]]
+       [:dispatch [:lipas.ui.map.events/set-zoom (or (:zoom action) 16)]]])
+
     "navigate-to-view"
     (when-let [route (view->route (:view action))]
       [[:dispatch [:lipas.ui.events/navigate route]]])
@@ -134,14 +214,16 @@
 
 (rf/reg-event-fx ::run-action
   (fn [{:keys [db]} [_ msg-idx action-idx action]]
-    (if (contains? #{:editing :drawing} (-> db :map :mode :name))
-      ;; Never navigate away from unsaved edits.
-      {:dispatch [:lipas.ui.events/set-active-notification
-                  {:message "Sulje ensin muokkaustila, niin avustaja voi ohjata näkymää."
-                   :success? false}]}
-      (when-let [fx (action->fx action)]
-        {:db (assoc-in db [:assistant :messages msg-idx :actions action-idx :executed?] true)
-         :fx (vec fx)}))))
+    (let [editing? (contains? #{:editing :drawing :adding} (-> db :map :mode :name))]
+      ;; Never navigate away from unsaved edits — but pure map pan/zoom
+      ;; (inspecting a geometry problem) is safe during editing.
+      (if (and editing? (not= "pan-to-coordinates" (:type action)))
+        {:dispatch [:lipas.ui.events/set-active-notification
+                    {:message "Sulje ensin muokkaustila, niin avustaja voi ohjata näkymää."
+                     :success? false}]}
+        (when-let [fx (action->fx action)]
+          {:db (assoc-in db [:assistant :messages msg-idx :actions action-idx :executed?] true)
+           :fx (vec fx)})))))
 
 (rf/reg-event-fx ::pan-to-location
   (fn [_ [_ location]]

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [lipas.ui.help.events :as help-events]
             [lipas.ui.map.events :as map-events]
+            [lipas.ui.ptv.events :as ptv-events]
             [lipas.ui.utils :as utils]
             [re-frame.core :as rf]))
 
@@ -14,12 +15,16 @@
   (let [tr (:translator db)
         locale (when tr (name (tr)))
         route (some-> db :current-route :data :name str)
-        view (when route
-               (cond
-                 (str/includes? route "routes.map") "map view (karttanäkymä)"
-                 (str/includes? route "front-page") "front page"
-                 (str/includes? route "stats") "statistics view"
-                 :else nil))
+        ptv-ctx (ptv-events/dialog-context db)
+        view (cond
+               ;; A fullscreen dialog covers whatever the route renders —
+               ;; it is where the user actually is.
+               ptv-ctx "PTV export dialog 'Vie Palvelutietovarantoon' (covers the map view)"
+               (nil? route) nil
+               (str/includes? route "routes.map") "map view (karttanäkymä)"
+               (str/includes? route "front-page") "front page"
+               (str/includes? route "stats") "statistics view"
+               :else nil)
         lipas-id (-> db :map :mode :lipas-id)
         edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))
         help-ctx (help-events/dialog-context db)]
@@ -29,7 +34,8 @@
       view (assoc :view view)
       lipas-id (assoc :site {:lipas-id lipas-id})
       edit-mode? (assoc :edit-mode? true)
-      (seq help-ctx) (assoc :help help-ctx))))
+      (seq help-ctx) (assoc :help help-ctx)
+      (seq ptv-ctx) (assoc :ptv ptv-ctx))))
 
 (rf/reg-event-db ::toggle-panel
   (fn [db _]

--- a/webapp/src/cljs/lipas/ui/assistant/events.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/events.cljs
@@ -1,0 +1,131 @@
+(ns lipas.ui.assistant.events
+  (:require [ajax.core :as ajax]
+            [clojure.string :as str]
+            [re-frame.core :as rf]))
+
+(defn db->context
+  "Snapshot of where the user is, sent with every message so the
+   assistant can ground answers in the current view. Only the site id is
+   sent — the agent fetches details with its own tools."
+  [db]
+  (let [tr (:translator db)
+        locale (when tr (name (tr)))
+        route (some-> db :current-route :data :name str)
+        lipas-id (-> db :map :mode :lipas-id)
+        edit-mode? (contains? #{:editing :drawing} (-> db :map :mode :name))]
+    (cond-> {}
+      locale (assoc :locale locale)
+      route (assoc :route route)
+      lipas-id (assoc :site {:lipas-id lipas-id})
+      edit-mode? (assoc :edit-mode? true))))
+
+(rf/reg-event-db ::toggle-panel
+  (fn [db _]
+    (update-in db [:assistant :open?] not)))
+
+(rf/reg-event-db ::set-input
+  (fn [db [_ v]]
+    (assoc-in db [:assistant :input] v)))
+
+(rf/reg-event-fx ::send-message
+  (fn [{:keys [db]} _]
+    (let [message (str/trim (get-in db [:assistant :input] ""))
+          token (-> db :user :login :token)
+          history (->> (get-in db [:assistant :messages] [])
+                       (mapv #(select-keys % [:role :text])))]
+      (when-not (str/blank? message)
+        {:db (-> db
+                 (update-in [:assistant :messages] (fnil conj [])
+                            {:role "user" :text message})
+                 (assoc-in [:assistant :input] "")
+                 (assoc-in [:assistant :thinking?] true)
+                 (assoc-in [:assistant :pending-escalation] nil))
+         :fx [[:http-xhrio
+               {:method          :post
+                :headers         {:Authorization (str "Token " token)}
+                :uri             (str (:backend-url db) "/actions/assistant-chat")
+                :params          {:message message
+                                  :history history
+                                  :context (db->context db)}
+                :format          (ajax/transit-request-format)
+                :response-format (ajax/transit-response-format)
+                :on-success      [::receive-answer]
+                :on-failure      [::chat-failure]}]]}))))
+
+(rf/reg-event-db ::receive-answer
+  (fn [db [_ {:keys [answer-md sources escalation]}]]
+    (-> db
+        (update-in [:assistant :messages] (fnil conj [])
+                   {:role "assistant" :text answer-md :sources sources})
+        (assoc-in [:assistant :thinking?] false)
+        (assoc-in [:assistant :pending-escalation]
+                  (when escalation (:summary escalation))))))
+
+(rf/reg-event-db ::chat-failure
+  (fn [db [_ resp]]
+    (let [msg (if (= 429 (:status resp))
+                (or (-> resp :response :error)
+                    "Viestiraja täynnä. Yritä myöhemmin uudelleen.")
+                "Avustajaan ei juuri nyt saada yhteyttä. Yritä hetken päästä uudelleen.")]
+      (-> db
+          (update-in [:assistant :messages] (fnil conj [])
+                     {:role "assistant" :text msg :error? true})
+          (assoc-in [:assistant :thinking?] false)))))
+
+(rf/reg-event-db ::edit-escalation
+  (fn [db [_ v]]
+    (assoc-in db [:assistant :pending-escalation] v)))
+
+(rf/reg-event-db ::dismiss-escalation
+  (fn [db _]
+    (assoc-in db [:assistant :pending-escalation] nil)))
+
+(rf/reg-event-fx ::confirm-escalation
+  (fn [{:keys [db]} _]
+    (let [summary (get-in db [:assistant :pending-escalation])
+          token (-> db :user :login :token)
+          transcript (->> (get-in db [:assistant :messages] [])
+                          (mapv #(select-keys % [:role :text])))]
+      {:db (assoc-in db [:assistant :escalation-in-progress?] true)
+       :fx [[:http-xhrio
+             {:method          :post
+              :headers         {:Authorization (str "Token " token)}
+              :uri             (str (:backend-url db) "/actions/assistant-escalate")
+              :params          {:summary summary
+                                :transcript transcript
+                                :context (db->context db)}
+              :format          (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success      [::escalation-sent]
+              :on-failure      [::escalation-failure]}]]})))
+
+(rf/reg-event-db ::escalation-sent
+  (fn [db _]
+    (-> db
+        (update-in [:assistant :messages] (fnil conj [])
+                   {:role "assistant"
+                    :text "Tukipyyntö on lähetetty LIPAS-tuelle. Saat vastauksen sähköpostiisi."})
+        (assoc-in [:assistant :pending-escalation] nil)
+        (assoc-in [:assistant :escalation-in-progress?] false))))
+
+(rf/reg-event-db ::escalation-failure
+  (fn [db [_ resp]]
+    (let [msg (if (= 429 (:status resp))
+                (or (-> resp :response :error)
+                    "Tukipyyntöraja täynnä tälle päivälle.")
+                "Tukipyynnön lähetys epäonnistui. Voit lähettää sähköpostia osoitteeseen lipasinfo@jyu.fi.")]
+      (-> db
+          (update-in [:assistant :messages] (fnil conj [])
+                     {:role "assistant" :text msg :error? true})
+          (assoc-in [:assistant :escalation-in-progress?] false)))))
+
+(rf/reg-fx ::open-window!
+  (fn [url]
+    (js/window.open url "_blank")))
+
+(rf/reg-event-fx ::open-source
+  (fn [_ [_ deep-link]]
+    (if (and deep-link (str/starts-with? deep-link "?ohje="))
+      (let [[section page] (-> deep-link (subs 6) (str/split #"/"))]
+        {:fx [[:dispatch [:lipas.ui.help.events/navigate-to section page]]]})
+      {::open-window! deep-link})))

--- a/webapp/src/cljs/lipas/ui/assistant/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/subs.cljs
@@ -1,0 +1,36 @@
+(ns lipas.ui.assistant.subs
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub ::assistant
+  (fn [db _]
+    (:assistant db)))
+
+(rf/reg-sub ::open?
+  :<- [::assistant]
+  (fn [m _]
+    (boolean (:open? m))))
+
+(rf/reg-sub ::messages
+  :<- [::assistant]
+  (fn [m _]
+    (:messages m [])))
+
+(rf/reg-sub ::input
+  :<- [::assistant]
+  (fn [m _]
+    (:input m "")))
+
+(rf/reg-sub ::thinking?
+  :<- [::assistant]
+  (fn [m _]
+    (boolean (:thinking? m))))
+
+(rf/reg-sub ::pending-escalation
+  :<- [::assistant]
+  (fn [m _]
+    (:pending-escalation m)))
+
+(rf/reg-sub ::escalation-in-progress?
+  :<- [::assistant]
+  (fn [m _]
+    (boolean (:escalation-in-progress? m))))

--- a/webapp/src/cljs/lipas/ui/assistant/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/subs.cljs
@@ -1,9 +1,17 @@
 (ns lipas.ui.assistant.subs
-  (:require [re-frame.core :as rf]))
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]))
 
 (rf/reg-sub ::assistant
   (fn [db _]
     (:assistant db)))
+
+(rf/reg-sub ::map-route?
+  ;; On the map the launcher is embedded in the bottom-right control
+  ;; container (the corner itself is crowded there) instead of floating.
+  (fn [db _]
+    (boolean (some-> db :current-route :data :name str
+                     (str/includes? "routes.map")))))
 
 (rf/reg-sub ::open?
   :<- [::assistant]

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -1,5 +1,6 @@
 (ns lipas.ui.assistant.views
   (:require
+   ["@mui/icons-material/AddComment$default" :as AddCommentIcon]
    ["@mui/icons-material/Close$default" :as CloseIcon]
    ["@mui/icons-material/Send$default" :as SendIcon]
    ["@mui/icons-material/SmartToy$default" :as SmartToyIcon]
@@ -130,6 +131,12 @@
       [:> SmartToyIcon {:fontSize "small" :sx #js{:mr 1}}]
       [:> Typography {:variant "subtitle1" :sx #js{:flexGrow 1}}
        "LIPAS-avustaja"]
+      (when (seq messages)
+        [:> Tooltip {:title "Uusi keskustelu"}
+         [:> IconButton {:size "small"
+                         :sx #js{:color "inherit"}
+                         :onClick #(==> [::events/new-chat])}
+          [:> AddCommentIcon {:fontSize "small"}]]])
       [:> IconButton {:size "small"
                       :sx #js{:color "inherit"}
                       :onClick #(==> [::events/toggle-panel])}

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -2,6 +2,10 @@
   (:require
    ["@mui/icons-material/AddComment$default" :as AddCommentIcon]
    ["@mui/icons-material/Close$default" :as CloseIcon]
+   ["@mui/icons-material/Done$default" :as DoneIcon]
+   ["@mui/icons-material/ExpandLess$default" :as ExpandLessIcon]
+   ["@mui/icons-material/ExpandMore$default" :as ExpandMoreIcon]
+   ["@mui/icons-material/PlayArrow$default" :as PlayArrowIcon]
    ["@mui/icons-material/Send$default" :as SendIcon]
    ["@mui/icons-material/SmartToy$default" :as SmartToyIcon]
    ["@mui/material/Box$default" :as Box]
@@ -10,6 +14,7 @@
    ["@mui/material/CardActions$default" :as CardActions]
    ["@mui/material/CardContent$default" :as CardContent]
    ["@mui/material/Chip$default" :as Chip]
+   ["@mui/material/Collapse$default" :as Collapse]
    ["@mui/material/CircularProgress$default" :as CircularProgress]
    ["@mui/material/Fab$default" :as Fab]
    ["@mui/material/IconButton$default" :as IconButton]
@@ -25,7 +30,8 @@
    [lipas.ui.user.subs :as user-subs]
    [lipas.ui.utils :refer [==>]]
    [re-frame.core :as rf]
-   [reagent.core :as r]))
+   [reagent.core :as r]
+   [reagent.hooks :as hooks]))
 
 (defn- md-link
   "Markdown link renderer: ?ohje= links open the in-app help center,
@@ -43,8 +49,9 @@
       (.-children props)])))
 
 (r/defc Message
-  [{:keys [message]}]
-  (let [{:keys [role text sources error?]} message
+  [{:keys [message idx]}]
+  (let [[sources-open? set-sources-open!] (hooks/use-state false)
+        {:keys [role text sources actions error?]} message
         user? (= "user" role)]
     [:> Box {:sx #js{:display "flex"
                      :justifyContent (if user? "flex-end" "flex-start")}}
@@ -63,16 +70,51 @@
                          "& ul, & ol" #js{:mt 0 :mb 1 :pl 2.5}
                          "& a" #js{:color "secondary.dark"}}}
          [:> ReactMarkdown {:components #js{:a md-link}} text]])
+      ;; Sources collapsed by default — they earn their space on demand.
       (when (seq sources)
+        (let [shown (take 4 sources)]
+          [:<>
+           [:> Button {:size "small"
+                       :variant "text"
+                       :sx #js{:textTransform "none"
+                               :color "text.secondary"
+                               :mt 0.5
+                               :p 0
+                               :minWidth 0}
+                       :endIcon (r/as-element
+                                 (if sources-open?
+                                   [:> ExpandLessIcon {:fontSize "small"}]
+                                   [:> ExpandMoreIcon {:fontSize "small"}]))
+                       :onClick #(set-sources-open! (not sources-open?))}
+            (str "Lähteet (" (count shown) ")")]
+           [:> Collapse {:in sources-open? :timeout 150}
+            [:> Stack {:direction "row" :spacing 0.5 :useFlexGap true
+                       :sx #js{:flexWrap "wrap" :mt 0.5}}
+             (for [{:keys [id title deep-link]} shown]
+               ^{:key id}
+               [:> Chip {:label title
+                         :size "small"
+                         :variant "outlined"
+                         :clickable true
+                         :onClick #(==> [::events/open-source deep-link])}])]]]))
+      ;; Actions the assistant proposes — nothing runs until clicked.
+      (when (seq actions)
         [:> Stack {:direction "row" :spacing 0.5 :useFlexGap true
                    :sx #js{:flexWrap "wrap" :mt 1}}
-         (for [{:keys [id title deep-link]} (take 4 sources)]
-           ^{:key id}
-           [:> Chip {:label title
-                     :size "small"
-                     :variant "outlined"
-                     :clickable true
-                     :onClick #(==> [::events/open-source deep-link])}])])]]))
+         (for [[action-idx {:keys [label executed?] :as action}]
+               (map-indexed vector actions)]
+           ^{:key action-idx}
+           [:> Button {:size "small"
+                       :variant (if executed? "text" "contained")
+                       :color "secondary"
+                       :disabled executed?
+                       :startIcon (r/as-element
+                                   (if executed?
+                                     [:> DoneIcon {:fontSize "small"}]
+                                     [:> PlayArrowIcon {:fontSize "small"}]))
+                       :sx #js{:textTransform "none"}
+                       :onClick #(==> [::events/run-action idx action-idx action])}
+            label])])]]))
 
 (r/defc EscalationCard []
   (let [summary @(rf/subscribe [::subs/pending-escalation])
@@ -110,7 +152,16 @@
 (r/defc Panel []
   (let [messages @(rf/subscribe [::subs/messages])
         input @(rf/subscribe [::subs/input])
-        thinking? @(rf/subscribe [::subs/thinking?])]
+        thinking? @(rf/subscribe [::subs/thinking?])
+        pending-escalation @(rf/subscribe [::subs/pending-escalation])
+        scroll-ref (hooks/use-ref nil)]
+    ;; Keep the newest message — and especially the escalation card, which
+    ;; appears below the answer — in view.
+    (hooks/use-effect
+     (fn []
+       (when-let [el (.-current scroll-ref)]
+         (set! (.-scrollTop el) (.-scrollHeight el))))
+     [(count messages) thinking? pending-escalation])
     [:> Paper
      {:elevation 8
       :sx #js{:position "fixed"
@@ -130,7 +181,7 @@
                       :color "primary.contrastText"}}
       [:> SmartToyIcon {:fontSize "small" :sx #js{:mr 1}}]
       [:> Typography {:variant "subtitle1" :sx #js{:flexGrow 1}}
-       "LIPAS-avustaja"]
+       "Lipastaja"]
       (when (seq messages)
         [:> Tooltip {:title "Uusi keskustelu"}
          [:> IconButton {:size "small"
@@ -143,7 +194,8 @@
        [:> CloseIcon {:fontSize "small"}]]]
 
      ;; Messages
-     [:> Stack {:spacing 1.5
+     [:> Stack {:ref scroll-ref
+                :spacing 1.5
                 :sx #js{:flexGrow 1
                         :overflowY "auto"
                         :p 1.5}}
@@ -154,7 +206,7 @@
           lähteet."])
       (for [[idx m] (map-indexed vector messages)]
         ^{:key idx}
-        [Message {:message m}])
+        [Message {:message m :idx idx}])
       (when thinking?
         [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
          [:> CircularProgress {:size 16}]
@@ -190,7 +242,7 @@
     (when can-use?
       [:<>
        (when open? [Panel])
-       [:> Tooltip {:title "LIPAS-avustaja"}
+       [:> Tooltip {:title "Lipastaja"}
         [:> Fab {:color "secondary"
                  :size "medium"
                  :sx #js{:position "fixed"

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -28,6 +28,7 @@
    [lipas.ui.assistant.events :as events]
    [lipas.ui.assistant.subs :as subs]
    [lipas.ui.help.subs :as help-subs]
+   [lipas.ui.ptv.subs :as ptv-subs]
    [lipas.ui.user.subs :as user-subs]
    [lipas.ui.utils :refer [==>]]
    [re-frame.core :as rf]
@@ -271,13 +272,14 @@
   (let [can-use? @(rf/subscribe [::user-subs/check-privilege nil :ai-assistant/use])
         open? @(rf/subscribe [::subs/open?])
         map-route? @(rf/subscribe [::subs/map-route?])
-        help-open? @(rf/subscribe [::help-subs/dialog-open?])]
+        help-open? @(rf/subscribe [::help-subs/dialog-open?])
+        ptv-open? @(rf/subscribe [::ptv-subs/dialog-open?])]
     (when can-use?
       [:<>
        (when open? [Panel])
        ;; On the map route the launcher lives inside the bottom-right
-       ;; map-control container (see MapLauncher) — except when the
-       ;; fullscreen help dialog covers the map controls, in which case
-       ;; the floating Fab takes over again.
-       (when (or (not map-route?) help-open?)
+       ;; map-control container (see MapLauncher) — except when a
+       ;; fullscreen dialog (help center, PTV) covers the map controls,
+       ;; in which case the floating Fab takes over again.
+       (when (or (not map-route?) help-open? ptv-open?)
          [LauncherFab {:fixed? true}])])))

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -27,6 +27,7 @@
    [clojure.string :as str]
    [lipas.ui.assistant.events :as events]
    [lipas.ui.assistant.subs :as subs]
+   [lipas.ui.help.subs :as help-subs]
    [lipas.ui.user.subs :as user-subs]
    [lipas.ui.utils :refer [==>]]
    [re-frame.core :as rf]
@@ -164,10 +165,13 @@
      [(count messages) thinking? pending-escalation])
     [:> Paper
      {:elevation 8
+      ;; bottom clears the map's bottom-right control cluster; zIndex
+      ;; above MUI modal (1300) so the assistant stays usable inside
+      ;; fullscreen dialogs (help center); below snackbar (1400).
       :sx #js{:position "fixed"
               :bottom 88
               :right 16
-              :zIndex 1250
+              :zIndex 1350
               :width #js{:xs "calc(100vw - 32px)" :sm 420}
               :height "min(600px, calc(100vh - 120px))"
               :display "flex"
@@ -233,21 +237,47 @@
                       :onClick #(==> [::events/send-message])}
        [:> SendIcon]]]]))
 
+(r/defc LauncherFab
+  ;; fixed? true = floating in the viewport corner; false = in normal
+  ;; flow (embedded in the map-control container). zIndex sits above MUI
+  ;; modal (1300) so the launcher works inside fullscreen dialogs (help
+  ;; center), below snackbar (1400).
+  [{:keys [fixed?]}]
+  [:> Tooltip {:title "Lipastaja"}
+   [:> Fab {:color "secondary"
+            :size "medium"
+            :sx (if fixed?
+                  #js{:position "fixed"
+                      :bottom 24
+                      :right 16
+                      :zIndex 1350}
+                  #js{})
+            :onClick #(==> [::events/toggle-panel])}
+    [:> SmartToyIcon]]])
+
+(r/defc MapLauncher
+  "Assistant launcher for the map view's bottom-right control container —
+   the corner itself is crowded there. Renders nothing without the
+   :ai-assistant/use privilege."
+  []
+  (let [can-use? @(rf/subscribe [::user-subs/check-privilege nil :ai-assistant/use])]
+    (when can-use?
+      [LauncherFab {:fixed? false}])))
+
 (r/defc view
   "Floating assistant launcher + chat panel. Mounted once at app root;
    rendered only for users with the :ai-assistant/use privilege."
   []
   (let [can-use? @(rf/subscribe [::user-subs/check-privilege nil :ai-assistant/use])
-        open? @(rf/subscribe [::subs/open?])]
+        open? @(rf/subscribe [::subs/open?])
+        map-route? @(rf/subscribe [::subs/map-route?])
+        help-open? @(rf/subscribe [::help-subs/dialog-open?])]
     (when can-use?
       [:<>
        (when open? [Panel])
-       [:> Tooltip {:title "Lipastaja"}
-        [:> Fab {:color "secondary"
-                 :size "medium"
-                 :sx #js{:position "fixed"
-                         :bottom 24
-                         :right 16
-                         :zIndex 1250}
-                 :onClick #(==> [::events/toggle-panel])}
-         [:> SmartToyIcon]]]])))
+       ;; On the map route the launcher lives inside the bottom-right
+       ;; map-control container (see MapLauncher) — except when the
+       ;; fullscreen help dialog covers the map controls, in which case
+       ;; the floating Fab takes over again.
+       (when (or (not map-route?) help-open?)
+         [LauncherFab {:fixed? true}])])))

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -1,0 +1,194 @@
+(ns lipas.ui.assistant.views
+  (:require
+   ["@mui/icons-material/Close$default" :as CloseIcon]
+   ["@mui/icons-material/Send$default" :as SendIcon]
+   ["@mui/icons-material/SmartToy$default" :as SmartToyIcon]
+   ["@mui/material/Box$default" :as Box]
+   ["@mui/material/Button$default" :as Button]
+   ["@mui/material/Card$default" :as Card]
+   ["@mui/material/CardActions$default" :as CardActions]
+   ["@mui/material/CardContent$default" :as CardContent]
+   ["@mui/material/Chip$default" :as Chip]
+   ["@mui/material/CircularProgress$default" :as CircularProgress]
+   ["@mui/material/Fab$default" :as Fab]
+   ["@mui/material/IconButton$default" :as IconButton]
+   ["@mui/material/Paper$default" :as Paper]
+   ["@mui/material/Stack$default" :as Stack]
+   ["@mui/material/TextField$default" :as TextField]
+   ["@mui/material/Tooltip$default" :as Tooltip]
+   ["@mui/material/Typography$default" :as Typography]
+   ["react-markdown$default" :as ReactMarkdown]
+   [clojure.string :as str]
+   [lipas.ui.assistant.events :as events]
+   [lipas.ui.assistant.subs :as subs]
+   [lipas.ui.user.subs :as user-subs]
+   [lipas.ui.utils :refer [==>]]
+   [re-frame.core :as rf]
+   [reagent.core :as r]))
+
+(defn- md-link
+  "Markdown link renderer: ?ohje= links open the in-app help center,
+   everything else opens in a new tab."
+  [^js props]
+  (let [href (.-href props)]
+    (r/as-element
+     [:a {:href href
+          :on-click (fn [e]
+                      (when (str/starts-with? (str href) "?ohje=")
+                        (.preventDefault e)
+                        (==> [::events/open-source href])))
+          :target (when-not (str/starts-with? (str href) "?ohje=") "_blank")
+          :rel "noopener"}
+      (.-children props)])))
+
+(r/defc Message
+  [{:keys [message]}]
+  (let [{:keys [role text sources error?]} message
+        user? (= "user" role)]
+    [:> Box {:sx #js{:display "flex"
+                     :justifyContent (if user? "flex-end" "flex-start")}}
+     [:> Paper {:elevation 1
+                :sx #js{:p 1.5
+                        :maxWidth "85%"
+                        :bgcolor (cond
+                                   error? "error.light"
+                                   user? "secondary.light"
+                                   :else "grey.100")}}
+      (if user?
+        [:> Typography {:variant "body2"} text]
+        [:> Box {:sx #js{:typography "body2"
+                         "& p" #js{:mt 0 :mb 1}
+                         "& p:last-child" #js{:mb 0}
+                         "& ul, & ol" #js{:mt 0 :mb 1 :pl 2.5}
+                         "& a" #js{:color "secondary.dark"}}}
+         [:> ReactMarkdown {:components #js{:a md-link}} text]])
+      (when (seq sources)
+        [:> Stack {:direction "row" :spacing 0.5 :useFlexGap true
+                   :sx #js{:flexWrap "wrap" :mt 1}}
+         (for [{:keys [id title deep-link]} (take 4 sources)]
+           ^{:key id}
+           [:> Chip {:label title
+                     :size "small"
+                     :variant "outlined"
+                     :clickable true
+                     :onClick #(==> [::events/open-source deep-link])}])])]]))
+
+(r/defc EscalationCard []
+  (let [summary @(rf/subscribe [::subs/pending-escalation])
+        in-progress? @(rf/subscribe [::subs/escalation-in-progress?])
+        email (:email @(rf/subscribe [::user-subs/user-data]))]
+    (when summary
+      [:> Card {:variant "outlined"
+                :sx #js{:borderColor "secondary.main"}}
+       [:> CardContent {:sx #js{:pb 0}}
+        [:> Typography {:variant "subtitle2" :gutterBottom true}
+         "Tukipyyntö LIPAS-tuelle"]
+        [:> TextField {:value summary
+                       :onChange #(==> [::events/edit-escalation
+                                        (.. % -target -value)])
+                       :multiline true
+                       :minRows 2
+                       :maxRows 6
+                       :fullWidth true
+                       :size "small"}]
+        [:> Typography {:variant "caption" :color "text.secondary"}
+         (str "Kysymyksesi ja keskustelun tiivistelmä lähetetään LIPAS-tuelle "
+              "(lipasinfo@jyu.fi). Saat vastauksen osoitteeseen " email ".")]]
+       [:> CardActions
+        [:> Button {:size "small"
+                    :variant "contained"
+                    :color "secondary"
+                    :disabled in-progress?
+                    :onClick #(==> [::events/confirm-escalation])}
+         "Lähetä tukipyyntö"]
+        [:> Button {:size "small"
+                    :disabled in-progress?
+                    :onClick #(==> [::events/dismiss-escalation])}
+         "Peruuta"]]])))
+
+(r/defc Panel []
+  (let [messages @(rf/subscribe [::subs/messages])
+        input @(rf/subscribe [::subs/input])
+        thinking? @(rf/subscribe [::subs/thinking?])]
+    [:> Paper
+     {:elevation 8
+      :sx #js{:position "fixed"
+              :bottom 88
+              :right 16
+              :zIndex 1250
+              :width #js{:xs "calc(100vw - 32px)" :sm 420}
+              :height "min(600px, calc(100vh - 120px))"
+              :display "flex"
+              :flexDirection "column"}}
+
+     ;; Header
+     [:> Box {:sx #js{:display "flex"
+                      :alignItems "center"
+                      :p 1.5
+                      :bgcolor "primary.main"
+                      :color "primary.contrastText"}}
+      [:> SmartToyIcon {:fontSize "small" :sx #js{:mr 1}}]
+      [:> Typography {:variant "subtitle1" :sx #js{:flexGrow 1}}
+       "LIPAS-avustaja"]
+      [:> IconButton {:size "small"
+                      :sx #js{:color "inherit"}
+                      :onClick #(==> [::events/toggle-panel])}
+       [:> CloseIcon {:fontSize "small"}]]]
+
+     ;; Messages
+     [:> Stack {:spacing 1.5
+                :sx #js{:flexGrow 1
+                        :overflowY "auto"
+                        :p 1.5}}
+      (when (empty? messages)
+        [:> Typography {:variant "body2" :color "text.secondary"}
+         "Kysy LIPAS-järjestelmän käytöstä, liikuntapaikkatyypeistä tai
+          tietojen ylläpidosta. Vastaan ohjeiden pohjalta ja linkitän
+          lähteet."])
+      (for [[idx m] (map-indexed vector messages)]
+        ^{:key idx}
+        [Message {:message m}])
+      (when thinking?
+        [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
+         [:> CircularProgress {:size 16}]
+         [:> Typography {:variant "caption" :color "text.secondary"}
+          "Etsin vastausta…"]])
+      [EscalationCard]]
+
+     ;; Input
+     [:> Box {:sx #js{:display "flex" :gap 1 :p 1.5 :pt 0.5}}
+      [:> TextField {:value input
+                     :onChange #(==> [::events/set-input (.. % -target -value)])
+                     :onKeyDown (fn [e]
+                                  (when (and (= "Enter" (.-key e))
+                                             (not (.-shiftKey e)))
+                                    (.preventDefault e)
+                                    (==> [::events/send-message])))
+                     :placeholder "Kirjoita kysymys…"
+                     :multiline true
+                     :maxRows 4
+                     :fullWidth true
+                     :size "small"}]
+      [:> IconButton {:color "secondary"
+                      :disabled (str/blank? input)
+                      :onClick #(==> [::events/send-message])}
+       [:> SendIcon]]]]))
+
+(r/defc view
+  "Floating assistant launcher + chat panel. Mounted once at app root;
+   rendered only for users with the :ai-assistant/use privilege."
+  []
+  (let [can-use? @(rf/subscribe [::user-subs/check-privilege nil :ai-assistant/use])
+        open? @(rf/subscribe [::subs/open?])]
+    (when can-use?
+      [:<>
+       (when open? [Panel])
+       [:> Tooltip {:title "LIPAS-avustaja"}
+        [:> Fab {:color "secondary"
+                 :size "medium"
+                 :sx #js{:position "fixed"
+                         :bottom 24
+                         :right 16
+                         :zIndex 1250}
+                 :onClick #(==> [::events/toggle-panel])}
+         [:> SmartToyIcon]]]])))

--- a/webapp/src/cljs/lipas/ui/assistant/views.cljs
+++ b/webapp/src/cljs/lipas/ui/assistant/views.cljs
@@ -20,13 +20,13 @@
    ["@mui/material/IconButton$default" :as IconButton]
    ["@mui/material/Paper$default" :as Paper]
    ["@mui/material/Stack$default" :as Stack]
-   ["@mui/material/TextField$default" :as TextField]
    ["@mui/material/Tooltip$default" :as Tooltip]
    ["@mui/material/Typography$default" :as Typography]
    ["react-markdown$default" :as ReactMarkdown]
    [clojure.string :as str]
    [lipas.ui.assistant.events :as events]
    [lipas.ui.assistant.subs :as subs]
+   [lipas.ui.components.text-fields :as text-fields]
    [lipas.ui.help.subs :as help-subs]
    [lipas.ui.ptv.subs :as ptv-subs]
    [lipas.ui.user.subs :as user-subs]
@@ -128,14 +128,14 @@
        [:> CardContent {:sx #js{:pb 0}}
         [:> Typography {:variant "subtitle2" :gutterBottom true}
          "Tukipyyntö LIPAS-tuelle"]
-        [:> TextField {:value summary
-                       :onChange #(==> [::events/edit-escalation
-                                        (.. % -target -value)])
-                       :multiline true
-                       :minRows 2
-                       :maxRows 6
-                       :fullWidth true
-                       :size "small"}]
+        [text-fields/text-field
+         {:value summary
+          :on-change #(==> [::events/edit-escalation (or % "")])
+          :multiline true
+          :rows 4
+          :fullWidth true
+          :size "small"
+          :variant "outlined"}]
         [:> Typography {:variant "caption" :color "text.secondary"}
          (str "Kysymyksesi ja keskustelun tiivistelmä lähetetään LIPAS-tuelle "
               "(lipasinfo@jyu.fi). Saat vastauksen osoitteeseen " email ".")]]
@@ -219,20 +219,23 @@
           "Etsin vastausta…"]])
       [EscalationCard]]
 
-     ;; Input
+     ;; Input — the shared text-field routes typing through reagent's
+     ;; patched textarea (caret survives async re-render).
      [:> Box {:sx #js{:display "flex" :gap 1 :p 1.5 :pt 0.5}}
-      [:> TextField {:value input
-                     :onChange #(==> [::events/set-input (.. % -target -value)])
-                     :onKeyDown (fn [e]
-                                  (when (and (= "Enter" (.-key e))
-                                             (not (.-shiftKey e)))
-                                    (.preventDefault e)
-                                    (==> [::events/send-message])))
-                     :placeholder "Kirjoita kysymys…"
-                     :multiline true
-                     :maxRows 4
-                     :fullWidth true
-                     :size "small"}]
+      [text-fields/text-field
+       {:value input
+        :on-change #(==> [::events/set-input (or % "")])
+        :onKeyDown (fn [e]
+                     (when (and (= "Enter" (.-key e))
+                                (not (.-shiftKey e)))
+                       (.preventDefault e)
+                       (==> [::events/send-message])))
+        :placeholder "Kirjoita kysymys…"
+        :multiline true
+        :rows 2
+        :fullWidth true
+        :size "small"
+        :variant "outlined"}]
       [:> IconButton {:color "secondary"
                       :disabled (str/blank? input)
                       :onClick #(==> [::events/send-message])}

--- a/webapp/src/cljs/lipas/ui/core.cljs
+++ b/webapp/src/cljs/lipas/ui/core.cljs
@@ -3,6 +3,7 @@
             [lipas.ui.config :as config]
             [lipas.ui.effects]
             [lipas.ui.events :as events]
+            [lipas.ui.help.events :as help-events]
             [lipas.ui.interceptors]
             [lipas.ui.local-storage]
             [lipas.ui.project-devtools :as project-devtools]
@@ -35,6 +36,9 @@
 
 (defn init []
   (rf/dispatch-sync [::events/initialize-db])
+  ;; Sync so the ?ohje= deep-link param is read before the router's
+  ;; root-route redirect can rewrite the URL.
+  (rf/dispatch-sync [::help-events/init])
   (dev-setup)
   (qa-setup)
   (mount-root)

--- a/webapp/src/cljs/lipas/ui/help/db.cljs
+++ b/webapp/src/cljs/lipas/ui/help/db.cljs
@@ -3,10 +3,14 @@
 (def default-db
   {:dialog
    {:open? false
-    :selected-section-idx 0 ; Index of selected section in vector
+    ;; Selection is by canonical slug (strings). ?ohje= aliases resolve
+    ;; to these on navigation.
     :selected-section-slug nil
-    :selected-page-idx nil ; Index of selected page in section's pages vector
     :selected-page-slug nil
+    :expanded-sections #{}
+    :search-term ""
     :mode :read}
-   ;; Help data is loaded from the server
+   :editor
+   {:locale :fi}
+   ;; {:fi [sections] :se [...] :en [...]} loaded from the server
    :data nil})

--- a/webapp/src/cljs/lipas/ui/help/events.cljs
+++ b/webapp/src/cljs/lipas/ui/help/events.cljs
@@ -1,28 +1,97 @@
 (ns lipas.ui.help.events
   (:require [ajax.core :as ajax]
+            [clojure.string :as str]
             [re-frame.core :as rf]))
 
-(rf/reg-event-db ::open-dialog
-  (fn [db _]
-    (assoc-in db [:help :dialog :open?] true)))
+(defn- index-of-slug
+  [coll slug]
+  (when slug
+    (first (keep-indexed
+            (fn [idx x] (when (= (keyword slug) (:slug x)) idx))
+            coll))))
 
-(rf/reg-event-db ::close-dialog
-  (fn [db]
-    (assoc-in db [:help :dialog :open?] false)))
+(defn- resolve-selection
+  "Resolve section/page slugs (strings or keywords) against loaded help
+   data. Returns selection paths or nil when the section is unknown."
+  [data section-slug page-slug]
+  (when-let [section-idx (index-of-slug data section-slug)]
+    (let [pages    (get-in data [section-idx :pages])
+          page-idx (index-of-slug pages page-slug)]
+      {:section-idx  section-idx
+       :section-slug (get-in data [section-idx :slug])
+       :page-idx     page-idx
+       :page-slug    (when page-idx (get-in pages [page-idx :slug]))})))
 
-(rf/reg-event-db ::select-section
-  (fn [db [_ section-idx section-slug]]
-    (-> db
-        (assoc-in [:help :dialog :selected-section-idx] section-idx)
-        (assoc-in [:help :dialog :selected-section-slug] section-slug)
-        (assoc-in [:help :dialog :selected-page-idx] nil)
-        (assoc-in [:help :dialog :selected-page-slug] nil))))
+(defn- apply-selection
+  [db {:keys [section-idx section-slug page-idx page-slug]}]
+  (-> db
+      (assoc-in [:help :dialog :selected-section-idx] section-idx)
+      (assoc-in [:help :dialog :selected-section-slug] section-slug)
+      (assoc-in [:help :dialog :selected-page-idx] page-idx)
+      (assoc-in [:help :dialog :selected-page-slug] page-slug)))
 
-(rf/reg-event-db ::select-page
-  (fn [db [_ page-idx page-slug]]
-    (-> db
-        (assoc-in [:help :dialog :selected-page-idx] page-idx)
-        (assoc-in [:help :dialog :selected-page-slug] page-slug))))
+(defn- ohje-param
+  "Current dialog selection as the ?ohje= query param value, or nil when
+   the dialog is closed (nil removes the param from the URL)."
+  [db]
+  (when (get-in db [:help :dialog :open?])
+    (let [section-slug (or (get-in db [:help :dialog :selected-section-slug])
+                           (let [idx (get-in db [:help :dialog :selected-section-idx])]
+                             (when (number? idx)
+                               (get-in db [:help :data idx :slug]))))
+          page-slug    (get-in db [:help :dialog :selected-page-slug])]
+      (cond
+        (and section-slug page-slug) (str (name section-slug) "/" (name page-slug))
+        section-slug                 (name section-slug)
+        :else                        ""))))
+
+(rf/reg-fx ::sync-url!
+  (fn [param]
+    (let [url (js/URL. js/window.location.href)]
+      (if (some? param)
+        (.set (.-searchParams url) "ohje" param)
+        (.delete (.-searchParams url) "ohje"))
+      (.replaceState js/window.history nil "" (.toString url)))))
+
+(rf/reg-event-fx ::open-dialog
+  (fn [{:keys [db]} _]
+    (let [db (assoc-in db [:help :dialog :open?] true)]
+      {:db db ::sync-url! (ohje-param db)})))
+
+(rf/reg-event-fx ::close-dialog
+  (fn [{:keys [db]} _]
+    (let [db (assoc-in db [:help :dialog :open?] false)]
+      {:db db ::sync-url! nil})))
+
+(rf/reg-event-fx ::select-section
+  (fn [{:keys [db]} [_ section-idx section-slug]]
+    (let [db (-> db
+                 (assoc-in [:help :dialog :selected-section-idx] section-idx)
+                 (assoc-in [:help :dialog :selected-section-slug] section-slug)
+                 (assoc-in [:help :dialog :selected-page-idx] nil)
+                 (assoc-in [:help :dialog :selected-page-slug] nil))]
+      {:db db ::sync-url! (ohje-param db)})))
+
+(rf/reg-event-fx ::select-page
+  (fn [{:keys [db]} [_ page-idx page-slug]]
+    (let [db (-> db
+                 (assoc-in [:help :dialog :selected-page-idx] page-idx)
+                 (assoc-in [:help :dialog :selected-page-slug] page-slug))]
+      {:db db ::sync-url! (ohje-param db)})))
+
+(rf/reg-event-fx ::navigate-to
+  (fn [{:keys [db]} [_ section-slug page-slug]]
+    (let [data (get-in db [:help :data])
+          db   (assoc-in db [:help :dialog :open?] true)
+          db   (if (nil? data)
+                 ;; Data not loaded yet — remember the target, ::get-success
+                 ;; resolves it once content arrives.
+                 (assoc-in db [:help :dialog :pending-slugs]
+                           {:section section-slug :page page-slug})
+                 (if-let [selection (resolve-selection data section-slug page-slug)]
+                   (apply-selection db selection)
+                   db))]
+      {:db db ::sync-url! (ohje-param db)})))
 
 (rf/reg-event-fx ::open-edit-mode
   (fn [{:keys [db]} _]
@@ -33,10 +102,20 @@
   (fn [db _]
     (assoc-in db [:help :dialog :mode] :read)))
 
+(rf/reg-event-fx ::init
+  ;; Dispatched once at app startup: loads help content and opens the
+  ;; dialog when the URL carries an ?ohje=section/page deep link.
+  (fn [_ _]
+    (let [ohje (-> (js/URLSearchParams. js/window.location.search)
+                   (.get "ohje"))]
+      {:fx (cond-> [[:dispatch [::get-help-data]]]
+             (some? ohje)
+             (conj [:dispatch (let [[section page] (str/split ohje #"/")]
+                                [::navigate-to (not-empty section) (not-empty page)])]))})))
+
 (rf/reg-event-fx ::get-help-data
   (fn [{:keys [db]} _]
-    {:db (assoc-in db [:help :save-in-progress] true)
-     :fx [[:http-xhrio
+    {:fx [[:http-xhrio
            {:method          :post
             :uri             (str (:backend-url db) "/actions/get-help-data")
             :format          (ajax/transit-request-format)
@@ -46,7 +125,18 @@
 
 (rf/reg-event-fx ::get-success
   (fn [{:keys [db]} [_ help-data]]
-    {:db (assoc-in db [:help :data] help-data)}))
+    (let [pending (get-in db [:help :dialog :pending-slugs])
+          db      (-> db
+                      (assoc-in [:help :data] help-data)
+                      (update-in [:help :dialog] dissoc :pending-slugs))
+          db      (if-let [selection (and pending
+                                          (resolve-selection help-data
+                                                             (:section pending)
+                                                             (:page pending)))]
+                    (apply-selection db selection)
+                    db)]
+      (cond-> {:db db}
+        pending (assoc ::sync-url! (ohje-param db))))))
 
 (rf/reg-event-fx ::get-failure
   (fn [{:keys [db]} [_ resp]]

--- a/webapp/src/cljs/lipas/ui/help/events.cljs
+++ b/webapp/src/cljs/lipas/ui/help/events.cljs
@@ -3,47 +3,76 @@
             [clojure.string :as str]
             [re-frame.core :as rf]))
 
-(defn- index-of-slug
-  [coll slug]
-  (when slug
-    (first (keep-indexed
-            (fn [idx x] (when (= (keyword slug) (:slug x)) idx))
-            coll))))
+;; Help content is v2: {:fi [sections] :se [...] :en [...]} — each
+;; locale has its own independent tree. The UI shows the user's locale
+;; when it has published content, otherwise falls back to Finnish.
+
+(defn- match-slug?
+  "Slug match including :aliases so old published ?ohje= links and KB
+   citations keep resolving after renames."
+  [{:keys [slug aliases]} target]
+  (let [t (name target)]
+    (boolean (or (= slug t) (some #(= t %) aliases)))))
+
+(defn find-section [tree slug]
+  (when (and tree slug)
+    (first (filter #(match-slug? % slug) tree))))
+
+(defn find-page [section slug]
+  (when (and section slug)
+    (first (filter #(match-slug? % slug) (:pages section)))))
+
+(defn display-tree
+  "The tree shown to the user: their locale's tree, or the fi tree when
+   their locale has no published content."
+  [db]
+  (let [locale ((:translator db))
+        data (get-in db [:help :data])
+        tree (get data locale)]
+    (if (seq tree) tree (:fi data))))
 
 (defn- resolve-selection
-  "Resolve section/page slugs (strings or keywords) against loaded help
-   data. Returns selection paths or nil when the section is unknown."
-  [data section-slug page-slug]
-  (when-let [section-idx (index-of-slug data section-slug)]
-    (let [pages    (get-in data [section-idx :pages])
-          page-idx (index-of-slug pages page-slug)]
-      {:section-idx  section-idx
-       :section-slug (get-in data [section-idx :slug])
-       :page-idx     page-idx
-       :page-slug    (when page-idx (get-in pages [page-idx :slug]))})))
+  "Resolve section/page slugs (strings, keywords or aliases) against the
+   display tree. Returns canonical slugs or nil when the section is
+   unknown."
+  [db section-slug page-slug]
+  (let [tree (display-tree db)]
+    (when-let [section (find-section tree section-slug)]
+      (let [page (find-page section page-slug)]
+        {:section-slug (:slug section)
+         :page-slug (:slug page)}))))
 
 (defn- apply-selection
-  [db {:keys [section-idx section-slug page-idx page-slug]}]
+  [db {:keys [section-slug page-slug]}]
   (-> db
-      (assoc-in [:help :dialog :selected-section-idx] section-idx)
       (assoc-in [:help :dialog :selected-section-slug] section-slug)
-      (assoc-in [:help :dialog :selected-page-idx] page-idx)
-      (assoc-in [:help :dialog :selected-page-slug] page-slug)))
+      (assoc-in [:help :dialog :selected-page-slug] page-slug)
+      (update-in [:help :dialog :expanded-sections] (fnil conj #{}) section-slug)))
 
 (defn- ohje-param
   "Current dialog selection as the ?ohje= query param value, or nil when
    the dialog is closed (nil removes the param from the URL)."
   [db]
   (when (get-in db [:help :dialog :open?])
-    (let [section-slug (or (get-in db [:help :dialog :selected-section-slug])
-                           (let [idx (get-in db [:help :dialog :selected-section-idx])]
-                             (when (number? idx)
-                               (get-in db [:help :data idx :slug]))))
-          page-slug    (get-in db [:help :dialog :selected-page-slug])]
+    (let [section-slug (get-in db [:help :dialog :selected-section-slug])
+          page-slug (get-in db [:help :dialog :selected-page-slug])]
       (cond
-        (and section-slug page-slug) (str (name section-slug) "/" (name page-slug))
-        section-slug                 (name section-slug)
-        :else                        ""))))
+        (and section-slug page-slug) (str section-slug "/" page-slug)
+        section-slug section-slug
+        :else ""))))
+
+(defn dialog-context
+  "Open help page for the assistant's context snapshot, or nil."
+  [db]
+  (when (get-in db [:help :dialog :open?])
+    (let [section-slug (get-in db [:help :dialog :selected-section-slug])
+          page-slug (get-in db [:help :dialog :selected-page-slug])
+          section (find-section (display-tree db) section-slug)
+          page (find-page section page-slug)]
+      (cond-> {}
+        section-slug (assoc :section section-slug)
+        page-slug (assoc :page page-slug)
+        (:title page) (assoc :title (:title page))))))
 
 (rf/reg-fx ::sync-url!
   (fn [param]
@@ -64,33 +93,47 @@
       {:db db ::sync-url! nil})))
 
 (rf/reg-event-fx ::select-section
-  (fn [{:keys [db]} [_ section-idx section-slug]]
-    (let [db (-> db
-                 (assoc-in [:help :dialog :selected-section-idx] section-idx)
-                 (assoc-in [:help :dialog :selected-section-slug] section-slug)
-                 (assoc-in [:help :dialog :selected-page-idx] nil)
-                 (assoc-in [:help :dialog :selected-page-slug] nil))]
+  (fn [{:keys [db]} [_ section-slug]]
+    (let [db (apply-selection db {:section-slug section-slug :page-slug nil})]
       {:db db ::sync-url! (ohje-param db)})))
 
 (rf/reg-event-fx ::select-page
-  (fn [{:keys [db]} [_ page-idx page-slug]]
-    (let [db (-> db
-                 (assoc-in [:help :dialog :selected-page-idx] page-idx)
-                 (assoc-in [:help :dialog :selected-page-slug] page-slug))]
+  (fn [{:keys [db]} [_ section-slug page-slug]]
+    (let [db (apply-selection db {:section-slug section-slug :page-slug page-slug})]
       {:db db ::sync-url! (ohje-param db)})))
+
+(rf/reg-event-fx ::go-home
+  (fn [{:keys [db]} _]
+    (let [db (-> db
+                 (assoc-in [:help :dialog :selected-section-slug] nil)
+                 (assoc-in [:help :dialog :selected-page-slug] nil))]
+      {:db db ::sync-url! (ohje-param db)})))
+
+(rf/reg-event-db ::toggle-section
+  (fn [db [_ section-slug]]
+    (update-in db [:help :dialog :expanded-sections]
+               (fn [expanded]
+                 (let [expanded (or expanded #{})]
+                   (if (contains? expanded section-slug)
+                     (disj expanded section-slug)
+                     (conj expanded section-slug)))))))
+
+(rf/reg-event-db ::set-search-term
+  (fn [db [_ term]]
+    (assoc-in db [:help :dialog :search-term] term)))
 
 (rf/reg-event-fx ::navigate-to
   (fn [{:keys [db]} [_ section-slug page-slug]]
     (let [data (get-in db [:help :data])
-          db   (assoc-in db [:help :dialog :open?] true)
-          db   (if (nil? data)
-                 ;; Data not loaded yet — remember the target, ::get-success
-                 ;; resolves it once content arrives.
-                 (assoc-in db [:help :dialog :pending-slugs]
-                           {:section section-slug :page page-slug})
-                 (if-let [selection (resolve-selection data section-slug page-slug)]
-                   (apply-selection db selection)
-                   db))]
+          db (assoc-in db [:help :dialog :open?] true)
+          db (if (nil? data)
+               ;; Data not loaded yet — remember the target, ::get-success
+               ;; resolves it once content arrives.
+               (assoc-in db [:help :dialog :pending-slugs]
+                         {:section section-slug :page page-slug})
+               (if-let [selection (resolve-selection db section-slug page-slug)]
+                 (apply-selection db selection)
+                 db))]
       {:db db ::sync-url! (ohje-param db)})))
 
 (rf/reg-event-fx ::open-edit-mode
@@ -130,7 +173,7 @@
                       (assoc-in [:help :data] help-data)
                       (update-in [:help :dialog] dissoc :pending-slugs))
           db      (if-let [selection (and pending
-                                          (resolve-selection help-data
+                                          (resolve-selection db
                                                              (:section pending)
                                                              (:page pending)))]
                     (apply-selection db selection)

--- a/webapp/src/cljs/lipas/ui/help/manage.cljs
+++ b/webapp/src/cljs/lipas/ui/help/manage.cljs
@@ -1,8 +1,13 @@
 (ns lipas.ui.help.manage
+  "Help content editor (v2): each locale (fi/se/en) is an independent
+   tree edited, drafted and published separately. The toolbar's locale
+   tabs switch which tree is being edited; Save draft / Publish /
+   History all target the active locale only."
   (:require
    ["@mui/icons-material/Add$default" :as AddIcon]
    ["@mui/icons-material/ArrowDownward$default" :as ArrowDownIcon]
    ["@mui/icons-material/ArrowUpward$default" :as ArrowUpIcon]
+   ["@mui/icons-material/AutoFixHigh$default" :as AutoFixIcon]
    ["@mui/icons-material/CategoryOutlined$default" :as CategoryIcon]
    ["@mui/icons-material/Delete$default" :as DeleteIcon]
    ["@mui/icons-material/Download$default" :as DownloadIcon]
@@ -19,6 +24,7 @@
    ["@mui/material/Card$default" :as Card]
    ["@mui/material/CardContent$default" :as CardContent]
    ["@mui/material/CardHeader$default" :as CardHeader]
+   ["@mui/material/Chip$default" :as Chip]
    ["@mui/material/Collapse$default" :as Collapse]
    ["@mui/material/Dialog$default" :as Dialog]
    ["@mui/material/DialogActions$default" :as DialogActions]
@@ -27,7 +33,7 @@
    ["@mui/material/DialogTitle$default" :as DialogTitle]
    ["@mui/material/FormControl$default" :as FormControl]
    ["@mui/material/IconButton$default" :as IconButton]
-   ["@mui/material/Chip$default" :as Chip]
+   ["@mui/material/InputAdornment$default" :as InputAdornment]
    ["@mui/material/InputLabel$default" :as InputLabel]
    ["@mui/material/List$default" :as MuiList]
    ["@mui/material/ListItem$default" :as ListItem]
@@ -40,948 +46,630 @@
    ["@mui/material/Tabs$default" :as Tabs]
    ["@mui/material/TextField$default" :as TextField]
    ["@mui/material/Toolbar$default" :as Toolbar]
+   ["@mui/material/Tooltip$default" :as Tooltip]
    ["@mui/material/Typography$default" :as Typography]
    [ajax.core :as ajax]
    [clojure.string :as str]
    [lipas.ui.help.events :as events]
    [lipas.ui.help.subs :as subs]
+   [lipas.utils :as cutils]
    [re-frame.core :as rf]
    [reagent.core :as r]
    [reagent.hooks :as hooks]))
 
-;; Events for managing help content
-(rf/reg-event-db
- ::initialize-editor
- (fn [db _]
-   (update db :help assoc :edited-data (get-in db [:help :data]))))
+;;; ——— Helpers ————————————————————————————————————————————————————————
 
-(rf/reg-event-db
- ::update-section-title
- (fn [db [_ section-idx lang value]]
-   (assoc-in db [:help :edited-data section-idx :title lang] value)))
+(defn- editor-locale [db]
+  (get-in db [:help :editor :locale] :fi))
 
-(rf/reg-event-db
- ::update-page-title
- (fn [db [_ section-idx page-idx lang value]]
-   (assoc-in db [:help :edited-data section-idx :pages page-idx :title lang] value)))
+(defn- epath
+  "Path into the active locale's edited tree."
+  [db & ks]
+  (into [:help :edited-data (editor-locale db)] ks))
 
-(rf/reg-event-db
- ::update-block-content
- (fn [db [_ section-idx page-idx block-idx field lang value]]
-   (assoc-in db [:help :edited-data section-idx :pages page-idx :blocks block-idx field lang] value)))
+(defn- unique-slug
+  "Slug from title, made unique among taken (a set of strings)."
+  [title fallback taken]
+  (let [base (let [s (cutils/->slug title)]
+               (if (str/blank? s) fallback s))]
+    (if-not (contains? taken base)
+      base
+      (loop [n 2]
+        (let [s (str base "-" n)]
+          (if (contains? taken s) (recur (inc n)) s))))))
 
-(rf/reg-event-db
- ::update-block-field
- (fn [db [_ section-idx page-idx block-idx field value]]
-   (assoc-in db [:help :edited-data section-idx :pages page-idx :blocks block-idx field] value)))
+(defn- vec-remove [v idx]
+  (vec (concat (subvec v 0 idx) (subvec v (inc idx)))))
 
-(rf/reg-event-db
- ::add-block
- (fn [db [_ section-idx page-idx block-type]]
-   (let [block-id (str (random-uuid))
-         base-block {:block-id block-id :type block-type}
-         new-block (case block-type
-                     :text (assoc base-block :content {:fi "" :en "" :se ""})
-                     :video (assoc base-block
-                                   :provider :youtube
-                                   :video-id ""
-                                   :title {:fi "" :en "" :se ""})
-                     :image (assoc base-block
-                                   :url ""
-                                   :alt {:fi "" :en "" :se ""}
-                                   :caption {:fi "" :en "" :se ""})
-                     :pdf (assoc base-block
-                                 :url ""
-                                 :caption {:fi "" :en "" :se ""}
-                                 :title {:fi "" :en "" :se ""})
-                     :type-code-explorer base-block ;; No additional props needed for type explorer
-                     :data-model-excel-download base-block)]
-     (update-in db [:help :edited-data section-idx :pages page-idx :blocks] conj new-block))))
+(defn- vec-swap [v i j]
+  (-> v (assoc i (v j)) (assoc j (v i))))
 
-(rf/reg-event-db
- ::delete-block
- (fn [db [_ section-idx page-idx block-idx]]
-   (update-in db [:help :edited-data section-idx :pages page-idx :blocks]
-              (fn [blocks]
-                (vec (concat
-                      (subvec blocks 0 block-idx)
-                      (subvec blocks (inc block-idx))))))))
+;;; ——— Editor state events ————————————————————————————————————————————
 
-(rf/reg-event-db
- ::move-block-up
- (fn [db [_ section-idx page-idx block-idx]]
-   (if (zero? block-idx)
-     db ; Already at the top, no change
-     (update-in db [:help :edited-data section-idx :pages page-idx :blocks]
-                (fn [blocks]
-                  (let [block (get blocks block-idx)
-                        prev-block (get blocks (dec block-idx))]
-                    (-> blocks
-                        (assoc (dec block-idx) block)
-                        (assoc block-idx prev-block))))))))
+(rf/reg-event-db ::initialize-editor
+  (fn [db _]
+    (-> db
+        (assoc-in [:help :edited-data] (get-in db [:help :data]))
+        (assoc-in [:help :editor :section-idx]
+                  (when (seq (get-in db [:help :data (editor-locale db)])) 0))
+        (assoc-in [:help :editor :page-idx] nil))))
 
-(rf/reg-event-db
- ::move-block-down
- (fn [db [_ section-idx page-idx block-idx]]
-   (let [blocks (get-in db [:help :edited-data section-idx :pages page-idx :blocks])
-         last-idx (dec (count blocks))]
-     (if (= block-idx last-idx)
-       db ; Already at the bottom, no change
-       (update-in db [:help :edited-data section-idx :pages page-idx :blocks]
-                  (fn [blocks]
-                    (let [block (get blocks block-idx)
-                          next-block (get blocks (inc block-idx))]
-                      (-> blocks
-                          (assoc block-idx next-block)
-                          (assoc (inc block-idx) block)))))))))
+(rf/reg-event-db ::set-editor-locale
+  (fn [db [_ locale]]
+    (-> db
+        (assoc-in [:help :editor :locale] locale)
+        (assoc-in [:help :editor :section-idx]
+                  (when (seq (get-in db [:help :edited-data locale])) 0))
+        (assoc-in [:help :editor :page-idx] nil))))
 
-;; Section reordering events
-(rf/reg-event-db
- ::move-section-up
- (fn [db [_ section-idx]]
-   (if (zero? section-idx)
-     db ; Already at the top, no change
-     (update-in db [:help :edited-data]
-                (fn [sections]
-                  (let [section (get sections section-idx)
-                        prev-section (get sections (dec section-idx))]
-                    (-> sections
-                        (assoc (dec section-idx) section)
-                        (assoc section-idx prev-section))))))))
+(rf/reg-event-db ::select-section
+  (fn [db [_ idx]]
+    (-> db
+        (assoc-in [:help :editor :section-idx] idx)
+        (assoc-in [:help :editor :page-idx] nil))))
 
-(rf/reg-event-db
- ::move-section-down
- (fn [db [_ section-idx]]
-   (let [sections (get-in db [:help :edited-data])
-         last-idx (dec (count sections))]
-     (if (= section-idx last-idx)
-       db ; Already at the bottom, no change
-       (update-in db [:help :edited-data]
-                  (fn [sections]
-                    (let [section (get sections section-idx)
-                          next-section (get sections (inc section-idx))]
-                      (-> sections
-                          (assoc section-idx next-section)
-                          (assoc (inc section-idx) section)))))))))
+(rf/reg-event-db ::select-page
+  (fn [db [_ idx]]
+    (assoc-in db [:help :editor :page-idx] idx)))
 
-;; Page reordering events
-(rf/reg-event-db
- ::move-page-up
- (fn [db [_ section-idx page-idx]]
-   (if (zero? page-idx)
-     db ; Already at the top, no change
-     (update-in db [:help :edited-data section-idx :pages]
-                (fn [pages]
-                  (let [page (get pages page-idx)
-                        prev-page (get pages (dec page-idx))]
-                    (-> pages
-                        (assoc (dec page-idx) page)
-                        (assoc page-idx prev-page))))))))
+;;; ——— Section/page field edits ———————————————————————————————————————
 
-(rf/reg-event-db
- ::move-page-down
- (fn [db [_ section-idx page-idx]]
-   (let [pages (get-in db [:help :edited-data section-idx :pages])
-         last-idx (dec (count pages))]
-     (if (= page-idx last-idx)
-       db ; Already at the bottom, no change
-       (update-in db [:help :edited-data section-idx :pages]
-                  (fn [pages]
-                    (let [page (get pages page-idx)
-                          next-page (get pages (inc page-idx))]
-                      (-> pages
-                          (assoc page-idx next-page)
-                          (assoc (inc page-idx) page)))))))))
+(rf/reg-event-db ::update-section-field
+  (fn [db [_ section-idx field value]]
+    (assoc-in db (epath db section-idx field) value)))
 
-;; Helper function to create a slug from a string
-(defn- create-slug [s]
-  (-> (or s "")
-      str/lower-case
-      (str/replace #"[^\w\s-]" "") ; Remove special chars except spaces and hyphens
-      (str/replace #"\s+" "-")     ; Replace spaces with hyphens
-      (str/replace #"-+" "-")      ; Replace multiple hyphens with single
-      (str/replace #"^-|-$" "")))  ; Remove leading/trailing hyphens
+(rf/reg-event-db ::update-page-field
+  (fn [db [_ section-idx page-idx field value]]
+    (assoc-in db (epath db section-idx :pages page-idx field) value)))
 
-(rf/reg-event-db
- ::add-page
- (fn [db [_ section-idx]]
-   (let [default-title "New Page"
-         ;; Create a basic slug from the title
-         base-slug (create-slug default-title)
-         ;; Add timestamp to ensure uniqueness
-         timestamp (.now js/Date)
-         ;; Create a basic page structure
-         new-page {:slug (keyword (str base-slug "-" timestamp))
-                   :title {:fi default-title :en default-title :se "Ny sida"}
-                   :blocks []}
-         ;; Get the current pages vector
-         pages (get-in db [:help :edited-data section-idx :pages])
-         new-page-idx (count pages)]
-     ;; Add the new page to the appropriate section
-     (-> db
-         (update-in [:help :edited-data section-idx :pages] conj new-page)
-         ;; Select the new page
-         (assoc-in [:help :dialog :selected-page-idx] new-page-idx)
-         (assoc-in [:help :dialog :selected-page-slug] (:slug new-page))))))
+(rf/reg-event-db ::generate-section-slug
+  ;; Regenerating a published slug is safe-ish: the old slug should be
+  ;; added to :aliases. We do that automatically here.
+  (fn [db [_ section-idx]]
+    (let [sections (get-in db (epath db))
+          {:keys [title slug aliases]} (get sections section-idx)
+          taken (into #{} (map :slug) (vec-remove sections section-idx))
+          new-slug (unique-slug title slug taken)]
+      (if (= new-slug slug)
+        db
+        (-> db
+            (assoc-in (epath db section-idx :slug) new-slug)
+            (assoc-in (epath db section-idx :aliases)
+                      (vec (distinct (concat aliases [slug])))))))))
 
-(rf/reg-event-db
- ::delete-page
- (fn [db [_ section-idx page-idx]]
-   (let [pages (get-in db [:help :edited-data section-idx :pages])
-         selected-page-idx (get-in db [:help :dialog :selected-page-idx])
-         ;; If we're deleting the currently selected page, select the first available page
-         new-selected-idx (if (= selected-page-idx page-idx)
-                            (if (= page-idx 0)
-                              (if (> (count pages) 1) 0 nil) ; Select first page if still pages, else nil
-                              (dec page-idx)) ; Select previous page
-                            (if (and selected-page-idx (> selected-page-idx page-idx))
-                              (dec selected-page-idx) ; Adjust selected index if it's after the deleted one
-                              selected-page-idx))
-         new-selected-slug (when (and (some? new-selected-idx) (< new-selected-idx (count (filterv #(not= % (nth pages page-idx)) pages))))
-                             (:slug (nth (filterv #(not= % (nth pages page-idx)) pages) new-selected-idx)))]
-     (-> db
-         ;; Remove the page from the section
-         (update-in [:help :edited-data section-idx :pages]
-                    (fn [pages] (vec (concat (subvec pages 0 page-idx) (subvec pages (inc page-idx))))))
-         ;; Update the selected page if needed
-         (assoc-in [:help :dialog :selected-page-idx] new-selected-idx)
-         (assoc-in [:help :dialog :selected-page-slug] new-selected-slug)))))
+(rf/reg-event-db ::generate-page-slug
+  (fn [db [_ section-idx page-idx]]
+    (let [pages (get-in db (epath db section-idx :pages))
+          {:keys [title slug aliases]} (get pages page-idx)
+          taken (into #{} (map :slug) (vec-remove pages page-idx))
+          new-slug (unique-slug title slug taken)]
+      (if (= new-slug slug)
+        db
+        (-> db
+            (assoc-in (epath db section-idx :pages page-idx :slug) new-slug)
+            (assoc-in (epath db section-idx :pages page-idx :aliases)
+                      (vec (distinct (concat aliases [slug])))))))))
 
-(rf/reg-event-db
- ::add-section
- (fn [db _]
-   (let [default-title "New Section"
-         ;; Create a basic slug from the title
-         base-slug (create-slug default-title)
-         ;; Add timestamp to ensure uniqueness
-         timestamp (.now js/Date)
-         ;; Create a basic section structure with one default page
-         section-slug (keyword (str base-slug "-" timestamp))
-         welcome-page {:slug (keyword "welcome")
-                       :title {:fi "Welcome" :en "Welcome" :se "Välkommen"}
-                       :blocks []}
-         new-section {:slug section-slug
-                      :title {:fi default-title :en default-title :se "Ny sektion"}
-                      :pages [welcome-page]}
-         ;; Get the current sections
-         sections (or (get-in db [:help :edited-data]) [])
-         new-section-idx (count sections)]
-     ;; Add the new section
-     (-> db
-         (update-in [:help :edited-data] (fn [sections] (conj (or sections []) new-section)))
-         ;; Select the new section and its first page
-         (assoc-in [:help :dialog :selected-section-idx] new-section-idx)
-         (assoc-in [:help :dialog :selected-section-slug] section-slug)
-         (assoc-in [:help :dialog :selected-page-idx] 0)
-         (assoc-in [:help :dialog :selected-page-slug] (:slug welcome-page))))))
+;;; ——— Block events ———————————————————————————————————————————————————
 
-(rf/reg-event-db
- ::delete-section
- (fn [db [_ section-idx]]
-   (let [sections (get-in db [:help :edited-data])
-         selected-section-idx (get-in db [:help :dialog :selected-section-idx])
-         ;; If we're deleting the currently selected section, select the first available section
-         new-selected-idx (if (= selected-section-idx section-idx)
-                            (if (= section-idx 0)
-                              (if (> (count sections) 1) 0 nil) ; Select first section if still sections, else nil
-                              (dec section-idx)) ; Select previous section
-                            (if (and selected-section-idx (> selected-section-idx section-idx))
-                              (dec selected-section-idx) ; Adjust selected index if it's after the deleted one
-                              selected-section-idx))
-         new-selected-slug (when (and (some? new-selected-idx) (< new-selected-idx (count (filterv #(not= % (nth sections section-idx)) sections))))
-                             (:slug (nth (filterv #(not= % (nth sections section-idx)) sections) new-selected-idx)))]
-     (-> db
-         ;; Remove the section
-         (update-in [:help :edited-data]
-                    (fn [sections] (vec (concat (subvec sections 0 section-idx) (subvec sections (inc section-idx))))))
-         ;; Update the selected section if needed
-         (assoc-in [:help :dialog :selected-section-idx] new-selected-idx)
-         (assoc-in [:help :dialog :selected-section-slug] new-selected-slug)
-         ;; Clear page selection if we deleted the selected section
-         ((fn [updated-db]
-            (if (= selected-section-idx section-idx)
-              (-> updated-db
-                  (assoc-in [:help :dialog :selected-page-idx] nil)
-                  (assoc-in [:help :dialog :selected-page-slug] nil))
-              updated-db)))))))
+(rf/reg-event-db ::update-block-field
+  (fn [db [_ section-idx page-idx block-idx field value]]
+    (assoc-in db (epath db section-idx :pages page-idx :blocks block-idx field)
+              value)))
 
-(rf/reg-event-db
- ::apply-changes
- (fn [db _]
-   (-> db
-       (assoc-in [:help :data] (get-in db [:help :edited-data]))
-       (assoc-in [:help :dialog :mode] :read))))
+(rf/reg-event-db ::add-block
+  (fn [db [_ section-idx page-idx block-type]]
+    (let [base-block {:block-id (str (random-uuid)) :type block-type}
+          new-block (case block-type
+                      :text (assoc base-block :content "")
+                      :video (assoc base-block
+                                    :provider :youtube
+                                    :video-id ""
+                                    :title "")
+                      :image (assoc base-block :url "" :alt "" :caption "")
+                      :pdf (assoc base-block :url "" :title "" :caption "")
+                      :type-code-explorer base-block
+                      :data-model-excel-download base-block)]
+      (update-in db (epath db section-idx :pages page-idx :blocks)
+                 (fnil conj []) new-block))))
+
+(rf/reg-event-db ::delete-block
+  (fn [db [_ section-idx page-idx block-idx]]
+    (update-in db (epath db section-idx :pages page-idx :blocks)
+               vec-remove block-idx)))
+
+(rf/reg-event-db ::move-block-up
+  (fn [db [_ section-idx page-idx block-idx]]
+    (if (zero? block-idx)
+      db
+      (update-in db (epath db section-idx :pages page-idx :blocks)
+                 vec-swap block-idx (dec block-idx)))))
+
+(rf/reg-event-db ::move-block-down
+  (fn [db [_ section-idx page-idx block-idx]]
+    (let [blocks (get-in db (epath db section-idx :pages page-idx :blocks))]
+      (if (= block-idx (dec (count blocks)))
+        db
+        (update-in db (epath db section-idx :pages page-idx :blocks)
+                   vec-swap block-idx (inc block-idx))))))
+
+;;; ——— Section/page add/delete/reorder ————————————————————————————————
+
+(rf/reg-event-db ::add-section
+  (fn [db _]
+    (let [sections (or (get-in db (epath db)) [])
+          slug (unique-slug "" "uusi-osio" (into #{} (map :slug) sections))
+          new-section {:id (str (random-uuid))
+                       :slug slug
+                       :title ""
+                       :pages []}]
+      (-> db
+          (assoc-in (epath db) (conj sections new-section))
+          (assoc-in [:help :editor :section-idx] (count sections))
+          (assoc-in [:help :editor :page-idx] nil)))))
+
+(rf/reg-event-db ::delete-section
+  (fn [db [_ section-idx]]
+    (let [sections (vec-remove (get-in db (epath db)) section-idx)]
+      (-> db
+          (assoc-in (epath db) sections)
+          (assoc-in [:help :editor :section-idx] (when (seq sections) 0))
+          (assoc-in [:help :editor :page-idx] nil)))))
+
+(rf/reg-event-db ::move-section-up
+  (fn [db [_ section-idx]]
+    (if (zero? section-idx)
+      db
+      (-> db
+          (update-in (epath db) vec-swap section-idx (dec section-idx))
+          (assoc-in [:help :editor :section-idx] (dec section-idx))))))
+
+(rf/reg-event-db ::move-section-down
+  (fn [db [_ section-idx]]
+    (let [sections (get-in db (epath db))]
+      (if (= section-idx (dec (count sections)))
+        db
+        (-> db
+            (update-in (epath db) vec-swap section-idx (inc section-idx))
+            (assoc-in [:help :editor :section-idx] (inc section-idx)))))))
+
+(rf/reg-event-db ::add-page
+  (fn [db [_ section-idx]]
+    (let [pages (or (get-in db (epath db section-idx :pages)) [])
+          slug (unique-slug "" "uusi-sivu" (into #{} (map :slug) pages))
+          new-page {:id (str (random-uuid))
+                    :slug slug
+                    :title ""
+                    :blocks []}]
+      (-> db
+          (assoc-in (epath db section-idx :pages) (conj pages new-page))
+          (assoc-in [:help :editor :page-idx] (count pages))))))
+
+(rf/reg-event-db ::delete-page
+  (fn [db [_ section-idx page-idx]]
+    (-> db
+        (update-in (epath db section-idx :pages) vec-remove page-idx)
+        (assoc-in [:help :editor :page-idx] nil))))
+
+(rf/reg-event-db ::move-page-up
+  (fn [db [_ section-idx page-idx]]
+    (if (zero? page-idx)
+      db
+      (-> db
+          (update-in (epath db section-idx :pages) vec-swap page-idx (dec page-idx))
+          (assoc-in [:help :editor :page-idx] (dec page-idx))))))
+
+(rf/reg-event-db ::move-page-down
+  (fn [db [_ section-idx page-idx]]
+    (let [pages (get-in db (epath db section-idx :pages))]
+      (if (= page-idx (dec (count pages)))
+        db
+        (-> db
+            (update-in (epath db section-idx :pages) vec-swap page-idx (inc page-idx))
+            (assoc-in [:help :editor :page-idx] (inc page-idx)))))))
+
+;;; ——— Preview / save / publish (per locale) ——————————————————————————
+
+(rf/reg-event-db ::apply-changes
+  ;; Preview: copy the active locale's edited tree into the read-mode
+  ;; data without saving.
+  (fn [db _]
+    (let [locale (editor-locale db)]
+      (-> db
+          (assoc-in [:help :data locale] (get-in db [:help :edited-data locale]))
+          (assoc-in [:help :dialog :mode] :read)))))
 
 (rf/reg-event-fx ::save-changes
-                 (fn [{:keys [db]} _]
-                   (let [token  (-> db :user :login :token)]
-                     {:db (assoc-in db [:help :save-in-progress] true)
-                      :fx [[:http-xhrio
-                            {:method          :post
-                             :headers         {:Authorization (str "Token " token)}
-                             :uri             (str (:backend-url db) "/actions/save-help-data")
-                             :params          (get-in db [:help :edited-data])
-                             :format          (ajax/transit-request-format)
-                             :response-format (ajax/transit-response-format)
-                             :on-success      [::save-success]
-                             :on-failure      [::save-failure]}]]})))
+  (fn [{:keys [db]} _]
+    (let [token (-> db :user :login :token)
+          locale (editor-locale db)]
+      {:db (assoc-in db [:help :save-in-progress] true)
+       :fx [[:http-xhrio
+             {:method          :post
+              :headers         {:Authorization (str "Token " token)}
+              :uri             (str (:backend-url db) "/actions/save-help-data")
+              :params          {:locale locale
+                                :data (get-in db [:help :edited-data locale])}
+              :format          (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success      [::save-success]
+              :on-failure      [::save-failure]}]]})))
 
 (rf/reg-event-fx ::save-success
-                 (fn [{:keys [db]} _]
-                   (let [tr           (:translator db)
-                         notification {:message  (tr :notifications/save-success)
-                                       :success? true}]
-                     {:db (-> db (assoc-in [:help :save-in-progress] false))
-                      :fx [[:dispatch [::apply-changes]]
-                           [:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
+  (fn [{:keys [db]} _]
+    (let [tr           (:translator db)
+          notification {:message  (tr :notifications/save-success)
+                        :success? true}]
+      {:db (assoc-in db [:help :save-in-progress] false)
+       :fx [[:dispatch [::apply-changes]]
+            [:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
 
 (rf/reg-event-fx ::save-failure
-                 (fn [{:keys [db]} [_ resp]]
-                   (let [tr           (:translator db)
-                         notification {:message  (tr :notifications/save-failed)
-                                       :success? false}]
-                     {:db (-> db
-                              (assoc-in [:help :save-in-progress] false)
-                              (assoc-in [:help :errors :save] resp))
-                      :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
+  (fn [{:keys [db]} [_ resp]]
+    (let [tr           (:translator db)
+          notification {:message  (tr :notifications/save-failed)
+                        :success? false}]
+      {:db (-> db
+               (assoc-in [:help :save-in-progress] false)
+               (assoc-in [:help :errors :save] resp))
+       :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
 
 (rf/reg-event-fx ::save-draft
-                 (fn [{:keys [db]} _]
-                   (let [token (-> db :user :login :token)]
-                     {:db (assoc-in db [:help :save-in-progress] true)
-                      :fx [[:http-xhrio
-                            {:method          :post
-                             :headers         {:Authorization (str "Token " token)}
-                             :uri             (str (:backend-url db) "/actions/save-help-draft")
-                             :params          (get-in db [:help :edited-data])
-                             :format          (ajax/transit-request-format)
-                             :response-format (ajax/transit-response-format)
-                             :on-success      [::save-draft-success]
-                             :on-failure      [::save-failure]}]]})))
+  (fn [{:keys [db]} _]
+    (let [token (-> db :user :login :token)
+          locale (editor-locale db)]
+      {:db (assoc-in db [:help :save-in-progress] true)
+       :fx [[:http-xhrio
+             {:method          :post
+              :headers         {:Authorization (str "Token " token)}
+              :uri             (str (:backend-url db) "/actions/save-help-draft")
+              :params          {:locale locale
+                                :data (get-in db [:help :edited-data locale])}
+              :format          (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success      [::save-draft-success]
+              :on-failure      [::save-failure]}]]})))
 
 (rf/reg-event-fx ::save-draft-success
-                 (fn [{:keys [db]} _]
-                   (let [tr           (:translator db)
-                         notification {:message  (tr :notifications/save-success)
-                                       :success? true}]
-                     {:db (assoc-in db [:help :save-in-progress] false)
-                      :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
+  (fn [{:keys [db]} _]
+    (let [tr           (:translator db)
+          notification {:message  (tr :notifications/save-success)
+                        :success? true}]
+      {:db (assoc-in db [:help :save-in-progress] false)
+       :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
 
-;; Version history
+;;; ——— Version history (per locale) ———————————————————————————————————
 
 (rf/reg-event-fx ::open-version-history
-                 (fn [{:keys [db]} _]
-                   {:db (assoc-in db [:help :versions :dialog-open?] true)
-                    :fx [[:dispatch [::get-versions]]]}))
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:help :versions :dialog-open?] true)
+     :fx [[:dispatch [::get-versions]]]}))
 
 (rf/reg-event-db ::close-version-history
-                 (fn [db _]
-                   (assoc-in db [:help :versions :dialog-open?] false)))
+  (fn [db _]
+    (assoc-in db [:help :versions :dialog-open?] false)))
 
 (rf/reg-event-fx ::get-versions
-                 (fn [{:keys [db]} _]
-                   (let [token (-> db :user :login :token)]
-                     {:fx [[:http-xhrio
-                            {:method          :post
-                             :headers         {:Authorization (str "Token " token)}
-                             :uri             (str (:backend-url db) "/actions/get-help-versions")
-                             :format          (ajax/transit-request-format)
-                             :response-format (ajax/transit-response-format)
-                             :on-success      [::get-versions-success]
-                             :on-failure      [::save-failure]}]]})))
+  (fn [{:keys [db]} _]
+    (let [token (-> db :user :login :token)]
+      {:fx [[:http-xhrio
+             {:method          :post
+              :headers         {:Authorization (str "Token " token)}
+              :uri             (str (:backend-url db) "/actions/get-help-versions")
+              :params          {:locale (editor-locale db)}
+              :format          (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success      [::get-versions-success]
+              :on-failure      [::save-failure]}]]})))
 
 (rf/reg-event-db ::get-versions-success
-                 (fn [db [_ versions]]
-                   (assoc-in db [:help :versions :items] versions)))
+  (fn [db [_ versions]]
+    (assoc-in db [:help :versions :items] versions)))
 
 (rf/reg-event-fx ::load-version
-                 (fn [{:keys [db]} [_ id]]
-                   (let [token (-> db :user :login :token)]
-                     {:fx [[:http-xhrio
-                            {:method          :post
-                             :headers         {:Authorization (str "Token " token)}
-                             :uri             (str (:backend-url db) "/actions/get-help-version")
-                             :params          {:id (str id)}
-                             :format          (ajax/transit-request-format)
-                             :response-format (ajax/transit-response-format)
-                             :on-success      [::load-version-success]
-                             :on-failure      [::save-failure]}]]})))
+  (fn [{:keys [db]} [_ id]]
+    (let [token (-> db :user :login :token)]
+      {:fx [[:http-xhrio
+             {:method          :post
+              :headers         {:Authorization (str "Token " token)}
+              :uri             (str (:backend-url db) "/actions/get-help-version")
+              :params          {:id (str id)}
+              :format          (ajax/transit-request-format)
+              :response-format (ajax/transit-response-format)
+              :on-success      [::load-version-success]
+              :on-failure      [::save-failure]}]]})))
 
 (rf/reg-event-fx ::load-version-success
-                 ;; Loads the version into the editor only — publishing it
-                 ;; (= rollback) is an explicit separate step.
-                 (fn [{:keys [db]} [_ version]]
-                   {:db (-> db
-                            (assoc-in [:help :edited-data] (:body version))
-                            (assoc-in [:help :versions :dialog-open?] false))
-                    :fx [[:dispatch [:lipas.ui.events/set-active-notification
-                                     {:message  "Version loaded into editor. Publish to make it live."
-                                      :success? true}]]]}))
+  ;; Loads the version into the editor only — publishing it
+  ;; (= rollback) is an explicit separate step.
+  (fn [{:keys [db]} [_ version]]
+    {:db (-> db
+             (assoc-in [:help :edited-data (editor-locale db)] (:body version))
+             (assoc-in [:help :versions :dialog-open?] false))
+     :fx [[:dispatch [:lipas.ui.events/set-active-notification
+                      {:message  "Version loaded into editor. Publish to make it live."
+                       :success? true}]]]}))
+
+;;; ——— Subs ———————————————————————————————————————————————————————————
 
 (rf/reg-sub ::versions
-            (fn [db _]
-              (get-in db [:help :versions])))
+  (fn [db _]
+    (get-in db [:help :versions])))
 
-(rf/reg-sub
- ::edited-help-data
- :<- [::subs/help]
- (fn [help _]
-   (:edited-data help)))
+(rf/reg-sub ::editor-locale*
+  (fn [db _]
+    (editor-locale db)))
 
-;; Confirmation dialog related events and subscriptions
-(rf/reg-event-db
- ::show-confirm-dialog
- (fn [db [_ dialog-type params]]
-   (assoc-in db [:help :confirm-dialog] {:open? true
-                                         :type dialog-type
-                                         :params params})))
+(rf/reg-sub ::edited-tree
+  ;; The active locale's edited tree
+  (fn [db _]
+    (get-in db [:help :edited-data (editor-locale db)])))
 
-(rf/reg-event-db
- ::hide-confirm-dialog
- (fn [db _]
-   (assoc-in db [:help :confirm-dialog :open?] false)))
+(rf/reg-sub ::editor-section-idx
+  (fn [db _]
+    (get-in db [:help :editor :section-idx])))
 
-(rf/reg-event-fx
- ::confirm-action
- (fn [{:keys [db]} _]
-   (let [{:keys [type params]} (get-in db [:help :confirm-dialog])]
-     {:db (assoc-in db [:help :confirm-dialog :open?] false)
-      :fx [[:dispatch (case type
-                        :delete-section [::delete-section (:section-idx params)]
-                        :delete-page [::delete-page (:section-idx params) (:page-idx params)]
-                        :delete-block [::delete-block (:section-idx params) (:page-idx params) (:block-idx params)])]]})))
+(rf/reg-sub ::editor-page-idx
+  (fn [db _]
+    (get-in db [:help :editor :page-idx])))
 
-(rf/reg-sub
- ::confirm-dialog
- :<- [::subs/help]
- (fn [help _]
-   (get help :confirm-dialog {:open? false})))
+;;; ——— Confirmation dialog ————————————————————————————————————————————
 
-;; Helper UI Components
-(r/defc language-tabs [{:keys [current-lang on-change]}]
-  [:> Tabs
-   {:value current-lang
-    :onChange #(on-change %2)
-    :centered true}
-   [:> Tab {:value :fi :label "Suomi"}]
-   [:> Tab {:value :en :label "English"}]
-   [:> Tab {:value :se :label "Svenska"}]])
+(rf/reg-event-db ::show-confirm-dialog
+  (fn [db [_ dialog-type params]]
+    (assoc-in db [:help :confirm-dialog] {:open? true
+                                          :type dialog-type
+                                          :params params})))
 
-(r/defc localized-text-field
-  [{:keys [value label on-change multiline rows lang]}]
-  [:> TextField
-   {:fullWidth true
-    :label label
-    :value (get value lang "")
-    :onChange #(on-change lang (.. % -target -value))
-    :variant "outlined"
-    :margin "normal"
-    :multiline (boolean multiline)
-    :rows (or rows 4)}])
+(rf/reg-event-db ::hide-confirm-dialog
+  (fn [db _]
+    (assoc-in db [:help :confirm-dialog :open?] false)))
 
-(r/defc section-editor [{:keys [section-idx section]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)]
-    [:> Box {:sx #js{:mt 2}}
-     [:> Paper {:sx #js{:p 2 :mb 2
-                        :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                        :transition "box-shadow 0.3s ease"}}
-      [:> Box {:sx #js{:display "flex" :justifyContent "space-between" :alignItems "center"}}
-       [:> Typography {:variant "body2" :gutterBottom false}
-        "SECTION SETTINGS"]
-       [:> IconButton {:onClick #(set-expanded! (not expanded))
-                       :size "small"
-                       :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                               :transition "transform 0.3s"}}
-        [:> ExpandMoreIcon {:fontSize "small"}]]]
+(rf/reg-event-fx ::confirm-action
+  (fn [{:keys [db]} _]
+    (let [{:keys [type params]} (get-in db [:help :confirm-dialog])]
+      {:db (assoc-in db [:help :confirm-dialog :open?] false)
+       :fx [[:dispatch (case type
+                         :delete-section [::delete-section (:section-idx params)]
+                         :delete-page [::delete-page (:section-idx params) (:page-idx params)]
+                         :delete-block [::delete-block (:section-idx params) (:page-idx params) (:block-idx params)])]]})))
 
-      [:> Collapse {:in expanded :timeout "auto"}
-       [:> Box {:sx #js{:mt 2}}
-        [language-tabs {:current-lang lang :on-change set-lang!}]
+(rf/reg-sub ::confirm-dialog
+  :<- [::subs/help]
+  (fn [help _]
+    (get help :confirm-dialog {:open? false})))
 
-        [localized-text-field
-         {:label "Section Title"
-          :value (:title section)
-          :lang lang
-          :on-change #(rf/dispatch [::update-section-title section-idx %1 %2])}]]]]]))
+;;; ——— UI: shared block chrome ————————————————————————————————————————
 
-(r/defc page-editor [{:keys [section-idx page-idx page]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)]
-    [:> Box {:sx #js{:mt 2}}
-     [:> Paper {:sx #js{:p 2 :mb 2
-                        :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                        :transition "box-shadow 0.3s ease"}}
-      [:> Box {:sx #js{:display "flex" :justifyContent "space-between" :alignItems "center"}}
-       [:> Typography {:variant "body2" :gutterBottom false}
-        "PAGE SETTINGS"]
-       [:> IconButton {:onClick #(set-expanded! (not expanded))
-                       :size "small"
-                       :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                               :transition "transform 0.3s"}}
-        [:> ExpandMoreIcon {:fontSize "small"}]]]
+(r/defc block-card
+  "Common card chrome for block editors: icon + label + preview text in
+   the header, expand/reorder/delete actions, editable fields inside."
+  [{:keys [icon label preview section-idx page-idx block-idx blocks-count children]}]
+  (let [[expanded set-expanded!] (hooks/use-state false)]
+    [:> Card {:variant "elevation"
+              :elevation 3
+              :sx #js{:mb 2
+                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
+                      :transition "box-shadow 0.3s ease"}}
+     [:> CardHeader
+      {:title (r/as-element
+               [:> Typography {:variant "subtitle1" :component "div"}
+                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
+                 icon
+                 label
+                 [:> Typography {:variant "body2" :color "text.secondary" :component "span" :sx #js{:ml 2}}
+                  preview]]])
+       :action (r/as-element
+                [:> Box {:sx #js{:display "flex" :gap 0.5}}
+                 [:> IconButton {:onClick #(set-expanded! (not expanded))
+                                 :size "small"
+                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
+                                         :transition "transform 0.3s"}}
+                  [:> ExpandMoreIcon {:fontSize "small"}]]
 
-      [:> Collapse {:in expanded :timeout "auto"}
-       [:> Box {:sx #js{:mt 2}}
-        [language-tabs {:current-lang lang :on-change set-lang!}]
+                 [:> IconButton {:color "primary"
+                                 :size "small"
+                                 :disabled (zero? block-idx)
+                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
+                  [:> ArrowUpIcon {:fontSize "small"}]]
 
-        [localized-text-field
-         {:label "Page Title"
-          :value (:title page)
-          :lang lang
-          :on-change #(rf/dispatch [::update-page-title section-idx page-idx %1 %2])}]]]]]))
+                 [:> IconButton {:color "primary"
+                                 :size "small"
+                                 :disabled (= block-idx (dec blocks-count))
+                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
+                  [:> ArrowDownIcon {:fontSize "small"}]]
+
+                 [:> IconButton {:color "error"
+                                 :size "small"
+                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block
+                                                         {:section-idx section-idx
+                                                          :page-idx page-idx
+                                                          :block-idx block-idx}])}
+                  [:> DeleteIcon {:fontSize "small"}]]])}]
+
+     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
+      [:> CardContent {}
+       children]]]))
+
+(defn- truncate [s n]
+  (when-not (str/blank? s)
+    (if (> (count s) n) (str (subs s 0 n) "...") s)))
+
+;;; ——— UI: block editors ——————————————————————————————————————————————
 
 (r/defc text-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)
-        content-preview (or
-                         (when-let [content (get-in block [:content :fi])]
-                           (when (not (str/blank? content))
-                             (if (> (count content) 50)
-                               (str (subs content 0 50) "...")
-                               content)))
-                         "Empty text block")]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> TextIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}]
-                 "Text Block"
-                 [:> Typography {:variant "body2" :color "text.secondary" :component "span" :sx #js{:ml 2}}
-                  content-preview]]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
-
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
-
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
-
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
-
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       [language-tabs {:current-lang lang :on-change set-lang!}]
-
-       [localized-text-field
-        {:label "Content"
-         :value (:content block)
-         :multiline true
-         :rows 6
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :content %1 %2])}]]]]))
+  [block-card
+   {:icon (r/as-element [:> TextIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+    :label "Text"
+    :preview (or (truncate (:content block) 50) "Empty text block")
+    :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+    :children
+    (r/as-element
+     [:> TextField
+      {:fullWidth true
+       :label "Content (markdown)"
+       :value (or (:content block) "")
+       :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                :content (.. % -target -value)])
+       :variant "outlined"
+       :margin "normal"
+       :multiline true
+       :rows 8}])}])
 
 (r/defc video-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)
-        video-id (or (:video-id block) "")
-        provider (name (or (:provider block) :youtube))
-        title (get-in block [:title :fi] "")]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> VideoIcon {:fontSize "small" :color "action" :sx #js {:mr 1}}]
-                 "Video Block"
-                 [:> Typography {:variant "body2" :color "text.secondary" :component "span" :sx #js{:ml 2}}
-                  (if (str/blank? video-id)
-                    "No video set"
-                    (str provider ": " video-id (when-not (str/blank? title) (str " - " title))))]]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
+  [block-card
+   {:icon (r/as-element [:> VideoIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+    :label "Video"
+    :preview (if (str/blank? (:video-id block))
+               "No video set"
+               (str (name (or (:provider block) :youtube)) ": " (:video-id block)
+                    (when-not (str/blank? (:title block)) (str " - " (:title block)))))
+    :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+    :children
+    (r/as-element
+     [:<>
+      [:> FormControl {:fullWidth true :margin "normal"}
+       [:> InputLabel {:id "video-provider-label"} "Provider"]
+       [:> Select {:labelId "video-provider-label"
+                   :value (name (or (:provider block) :youtube))
+                   :label "Provider"
+                   :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                            :provider (keyword (.. % -target -value))])}
+        [:> MenuItem {:value "youtube"} "YouTube"]
+        [:> MenuItem {:value "vimeo"} "Vimeo"]]]
 
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
+      [:> TextField {:fullWidth true
+                     :label "Video ID"
+                     :value (or (:video-id block) "")
+                     :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                              :video-id (.. % -target -value)])
+                     :variant "outlined"
+                     :margin "normal"
+                     :helperText "For YouTube: the part after v= in URL"}]
 
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
-
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
-
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       [:> FormControl {:fullWidth true :margin "normal"}
-        [:> InputLabel {:id "video-provider-label"} "Provider"]
-        [:> Select {:labelId "video-provider-label"
-                    :value (or (:provider block) :youtube)
-                    :onChange #(rf/dispatch [::update-block-field
-                                             section-idx page-idx block-idx
-                                             :provider
-                                             (keyword (.. % -target -value))])}
-         [:> MenuItem {:value "youtube"} "YouTube"]
-         [:> MenuItem {:value "vimeo"} "Vimeo"]]]
-
-       [:> TextField {:fullWidth true
-                      :label "Video ID"
-                      :value (or (:video-id block) "")
-                      :onChange #(rf/dispatch [::update-block-field
-                                               section-idx page-idx block-idx
-                                               :video-id
-                                               (.. % -target -value)])
-                      :variant "outlined"
-                      :margin "normal"
-                      :helperText "For YouTube: the part after v= in URL"}]
-
-       [language-tabs {:current-lang lang :on-change set-lang!}]
-
-       [localized-text-field
-        {:label "Title"
-         :value (:title block)
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :title %1 %2])}]]]]))
+      [:> TextField {:fullWidth true
+                     :label "Title"
+                     :value (or (:title block) "")
+                     :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                              :title (.. % -target -value)])
+                     :variant "outlined"
+                     :margin "normal"}]])}])
 
 (r/defc image-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)
-        url (or (:url block) "")
-        alt-text (get-in block [:alt :fi] "")
-        image-name (when-not (str/blank? url)
-                     (let [parts (str/split url #"/")]
-                       (if (seq parts)
-                         (last parts)
-                         url)))]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> ImageIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}]
-                 "Image Block"
-                 [:> Typography {:variant "body2" :color "text.secondary" :component "span" :sx #js{:ml 2}}
-                  (if (str/blank? url)
-                    "No image set"
-                    (if (str/blank? alt-text)
-                      image-name
-                      alt-text))]]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
+  [block-card
+   {:icon (r/as-element [:> ImageIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+    :label "Image"
+    :preview (cond
+               (str/blank? (:url block)) "No image set"
+               (not (str/blank? (:alt block))) (:alt block)
+               :else (last (str/split (:url block) #"/")))
+    :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+    :children
+    (r/as-element
+     [:<>
+      [:> TextField {:fullWidth true
+                     :label "Image URL"
+                     :value (or (:url block) "")
+                     :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                              :url (.. % -target -value)])
+                     :variant "outlined"
+                     :margin "normal"}]
 
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
+      [:> TextField {:fullWidth true
+                     :label "Alt text"
+                     :value (or (:alt block) "")
+                     :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                              :alt (.. % -target -value)])
+                     :variant "outlined"
+                     :margin "normal"
+                     :helperText "Mandatory for accessibility"}]
 
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
-
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
-
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       [:> TextField {:fullWidth true
-                      :label "Image URL"
-                      :value (or (:url block) "")
-                      :onChange #(rf/dispatch [::update-block-field
-                                               section-idx page-idx block-idx
-                                               :url
-                                               (.. % -target -value)])
-                      :variant "outlined"
-                      :margin "normal"}]
-
-       [language-tabs {:current-lang lang :on-change set-lang!}]
-
-       [localized-text-field
-        {:label "Alt Text"
-         :value (:alt block)
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :alt %1 %2])}]
-
-       [localized-text-field
-        {:label "Caption"
-         :value (:caption block)
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :caption %1 %2])}]]]]))
+      [:> TextField {:fullWidth true
+                     :label "Caption"
+                     :value (or (:caption block) "")
+                     :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                              :caption (.. % -target -value)])
+                     :variant "outlined"
+                     :margin "normal"}]])}])
 
 (r/defc pdf-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[lang set-lang!] (hooks/use-state :fi)
-        [expanded set-expanded!] (hooks/use-state false)
-        url (or (:url block) "")
-        title (get-in block [:title :fi] "")
-        pdf-name (when-not (str/blank? url)
-                   (let [parts (str/split url #"/")]
-                     (if (seq parts)
-                       (last parts)
-                       url)))]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> PdfIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}]
-                 "PDF Block"
-                 [:> Typography {:variant "body2" :color "text.secondary" :component "span" :sx #js{:ml 2}}
-                  (if (str/blank? url)
-                    "No PDF set"
-                    (if (str/blank? title)
-                      pdf-name
-                      title))]]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
+  (let [url (or (:url block) "")]
+    [block-card
+     {:icon (r/as-element [:> PdfIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+      :label "PDF"
+      :preview (cond
+                 (str/blank? url) "No PDF set"
+                 (not (str/blank? (:title block))) (:title block)
+                 :else (last (str/split url #"/")))
+      :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+      :children
+      (r/as-element
+       [:<>
+        [:> TextField {:fullWidth true
+                       :label "PDF URL"
+                       :value url
+                       :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                                :url (.. % -target -value)])
+                       :variant "outlined"
+                       :margin "normal"
+                       :helperText "URL path to the PDF file"}]
 
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
+        (when (and (str/starts-with? url "https://drive.google.com/file")
+                   (str/ends-with? url "/view?usp=sharing"))
+          (let [gid (second (re-find #"/file/d/([^/]+)" url))
+                gurl (str "https://docs.google.com/viewer?srcid="
+                          gid
+                          "&pid=explorer&efh=false&a=v&chrome=false&embedded=true")]
+            [:> Button {:onClick #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                                :url gurl])}
+             "Fix Google Drive Link"]))
 
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
+        [:> TextField {:fullWidth true
+                       :label "Title"
+                       :value (or (:title block) "")
+                       :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                                :title (.. % -target -value)])
+                       :variant "outlined"
+                       :margin "normal"}]
 
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
+        [:> TextField {:fullWidth true
+                       :label "Caption"
+                       :value (or (:caption block) "")
+                       :onChange #(rf/dispatch [::update-block-field section-idx page-idx block-idx
+                                                :caption (.. % -target -value)])
+                       :variant "outlined"
+                       :margin "normal"}]])}]))
 
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       [:> TextField {:fullWidth true
-                      :label "PDF URL"
-                      :value (or (:url block) "")
-                      :onChange #(rf/dispatch [::update-block-field
-                                               section-idx page-idx block-idx
-                                               :url
-                                               (.. % -target -value)])
-                      :variant "outlined"
-                      :margin "normal"
-                      :helperText "URL path to the PDF file"}]
+(r/defc type-code-explorer-block-editor [{:keys [section-idx page-idx block-idx blocks-count]}]
+  [block-card
+   {:icon (r/as-element [:> CategoryIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+    :label "Type Code Explorer"
+    :preview nil
+    :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+    :children
+    (r/as-element
+     [:> Typography {:variant "body2" :color "text.secondary"}
+      "This block displays a hierarchical browser for sports facility types."])}])
 
-       (when (and (str/starts-with? url "https://drive.google.com/file")
-                  (str/ends-with? url "/view?usp=sharing"))
-         (let [gid (second (re-find #"/file/d/([^/]+)" url))
-               gurl (str "https://docs.google.com/viewer?srcid="
-                         gid
-                         "&pid=explorer&efh=false&a=v&chrome=false&embedded=true")]
-           [:> Button {:onClick #(rf/dispatch [::update-block-field
-                                               section-idx page-idx block-idx
-                                               :url gurl])}
+(r/defc data-model-excel-download-block-editor [{:keys [section-idx page-idx block-idx blocks-count]}]
+  [block-card
+   {:icon (r/as-element [:> DownloadIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}])
+    :label "Data Model Excel Download"
+    :preview nil
+    :section-idx section-idx :page-idx page-idx :block-idx block-idx :blocks-count blocks-count
+    :children
+    (r/as-element
+     [:> Typography {:variant "body2" :color "text.secondary"}
+      "This block displays a button that downloads a data model Excel file."])}])
 
-            "Fix Google Drive Link"]))
-
-       [language-tabs {:current-lang lang :on-change set-lang!}]
-
-       [localized-text-field
-        {:label "Title"
-         :value (:title block)
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :title %1 %2])}]
-
-       [localized-text-field
-        {:label "Caption"
-         :value (:caption block)
-         :lang lang
-         :on-change #(rf/dispatch [::update-block-content section-idx page-idx block-idx :caption %1 %2])}]]]]))
-
-(r/defc type-code-explorer-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[expanded set-expanded!] (hooks/use-state false)]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> CategoryIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}]
-                 "Type Code Explorer"]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
-
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
-
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
-
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
-
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       ;; Type explorer has no editable properties - it just displays the sports facility types.
-       [:> Typography {:variant "body2" :color "text.secondary"}
-        "This block will display a hierarchical browser for sports facility types. Users can explore main categories, subcategories, and individual facility types."]]]]))
-
-(r/defc data-model-excel-download-block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
-  (let [[expanded set-expanded!] (hooks/use-state false)]
-    [:> Card {:variant "elevation"
-              :elevation 3
-              :sx #js{:mb 2
-                      :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
-                      :transition "box-shadow 0.3s ease"}}
-     [:> CardHeader
-      {:title (r/as-element
-               [:> Typography {:variant "subtitle1" :component "div"}
-                [:> Box {:sx #js{:display "flex" :alignItems "center" :gap 1}}
-                 [:> DownloadIcon {:fontSize "small" :color "action" :sx #js{:mr 1}}]
-                 "Data Model Excel Download"]])
-       :action (r/as-element
-                [:> Box {:sx #js{:display "flex" :gap 0.5}}
-                 ;; Expand/collapse button
-                 [:> IconButton {:onClick #(set-expanded! (not expanded))
-                                 :size "small"
-                                 :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
-                                         :transition "transform 0.3s"}}
-                  [:> ExpandMoreIcon {:fontSize "small"}]]
-
-                 ;; Move up button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (zero? block-idx)
-                                 :onClick #(rf/dispatch [::move-block-up section-idx page-idx block-idx])}
-                  [:> ArrowUpIcon {:fontSize "small"}]]
-
-                 ;; Move down button
-                 [:> IconButton {:color "primary"
-                                 :size "small"
-                                 :disabled (= block-idx (dec blocks-count))
-                                 :onClick #(rf/dispatch [::move-block-down section-idx page-idx block-idx])}
-                  [:> ArrowDownIcon {:fontSize "small"}]]
-
-                 ;; Delete button
-                 [:> IconButton {:color "error"
-                                 :size "small"
-                                 :onClick #(rf/dispatch [::show-confirm-dialog :delete-block {:section-idx section-idx :page-idx page-idx :block-idx block-idx}])}
-                  [:> DeleteIcon {:fontSize "small"}]]])}]
-
-     [:> Collapse {:in expanded :timeout "auto" :unmountOnExit true}
-      [:> CardContent {}
-       ;; Type explorer has no editable properties - it just displays the sports facility types.
-       [:> Typography {:variant "body2" :color "text.secondary"}
-        "This block will display a button that downloads a data model Excel file."]]]]))
-
-(r/defc block-editor [{:keys [section-idx page-idx block-idx blocks-count block]}]
+(r/defc block-editor [{:keys [block] :as props}]
   (case (:type block)
-    :text [text-block-editor {:section-idx section-idx
-                              :page-idx page-idx
-                              :block-idx block-idx
-                              :blocks-count blocks-count
-                              :block block}]
-    :video [video-block-editor {:section-idx section-idx
-                                :page-idx page-idx
-                                :block-idx block-idx
-                                :blocks-count blocks-count
-                                :block block}]
-    :image [image-block-editor {:section-idx section-idx
-                                :page-idx page-idx
-                                :block-idx block-idx
-                                :blocks-count blocks-count
-                                :block block}]
-    :pdf [pdf-block-editor {:section-idx section-idx
-                            :page-idx page-idx
-                            :block-idx block-idx
-                            :blocks-count blocks-count
-                            :block block}]
-    :type-code-explorer [type-code-explorer-block-editor {:section-idx section-idx
-                                                          :page-idx page-idx
-                                                          :block-idx block-idx
-                                                          :blocks-count blocks-count
-                                                          :block block}]
-    :data-model-excel-download [data-model-excel-download-block-editor {:section-idx section-idx
-                                                                        :page-idx page-idx
-                                                                        :block-idx block-idx
-                                                                        :blocks-count blocks-count
-                                                                        :block block}]
+    :text [text-block-editor props]
+    :video [video-block-editor props]
+    :image [image-block-editor props]
+    :pdf [pdf-block-editor props]
+    :type-code-explorer [type-code-explorer-block-editor props]
+    :data-model-excel-download [data-model-excel-download-block-editor props]
     [:> Typography {:color "error"} (str "Unknown block type: " (:type block))]))
 
 (r/defc add-block-controls [{:keys [section-idx page-idx]}]
@@ -1043,25 +731,132 @@
 
    [add-block-controls {:section-idx section-idx :page-idx page-idx}]])
 
-(r/defc section-selector [{:keys [sections selected-section-idx on-select]}]
+;;; ——— UI: section/page settings ——————————————————————————————————————
+
+(r/defc slug-field
+  [{:keys [value label on-change on-generate helper]}]
+  [:> TextField
+   {:fullWidth true
+    :label (or label "Slug")
+    :value (or value "")
+    :onChange #(on-change (.. % -target -value))
+    :variant "outlined"
+    :margin "normal"
+    :helperText (or helper "Used in ?ohje= links. Renames keep the old slug working (alias).")
+    :InputProps
+    #js{:endAdornment
+        (r/as-element
+         [:> InputAdornment {:position "end"}
+          [:> Tooltip {:title "Generate from title"}
+           [:> IconButton {:size "small" :onClick on-generate}
+            [:> AutoFixIcon {:fontSize "small"}]]]])}}])
+
+(r/defc section-editor [{:keys [section-idx section]}]
+  (let [[expanded set-expanded!] (hooks/use-state false)]
+    [:> Box {:sx #js{:mt 2}}
+     [:> Paper {:sx #js{:p 2 :mb 2
+                        :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
+                        :transition "box-shadow 0.3s ease"}}
+      [:> Box {:sx #js{:display "flex" :justifyContent "space-between" :alignItems "center"}}
+       [:> Typography {:variant "body2" :gutterBottom false}
+        "SECTION SETTINGS"]
+       [:> IconButton {:onClick #(set-expanded! (not expanded))
+                       :size "small"
+                       :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
+                               :transition "transform 0.3s"}}
+        [:> ExpandMoreIcon {:fontSize "small"}]]]
+
+      [:> Collapse {:in expanded :timeout "auto"}
+       [:> Box {:sx #js{:mt 2}}
+        [:> TextField
+         {:fullWidth true
+          :label "Section Title"
+          :value (or (:title section) "")
+          :onChange #(rf/dispatch [::update-section-field section-idx :title (.. % -target -value)])
+          :variant "outlined"
+          :margin "normal"}]
+
+        [slug-field
+         {:value (:slug section)
+          :on-change #(rf/dispatch [::update-section-field section-idx :slug %])
+          :on-generate #(rf/dispatch [::generate-section-slug section-idx])}]
+
+        [:> TextField
+         {:fullWidth true
+          :label "Summary"
+          :value (or (:summary section) "")
+          :onChange #(rf/dispatch [::update-section-field section-idx :summary (.. % -target -value)])
+          :variant "outlined"
+          :margin "normal"
+          :multiline true
+          :rows 2
+          :helperText "1-2 sentences shown in listings"}]]]]]))
+
+(r/defc page-editor [{:keys [section-idx page-idx page]}]
+  (let [[expanded set-expanded!] (hooks/use-state false)]
+    [:> Box {:sx #js{:mt 2}}
+     [:> Paper {:sx #js{:p 2 :mb 2
+                        :boxShadow (if expanded "0px 6px 10px rgba(0, 0, 0, 0.15)" "")
+                        :transition "box-shadow 0.3s ease"}}
+      [:> Box {:sx #js{:display "flex" :justifyContent "space-between" :alignItems "center"}}
+       [:> Typography {:variant "body2" :gutterBottom false}
+        "PAGE SETTINGS"]
+       [:> IconButton {:onClick #(set-expanded! (not expanded))
+                       :size "small"
+                       :sx #js{:transform (if expanded "rotate(180deg)" "rotate(0deg)")
+                               :transition "transform 0.3s"}}
+        [:> ExpandMoreIcon {:fontSize "small"}]]]
+
+      [:> Collapse {:in expanded :timeout "auto"}
+       [:> Box {:sx #js{:mt 2}}
+        [:> TextField
+         {:fullWidth true
+          :label "Page Title"
+          :value (or (:title page) "")
+          :onChange #(rf/dispatch [::update-page-field section-idx page-idx :title (.. % -target -value)])
+          :variant "outlined"
+          :margin "normal"}]
+
+        [slug-field
+         {:value (:slug page)
+          :on-change #(rf/dispatch [::update-page-field section-idx page-idx :slug %])
+          :on-generate #(rf/dispatch [::generate-page-slug section-idx page-idx])}]
+
+        [:> TextField
+         {:fullWidth true
+          :label "Summary"
+          :value (or (:summary page) "")
+          :onChange #(rf/dispatch [::update-page-field section-idx page-idx :summary (.. % -target -value)])
+          :variant "outlined"
+          :margin "normal"
+          :multiline true
+          :rows 2
+          :helperText "1-2 sentences shown in listings and used by the AI assistant"}]]]]]))
+
+;;; ——— UI: selectors ——————————————————————————————————————————————————
+
+(defn- node-label [node idx kind]
+  (let [title (:title node)]
+    (if (str/blank? title)
+      (str kind " " (inc idx) " (" (:slug node) ")")
+      title)))
+
+(r/defc section-selector [{:keys [sections selected-section-idx]}]
   [:> Stack {:spacing 1}
 
    [:> Typography {:variant "h6"} "Select Section"]
 
    [:> FormControl {:fullWidth true}
-    #_[:> InputLabel {:id "section-select-label"} "Select Section"]
-    [:> Select {:labelId "section-select-label"
-                :value (or selected-section-idx "")
-                :onChange #(on-select (js/parseInt (.. % -target -value)))
+    [:> Select {:value (if (some? selected-section-idx) selected-section-idx "")
+                :onChange #(rf/dispatch [::select-section (js/parseInt (.. % -target -value))])
                 :displayEmpty true}
      (map-indexed
       (fn [idx section]
         [:> MenuItem {:key idx :value idx}
-         (get-in section [:title :fi] (str "Section " idx))])
+         (node-label section idx "Section")])
       sections)]]
 
    [:> Stack {:direction "row" :spacing 1 :flexWrap "wrap"}
-    ;; Add Section button
     [:> Button
      {:variant "contained"
       :color "primary"
@@ -1071,7 +866,6 @@
       :sx #js{:mt 0}}
      "Add Section"]
 
-    ;; Delete Section button (disabled if no section is selected)
     [:> Button
      {:variant "outlined"
       :color "error"
@@ -1082,7 +876,6 @@
       :sx #js{:mt 0}}
      "Delete Section"]
 
-    ;; Move Section Up button
     [:> Button
      {:variant "outlined"
       :color "primary"
@@ -1093,7 +886,6 @@
       :sx #js{:mt 0}}
      "Move Up"]
 
-    ;; Move Section Down button
     [:> Button
      {:variant "outlined"
       :color "primary"
@@ -1105,26 +897,23 @@
       :sx #js{:mt 0}}
      "Move Down"]]])
 
-(r/defc page-selector [{:keys [section-idx pages selected-page-idx on-select]}]
+(r/defc page-selector [{:keys [section-idx pages selected-page-idx]}]
   [:> Stack {:spacing 2}
 
    [:> Typography {:variant "h6"} "Select Page"]
 
    [:> FormControl {:fullWidth true}
-    #_[:> InputLabel {:id "page-select-label"} "Select Page"]
-    [:> Select {:labelId "page-select-label"
-                :value (or selected-page-idx "")
-                :onChange #(on-select (js/parseInt (.. % -target -value)))
+    [:> Select {:value (if (some? selected-page-idx) selected-page-idx "")
+                :onChange #(rf/dispatch [::select-page (js/parseInt (.. % -target -value))])
                 :displayEmpty true}
      (map-indexed
       (fn [idx page]
         [:> MenuItem {:key idx :value idx}
-         (get-in page [:title :fi] (str "Page " idx))])
+         (node-label page idx "Page")])
       pages)]]
 
    [:> Stack {:direction "row" :spacing 1 :flexWrap "wrap"}
 
-    ;; Add Page button
     [:> Button
      {:variant "contained"
       :color "primary"
@@ -1134,7 +923,6 @@
       :sx #js{:mt 0}}
      "Add Page"]
 
-    ;; Delete Page button (disabled if no page is selected)
     [:> Button
      {:variant "outlined"
       :color "error"
@@ -1146,7 +934,6 @@
       :sx #js{:mt 0}}
      "Delete Page"]
 
-    ;; Move Page Up button
     [:> Button
      {:variant "outlined"
       :color "primary"
@@ -1157,7 +944,6 @@
       :sx #js{:mt 0}}
      "Move Up"]
 
-    ;; Move Page Down button
     [:> Button
      {:variant "outlined"
       :color "primary"
@@ -1169,52 +955,65 @@
       :sx #js{:mt 0}}
      "Move Down"]]])
 
-(r/defc editor-toolbar []
-  [:> Toolbar {:disableGutters true :sx #js{:mb 2}}
-   [:> Typography {:variant "h5" :component "div" :sx #js{:flexGrow 1}}
-    "Help Content Editor"]
+;;; ——— UI: toolbar + dialogs ——————————————————————————————————————————
 
-   [:> Stack {:direction "row" :spacing 1}
-    [:> Button
-     {:variant "outlined"
-      :color "primary"
-      :startIcon (r/as-element [:> HistoryIcon {}])
-      :onClick #(rf/dispatch [::open-version-history])}
-     "History"]
-    [:> Button
-     {:variant "contained"
-      :color "primary"
-      :startIcon (r/as-element [:> PreviewIcon {}])
-      :onClick #(rf/dispatch [::apply-changes])}
-     "Preview"]
-    [:> Button
-     {:variant "outlined"
-      :color "secondary"
-      :startIcon (r/as-element [:> SaveIcon {}])
-      :onClick #(rf/dispatch [::save-draft])}
-     "Save draft"]
-    [:> Button
-     {:variant "contained"
-      :color "secondary"
-      :startIcon (r/as-element [:> SaveIcon {}])
-      :onClick #(rf/dispatch [::save-changes])}
-     "Publish"]
-    [:> Button
-     {:variant "outlined"
-      :color "secondary"
-      :sx #js{:ml 1}
-      :onClick #(rf/dispatch [::events/close-edit-mode])}
-     "Cancel"]]])
+(r/defc editor-toolbar []
+  (let [locale @(rf/subscribe [::editor-locale*])]
+    [:> Toolbar {:disableGutters true :sx #js{:mb 2 :gap 2 :flexWrap "wrap"}}
+     [:> Typography {:variant "h5" :component "div"}
+      "Help Content Editor"]
+
+     ;; Which language's tree is being edited. Each language is
+     ;; drafted/published independently.
+     [:> Tabs {:value (name locale)
+               :onChange #(rf/dispatch [::set-editor-locale (keyword %2)])
+               :sx #js{:flexGrow 1 :minHeight 40}}
+      [:> Tab {:value "fi" :label "Suomi"}]
+      [:> Tab {:value "se" :label "Svenska"}]
+      [:> Tab {:value "en" :label "English"}]]
+
+     [:> Stack {:direction "row" :spacing 1}
+      [:> Button
+       {:variant "outlined"
+        :color "primary"
+        :startIcon (r/as-element [:> HistoryIcon {}])
+        :onClick #(rf/dispatch [::open-version-history])}
+       "History"]
+      [:> Button
+       {:variant "contained"
+        :color "primary"
+        :startIcon (r/as-element [:> PreviewIcon {}])
+        :onClick #(rf/dispatch [::apply-changes])}
+       "Preview"]
+      [:> Button
+       {:variant "outlined"
+        :color "secondary"
+        :startIcon (r/as-element [:> SaveIcon {}])
+        :onClick #(rf/dispatch [::save-draft])}
+       (str "Save draft (" (name locale) ")")]
+      [:> Button
+       {:variant "contained"
+        :color "secondary"
+        :startIcon (r/as-element [:> SaveIcon {}])
+        :onClick #(rf/dispatch [::save-changes])}
+       (str "Publish (" (name locale) ")")]
+      [:> Button
+       {:variant "outlined"
+        :color "secondary"
+        :sx #js{:ml 1}
+        :onClick #(rf/dispatch [::events/close-edit-mode])}
+       "Cancel"]]]))
 
 (r/defc version-history-dialog []
-  (let [{:keys [dialog-open? items]} @(rf/subscribe [::versions])]
+  (let [{:keys [dialog-open? items]} @(rf/subscribe [::versions])
+        locale @(rf/subscribe [::editor-locale*])]
     [:> Dialog
      {:open (boolean dialog-open?)
       :onClose #(rf/dispatch [::close-version-history])
       :maxWidth "sm"
       :fullWidth true}
 
-     [:> DialogTitle {} "Version history"]
+     [:> DialogTitle {} (str "Version history (" (name locale) ")")]
 
      [:> DialogContent {}
       (if (empty? items)
@@ -1247,10 +1046,6 @@
 (r/defc confirmation-dialog []
   (let [dialog @(rf/subscribe [::confirm-dialog])
         dialog-type (:type dialog)
-        params (:params dialog)
-        section-idx (:section-idx params)
-        page-idx (:page-idx params)
-        block-idx (:block-idx params)
 
         get-title (fn []
                     (case dialog-type
@@ -1267,7 +1062,7 @@
                         "Are you sure you want to proceed with this action?"))]
 
     [:> Dialog
-     {:open (:open? dialog)
+     {:open (boolean (:open? dialog))
       :onClose #(rf/dispatch [::hide-confirm-dialog])
       :aria-labelledby "confirm-dialog-title"}
 
@@ -1293,13 +1088,13 @@
 
 (r/defc view
   []
-  (let [edit-data @(rf/subscribe [::edited-help-data])
-        selected-section-idx @(rf/subscribe [::subs/selected-section-idx])
-        selected-page-idx @(rf/subscribe [::subs/selected-page-idx])
+  (let [tree @(rf/subscribe [::edited-tree])
+        selected-section-idx @(rf/subscribe [::editor-section-idx])
+        selected-page-idx @(rf/subscribe [::editor-page-idx])
 
-        selected-section (when (and edit-data (number? selected-section-idx)
-                                    (< selected-section-idx (count edit-data)))
-                           (nth edit-data selected-section-idx))
+        selected-section (when (and tree (number? selected-section-idx)
+                                    (< selected-section-idx (count tree)))
+                           (nth tree selected-section-idx))
         selected-pages (when selected-section
                          (:pages selected-section))
         selected-page (when (and selected-pages (number? selected-page-idx)
@@ -1313,9 +1108,8 @@
      [editor-toolbar {}]
 
      [section-selector
-      {:sections edit-data
-       :selected-section-idx selected-section-idx
-       :on-select #(rf/dispatch [::events/select-section % (get-in (nth edit-data %) [:slug])])}]
+      {:sections tree
+       :selected-section-idx selected-section-idx}]
 
      (when selected-section
        [section-editor {:section-idx selected-section-idx :section selected-section}])
@@ -1324,8 +1118,7 @@
        [page-selector
         {:section-idx selected-section-idx
          :pages selected-pages
-         :selected-page-idx selected-page-idx
-         :on-select #(rf/dispatch [::events/select-page % (get-in (nth selected-pages %) [:slug])])}])
+         :selected-page-idx selected-page-idx}])
 
      (when (and selected-section selected-page)
        [page-editor

--- a/webapp/src/cljs/lipas/ui/help/manage.cljs
+++ b/webapp/src/cljs/lipas/ui/help/manage.cljs
@@ -326,7 +326,7 @@
                    (let [tr           (:translator db)
                          notification {:message  (tr :notifications/save-success)
                                        :success? true}]
-                     {:db (-> db (assoc-in [:ptv :save-in-progress] false))
+                     {:db (-> db (assoc-in [:help :save-in-progress] false))
                       :fx [[:dispatch [::apply-changes]]
                            [:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
 

--- a/webapp/src/cljs/lipas/ui/help/manage.cljs
+++ b/webapp/src/cljs/lipas/ui/help/manage.cljs
@@ -7,6 +7,7 @@
    ["@mui/icons-material/Delete$default" :as DeleteIcon]
    ["@mui/icons-material/Download$default" :as DownloadIcon]
    ["@mui/icons-material/ExpandMore$default" :as ExpandMoreIcon]
+   ["@mui/icons-material/History$default" :as HistoryIcon]
    ["@mui/icons-material/Image$default" :as ImageIcon]
    ["@mui/icons-material/PictureAsPdf$default" :as PdfIcon]
    ["@mui/icons-material/Preview$default" :as PreviewIcon]
@@ -26,7 +27,11 @@
    ["@mui/material/DialogTitle$default" :as DialogTitle]
    ["@mui/material/FormControl$default" :as FormControl]
    ["@mui/material/IconButton$default" :as IconButton]
+   ["@mui/material/Chip$default" :as Chip]
    ["@mui/material/InputLabel$default" :as InputLabel]
+   ["@mui/material/List$default" :as MuiList]
+   ["@mui/material/ListItem$default" :as ListItem]
+   ["@mui/material/ListItemText$default" :as ListItemText]
    ["@mui/material/MenuItem$default" :as MenuItem]
    ["@mui/material/Paper$default" :as Paper]
    ["@mui/material/Select$default" :as Select]
@@ -339,6 +344,83 @@
                               (assoc-in [:help :save-in-progress] false)
                               (assoc-in [:help :errors :save] resp))
                       :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
+
+(rf/reg-event-fx ::save-draft
+                 (fn [{:keys [db]} _]
+                   (let [token (-> db :user :login :token)]
+                     {:db (assoc-in db [:help :save-in-progress] true)
+                      :fx [[:http-xhrio
+                            {:method          :post
+                             :headers         {:Authorization (str "Token " token)}
+                             :uri             (str (:backend-url db) "/actions/save-help-draft")
+                             :params          (get-in db [:help :edited-data])
+                             :format          (ajax/transit-request-format)
+                             :response-format (ajax/transit-response-format)
+                             :on-success      [::save-draft-success]
+                             :on-failure      [::save-failure]}]]})))
+
+(rf/reg-event-fx ::save-draft-success
+                 (fn [{:keys [db]} _]
+                   (let [tr           (:translator db)
+                         notification {:message  (tr :notifications/save-success)
+                                       :success? true}]
+                     {:db (assoc-in db [:help :save-in-progress] false)
+                      :fx [[:dispatch [:lipas.ui.events/set-active-notification notification]]]})))
+
+;; Version history
+
+(rf/reg-event-fx ::open-version-history
+                 (fn [{:keys [db]} _]
+                   {:db (assoc-in db [:help :versions :dialog-open?] true)
+                    :fx [[:dispatch [::get-versions]]]}))
+
+(rf/reg-event-db ::close-version-history
+                 (fn [db _]
+                   (assoc-in db [:help :versions :dialog-open?] false)))
+
+(rf/reg-event-fx ::get-versions
+                 (fn [{:keys [db]} _]
+                   (let [token (-> db :user :login :token)]
+                     {:fx [[:http-xhrio
+                            {:method          :post
+                             :headers         {:Authorization (str "Token " token)}
+                             :uri             (str (:backend-url db) "/actions/get-help-versions")
+                             :format          (ajax/transit-request-format)
+                             :response-format (ajax/transit-response-format)
+                             :on-success      [::get-versions-success]
+                             :on-failure      [::save-failure]}]]})))
+
+(rf/reg-event-db ::get-versions-success
+                 (fn [db [_ versions]]
+                   (assoc-in db [:help :versions :items] versions)))
+
+(rf/reg-event-fx ::load-version
+                 (fn [{:keys [db]} [_ id]]
+                   (let [token (-> db :user :login :token)]
+                     {:fx [[:http-xhrio
+                            {:method          :post
+                             :headers         {:Authorization (str "Token " token)}
+                             :uri             (str (:backend-url db) "/actions/get-help-version")
+                             :params          {:id (str id)}
+                             :format          (ajax/transit-request-format)
+                             :response-format (ajax/transit-response-format)
+                             :on-success      [::load-version-success]
+                             :on-failure      [::save-failure]}]]})))
+
+(rf/reg-event-fx ::load-version-success
+                 ;; Loads the version into the editor only — publishing it
+                 ;; (= rollback) is an explicit separate step.
+                 (fn [{:keys [db]} [_ version]]
+                   {:db (-> db
+                            (assoc-in [:help :edited-data] (:body version))
+                            (assoc-in [:help :versions :dialog-open?] false))
+                    :fx [[:dispatch [:lipas.ui.events/set-active-notification
+                                     {:message  "Version loaded into editor. Publish to make it live."
+                                      :success? true}]]]}))
+
+(rf/reg-sub ::versions
+            (fn [db _]
+              (get-in db [:help :versions])))
 
 (rf/reg-sub
  ::edited-help-data
@@ -1094,23 +1176,73 @@
 
    [:> Stack {:direction "row" :spacing 1}
     [:> Button
+     {:variant "outlined"
+      :color "primary"
+      :startIcon (r/as-element [:> HistoryIcon {}])
+      :onClick #(rf/dispatch [::open-version-history])}
+     "History"]
+    [:> Button
      {:variant "contained"
       :color "primary"
       :startIcon (r/as-element [:> PreviewIcon {}])
       :onClick #(rf/dispatch [::apply-changes])}
      "Preview"]
     [:> Button
+     {:variant "outlined"
+      :color "secondary"
+      :startIcon (r/as-element [:> SaveIcon {}])
+      :onClick #(rf/dispatch [::save-draft])}
+     "Save draft"]
+    [:> Button
      {:variant "contained"
       :color "secondary"
       :startIcon (r/as-element [:> SaveIcon {}])
       :onClick #(rf/dispatch [::save-changes])}
-     "Save"]
+     "Publish"]
     [:> Button
      {:variant "outlined"
       :color "secondary"
       :sx #js{:ml 1}
       :onClick #(rf/dispatch [::events/close-edit-mode])}
      "Cancel"]]])
+
+(r/defc version-history-dialog []
+  (let [{:keys [dialog-open? items]} @(rf/subscribe [::versions])]
+    [:> Dialog
+     {:open (boolean dialog-open?)
+      :onClose #(rf/dispatch [::close-version-history])
+      :maxWidth "sm"
+      :fullWidth true}
+
+     [:> DialogTitle {} "Version history"]
+
+     [:> DialogContent {}
+      (if (empty? items)
+        [:> DialogContentText {} "No saved versions."]
+        [:> MuiList {}
+         (for [{:keys [id event-date status]} items]
+           ^{:key id}
+           [:> ListItem
+            {:secondaryAction
+             (r/as-element
+              [:> Button
+               {:size "small"
+                :variant "outlined"
+                :onClick #(rf/dispatch [::load-version id])}
+               "Load into editor"])}
+            [:> Chip {:size "small"
+                      :label status
+                      :color (if (= "active" status) "secondary" "default")
+                      :sx #js{:mr 2}}]
+            [:> ListItemText
+             ;; "2026-07-08 14:03:22.123456" → "2026-07-08 14:03"
+             {:primary (subs (str event-date) 0 16)}]])])]
+
+     [:> DialogActions {}
+      [:> Button
+       {:onClick #(rf/dispatch [::close-version-history])
+        :color "primary"}
+       "Close"]]]))
 
 (r/defc confirmation-dialog []
   (let [dialog @(rf/subscribe [::confirm-dialog])
@@ -1177,6 +1309,7 @@
     [:> Box {:sx #js{:p 2}}
      ;; Confirmation dialog always rendered but only shown when needed
      [confirmation-dialog {}]
+     [version-history-dialog {}]
      [editor-toolbar {}]
 
      [section-selector

--- a/webapp/src/cljs/lipas/ui/help/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/help/subs.cljs
@@ -82,8 +82,13 @@
                 (str/join " ")))
       (str/lower-case)))
 
+(defn- section-haystack [section]
+  (str/lower-case (str (:title section) " " (:summary section))))
+
 (rf/reg-sub ::search-results
-  ;; [{:section-slug .. :section-title .. :page ..} ...]
+  ;; [{:section-slug .. :section-title .. :pages [..]} ...] in tree
+  ;; order. A hit on the section title/summary surfaces the whole
+  ;; section (all its pages), not just pages whose own content matches.
   :<- [::display-tree]
   :<- [::search-term]
   (fn [[tree term] _]
@@ -91,8 +96,12 @@
       (let [q (str/lower-case (str/trim term))]
         (vec
          (for [section tree
-               page (:pages section)
-               :when (str/includes? (page-haystack page) q)]
+               :let [section-hit? (str/includes? (section-haystack section) q)
+                     pages (if section-hit?
+                             (:pages section)
+                             (filterv #(str/includes? (page-haystack %) q)
+                                      (:pages section)))]
+               :when (seq pages)]
            {:section-slug (:slug section)
             :section-title (:title section)
-            :page page}))))))
+            :pages pages}))))))

--- a/webapp/src/cljs/lipas/ui/help/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/help/subs.cljs
@@ -1,5 +1,7 @@
 (ns lipas.ui.help.subs
-  (:require [re-frame.core :as rf]))
+  (:require [clojure.string :as str]
+            [lipas.ui.help.events :as events]
+            [re-frame.core :as rf]))
 
 (rf/reg-sub ::help
   (fn [db _]
@@ -15,18 +17,27 @@
   (fn [help _]
     (get-in help [:dialog :open?])))
 
-;; Selected section and page by index
-(rf/reg-sub ::selected-section-idx
+(rf/reg-sub ::mode
   :<- [::help]
   (fn [help _]
-    (get-in help [:dialog :selected-section-idx])))
+    (get-in help [:dialog :mode])))
 
-(rf/reg-sub ::selected-page-idx
-  :<- [::help]
-  (fn [help _]
-    (get-in help [:dialog :selected-page-idx])))
+;; The tree the reader sees: user's locale, or fi when their locale has
+;; no published content.
+(rf/reg-sub ::display-tree
+  (fn [db _]
+    (events/display-tree db)))
 
-;; Selected section and page by slug
+(rf/reg-sub ::fallback?
+  ;; true when the user's locale has no published content and fi is
+  ;; shown instead
+  (fn [db _]
+    (let [locale ((:translator db))
+          data (get-in db [:help :data])]
+      (boolean (and (not= :fi locale)
+                    (empty? (get data locale))
+                    (seq (:fi data)))))))
+
 (rf/reg-sub ::selected-section-slug
   :<- [::help]
   (fn [help _]
@@ -37,28 +48,51 @@
   (fn [help _]
     (get-in help [:dialog :selected-page-slug])))
 
-;; Derived subscriptions for getting actual section and page data
-(rf/reg-sub ::selected-section
-  :<- [::help-data]
-  :<- [::selected-section-idx]
-  (fn [[data selected-idx] _]
-    (when (and data (number? selected-idx) (< selected-idx (count data)))
-      (nth data selected-idx))))
-
-(rf/reg-sub ::selected-section-pages
-  :<- [::selected-section]
-  (fn [section _]
-    (:pages section)))
-
-(rf/reg-sub ::selected-page
-  :<- [::selected-section-pages]
-  :<- [::selected-page-idx]
-  (fn [[pages selected-idx] _]
-    (when (and pages (number? selected-idx) (< selected-idx (count pages)))
-      (nth pages selected-idx))))
-
-;; For backward compatibility
-(rf/reg-sub ::mode
+(rf/reg-sub ::expanded-sections
   :<- [::help]
   (fn [help _]
-    (get-in help [:dialog :mode])))
+    (get-in help [:dialog :expanded-sections] #{})))
+
+(rf/reg-sub ::search-term
+  :<- [::help]
+  (fn [help _]
+    (get-in help [:dialog :search-term] "")))
+
+(rf/reg-sub ::selected-section
+  :<- [::display-tree]
+  :<- [::selected-section-slug]
+  (fn [[tree slug] _]
+    (events/find-section tree slug)))
+
+(rf/reg-sub ::selected-page
+  :<- [::selected-section]
+  :<- [::selected-page-slug]
+  (fn [[section slug] _]
+    (events/find-page section slug)))
+
+(defn- page-haystack [page]
+  (-> (str (:title page) " "
+           (:summary page) " "
+           (->> (:blocks page)
+                (keep (fn [block]
+                        (case (:type block)
+                          :text (:content block)
+                          (:video :pdf) (:title block)
+                          nil)))
+                (str/join " ")))
+      (str/lower-case)))
+
+(rf/reg-sub ::search-results
+  ;; [{:section-slug .. :section-title .. :page ..} ...]
+  :<- [::display-tree]
+  :<- [::search-term]
+  (fn [[tree term] _]
+    (when-not (str/blank? term)
+      (let [q (str/lower-case (str/trim term))]
+        (vec
+         (for [section tree
+               page (:pages section)
+               :when (str/includes? (page-haystack page) q)]
+           {:section-slug (:slug section)
+            :section-title (:title section)
+            :page page}))))))

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -1,14 +1,18 @@
 (ns lipas.ui.help.views
   (:require
-   ["@mui/icons-material/Close$default" :as CloseIcon]
-   ["@mui/icons-material/ArrowForwardIos$default" :as ArrowForwadIosIcon]
    ["@mui/icons-material/ArrowBack$default" :as ArrowBackIcon]
-   ["@mui/icons-material/ExpandMore$default" :as ExpandMoreIcon]
-   ["@mui/icons-material/Help$default" :as Help]
-   ["@mui/icons-material/Edit$default" :as EditIcon]
    ["@mui/material/Accordion$default" :as Accordion]
    ["@mui/material/AccordionSummary$default" :as AccordionSummary]
    ["@mui/material/AccordionDetails$default" :as AccordionDetails]
+   ["@mui/icons-material/Close$default" :as CloseIcon]
+   ["@mui/icons-material/Edit$default" :as EditIcon]
+   ["@mui/icons-material/ExpandMore$default" :as ExpandMoreIcon]
+   ["@mui/icons-material/Help$default" :as Help]
+   ["@mui/icons-material/Menu$default" :as MenuIcon]
+   ["@mui/icons-material/OpenInNew$default" :as OpenInNewIcon]
+   ["@mui/icons-material/PictureAsPdf$default" :as PdfIcon]
+   ["@mui/icons-material/Search$default" :as SearchIcon]
+   ["@mui/material/Alert$default" :as Alert]
    ["@mui/material/AppBar$default" :as AppBar]
    ["@mui/material/Box$default" :as Box]
    ["@mui/material/Breadcrumbs$default" :as Breadcrumbs]
@@ -16,33 +20,33 @@
    ["@mui/material/Card$default" :as Card]
    ["@mui/material/CardContent$default" :as CardContent]
    ["@mui/material/Chip$default" :as Chip]
+   ["@mui/material/Collapse$default" :as Collapse]
    ["@mui/material/Dialog$default" :as Dialog]
    ["@mui/material/DialogContent$default" :as DialogContent]
    ["@mui/material/Divider$default" :as Divider]
+   ["@mui/material/Drawer$default" :as Drawer]
    ["@mui/material/GridLegacy$default" :as Grid]
    ["@mui/material/IconButton$default" :as IconButton]
+   ["@mui/material/InputAdornment$default" :as InputAdornment]
    ["@mui/material/Link$default" :as Link]
    ["@mui/material/List$default" :as List]
-   ["@mui/material/ListItem$default" :as ListItem]
    ["@mui/material/ListItemButton$default" :as ListItemButton]
    ["@mui/material/ListItemText$default" :as ListItemText]
-   ["@mui/material/ListItemIcon$default" :as ListItemIcon]
+   ["@mui/material/ListSubheader$default" :as ListSubheader]
    ["@mui/material/Paper$default" :as Paper]
    ["@mui/material/Stack$default" :as Stack]
-   ["@mui/material/Tab$default" :as Tab]
    ["@mui/material/Table$default" :as Table]
    ["@mui/material/TableBody$default" :as TableBody]
    ["@mui/material/TableCell$default" :as TableCell]
    ["@mui/material/TableContainer$default" :as TableContainer]
    ["@mui/material/TableHead$default" :as TableHead]
    ["@mui/material/TableRow$default" :as TableRow]
-   ["@mui/material/Tabs$default" :as Tabs]
    ["@mui/material/TextField$default" :as TextField]
    ["@mui/material/Toolbar$default" :as Toolbar]
    ["@mui/material/Tooltip$default" :as Tooltip]
    ["@mui/material/Typography$default" :as Typography]
+   ["@mui/material/useMediaQuery$default" :as useMediaQuery]
    ["react-markdown$default" :as ReactMarkdown]
-   [lipas.utils :as cutils]
    [lipas.ui.help.events :as events]
    [lipas.ui.help.manage :as manage]
    [lipas.ui.help.subs :as subs]
@@ -52,29 +56,14 @@
    [reagent.hooks :as hooks]
    [re-frame.core :as rf]))
 
-(r/defc YoutubeIframe
-  [{:keys [video-id title]}]
-  [:iframe
-   {:width "560"
-    :height "315"
-    :src (str "https://www.youtube.com/embed/" video-id)
-    :title (or title "YouTube video player")
-    :frame-border "0"
-    :allow "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    :referrer-policy "strict-origin-when-cross-origin"
-    :allow-full-screen true}])
+;; The app theme uppercases every heading variant — help content titles
+;; are sentence-length, so they opt out explicitly.
+(def title-sx
+  #js{:textTransform "none"
+      :fontWeight 700
+      :lineHeight 1.25})
 
-(r/defc PdfIframe
-  [{:keys [url title]}]
-  [:> Box {:width "100%" :height "100%"}
-   [:> Paper {:elevation 2 :sx #js {:p 2}}
-    [:iframe
-     {:width "100%"
-      :height "600px"
-      :src url
-      :title (or title "PDF")
-      :frame-border "0"
-      :allow-full-screen true}]]])
+;;; ——— Type code explorer (unchanged from v1) ————————————————————————
 
 ;; Helper component to display a list of types
 (r/defc TypesList
@@ -368,150 +357,262 @@
     [:> Stack {:spacing 1}
      [:> Typography {:variant "h6"} (tr :help/data-model)]
      [:> Typography (tr :help/data-model-excel)]
-     [:> Button {:variant "contained"
-                 :on-click #(rf/dispatch [:lipas.ui.reports.events/create-data-model-report])}
-      (tr :actions/download-excel)]]))
+     [:> Box
+      [:> Button {:variant "contained"
+                  :on-click #(rf/dispatch [:lipas.ui.reports.events/create-data-model-report])}
+       (tr :actions/download-excel)]]]))
 
-(r/defc ContentBlock
+;;; ——— Content blocks —————————————————————————————————————————————————
+
+(r/defc ResponsiveVideo
+  [{:keys [video-id title]}]
+  [:> Box {:sx #js{:maxWidth 760}}
+   (when-not (empty? title)
+     [:> Typography {:variant "subtitle1" :sx #js{:fontWeight 700 :mb 1}}
+      title])
+   [:> Box {:sx #js{:position "relative"
+                    :pt "56.25%" ; 16:9
+                    :borderRadius 1
+                    :overflow "hidden"
+                    :bgcolor "common.black"}}
+    [:iframe
+     {:style {:position "absolute" :top 0 :left 0
+              :width "100%" :height "100%" :border 0}
+      :src (str "https://www.youtube.com/embed/" video-id)
+      :title (or title "YouTube video player")
+      :allow "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      :referrer-policy "strict-origin-when-cross-origin"
+      :allow-full-screen true}]]])
+
+(r/defc PdfCard
+  [{:keys [url title caption]}]
+  [:> Paper {:variant "outlined" :sx #js{:overflow "hidden"}}
+   [:> Stack {:direction "row" :spacing 1 :alignItems "center"
+              :sx #js{:px 2 :py 1 :bgcolor "action.hover"}}
+    [:> PdfIcon {:color "action"}]
+    [:> Typography {:variant "subtitle1" :sx #js{:fontWeight 700 :flexGrow 1}}
+     (if (empty? title) "PDF" title)]
+    [:> Tooltip {:title "Avaa uuteen välilehteen"}
+     [:> IconButton {:component "a" :href url :target "_blank" :rel "noopener"
+                     :size "small"}
+      [:> OpenInNewIcon {:fontSize "small"}]]]]
+   [:iframe
+    {:style {:width "100%" :height "70vh" :border 0 :display "block"}
+     :src url
+     :title (or title "PDF")
+     :allow-full-screen true}]
+   (when-not (empty? caption)
+     [:> Typography {:variant "body2" :color "text.secondary" :sx #js{:p 1.5}}
+      caption])])
+
+(r/defc BlockView
   [{:keys [block]}]
-  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (partial cutils/localized (tr))]
-    (case (:type block)
-      :text
-      [:> Box {:sx #js{:typography "body1"
-                       "& p" #js{:mt 0 :mb 1.5}
-                       "& p:last-child" #js{:mb 0}
-                       "& a" #js{:color "secondary.main"}
-                       "& img" #js{:maxWidth "100%"}}}
-       [:> ReactMarkdown (locale (:content block))]]
+  (case (:type block)
+    :text
+    [:> Box {:sx #js{:typography "body1"
+                     :maxWidth 760
+                     "& p" #js{:mt 0 :mb 1.5}
+                     "& p:last-child" #js{:mb 0}
+                     "& a" #js{:color "secondary.main"}
+                     "& img" #js{:maxWidth "100%"}}}
+     [:> ReactMarkdown (:content block)]]
 
-      :video
-      [YoutubeIframe {:video-id (:video-id block)
-                      :title (when (:title block) (locale (:title block)))}]
+    :video
+    [ResponsiveVideo {:video-id (:video-id block) :title (:title block)}]
 
-      :image
-      [:img {:src (:url block)
-             :alt (locale (:alt block))
-             :style #js{:maxWidth "100%"}}]
+    :image
+    [:> Box {:sx #js{:maxWidth 760}}
+     [:img {:src (:url block)
+            :alt (:alt block)
+            :style {:maxWidth "100%" :borderRadius "4px"}}]
+     (when-not (empty? (:caption block))
+       [:> Typography {:variant "body2" :color "text.secondary"}
+        (:caption block)])]
 
-      :pdf
-      [PdfIframe {:url (:url block)
-                  :title (when (:title block) (locale (:title block)))}]
+    :pdf
+    [PdfCard {:url (:url block) :title (:title block) :caption (:caption block)}]
 
-      :type-code-explorer
-      [TypeCodeExplorer]
+    :type-code-explorer
+    [TypeCodeExplorer]
 
-      :data-model-excel-download
-      [DataModelExcelDownload]
+    :data-model-excel-download
+    [DataModelExcelDownload]
 
-      ;; Default case - unknown block type
-      [:> Typography {:color "error"} (str "Unknown block type: " (:type block))])))
+    ;; Default case - unknown block type
+    [:> Typography {:color "error"} (str "Unknown block type: " (:type block))]))
 
-(r/defc HelpContent
-  [{:keys [title blocks]}]
-  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (partial cutils/localized (tr))]
-    [:> Stack {:direction "column" :spacing 2 :sx #js{:pl 4 :flex 1}}
-     [:> Typography {:variant :h6} (locale title)]
+;;; ——— Content area ———————————————————————————————————————————————————
 
-     ;; Content blocks container
-     [:> Stack {:direction "column" :spacing 2}
-      (for [block blocks]
-        ^{:key (:block-id block)}
-        [ContentBlock {:block block}])]]))
+(r/defc PageView
+  [{:keys [page]}]
+  [:> Stack {:spacing 3}
+   [:> Box
+    [:> Typography {:variant "h4" :component "h1" :sx title-sx}
+     (:title page)]
+    (when-not (empty? (:summary page))
+      [:> Typography {:variant "body1" :color "text.secondary" :sx #js{:mt 1}}
+       (:summary page)])]
+   (for [block (:blocks page)]
+     ^{:key (:block-id block)}
+     [BlockView {:block block}])])
 
-(r/defc SummaryGrid
-  [{:keys [pages on-page-select]}]
-  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (partial cutils/localized (tr))]
-    [:> Grid {:container true :spacing 2 :sx #js{:pl 4 :flex 1}}
-     [:> Grid {:item true :xs 12}
-      [:> Typography
-       {:variant "subtitle1"
-        :gutterBottom true}
-       (tr :help/available-pages)]]
+(r/defc PageList
+  ;; Landing list: page titles + summaries, theme-colored (the v1 cards
+  ;; hardcoded a light gradient that was unreadable in dark mode).
+  [{:keys [section]}]
+  [:> Paper {:variant "outlined"}
+   [:> List {:disablePadding true}
+    (map-indexed
+     (fn [idx {:keys [slug title summary blocks]}]
+       ^{:key slug}
+       [:<>
+        (when (pos? idx) [:> Divider])
+        [:> ListItemButton
+         {:onClick #(==> [::events/select-page (:slug section) slug])
+          :sx #js{:py 1.5}}
+         [:> ListItemText
+          {:primary title
+           :secondary (if (empty? summary)
+                        (some #(when (= :text (:type %)) (:content %)) blocks)
+                        summary)
+           :primaryTypographyProps #js{:sx #js{:fontWeight 700}}
+           :secondaryTypographyProps #js{:sx #js{:overflow "hidden"
+                                                 :textOverflow "ellipsis"
+                                                 :display "-webkit-box"
+                                                 :WebkitLineClamp 2
+                                                 :WebkitBoxOrient "vertical"}}}]]])
+     (:pages section))]])
 
-     (map-indexed
-      (fn [idx {:keys [slug title blocks]}]
-         ;; Find the first text block to display as summary
-        (let [summary-block (first (filter #(= :text (:type %)) blocks))
-              summary-text (when summary-block (:content summary-block))]
-          [:> Grid {:item true :xs 12 :sm 6 :md 4 :key (name slug)}
-           [:> Card {:sx #js{:height "100%"
-                             :cursor "pointer"
-                             :transition "transform 0.2s, box-shadow 0.2s, border-color 0.2s"
-                             :boxShadow 3
-                             :border "1px solid"
-                             :borderColor "divider"
-                             :background "linear-gradient(145deg, #ffffff, #f5f5f5)"
-                             ":hover" #js{:transform "scale(1.03)"
-                                          :boxShadow 6
-                                          :borderColor "secondary.main"}} ;; Use secondary color for border on hover
-                     :onClick #(on-page-select idx slug)}
-            [:> CardContent
-             [:> Typography
-              {:variant "subtitle2"
-               :gutterBottom true
-               :fontWeight "bold"}
-              (locale title)]
-             [:> Typography
-              {:variant "body2"
-               :color "text.secondary"
-               :sx #js{:overflow "hidden"
-                       :textOverflow "ellipsis"
-                       :display "-webkit-box"
-                       :-webkit-line-clamp 3
-                       :-webkit-box-orient "vertical"}}
-              (locale summary-text)]]]]))
-      pages)]))
+(r/defc SectionLanding
+  [{:keys [section]}]
+  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])]
+    [:> Stack {:spacing 2}
+     [:> Typography {:variant "h4" :component "h1" :sx title-sx}
+      (:title section)]
+     (when-not (empty? (:summary section))
+       [:> Typography {:variant "body1" :color "text.secondary"}
+        (:summary section)])
+     [:> Typography {:variant "subtitle2" :color "text.secondary" :sx #js{:pt 1}}
+      (tr :help/available-pages)]
+     [PageList {:section section}]]))
 
-(r/defc HelpMenu
-  [{:keys [pages selected-page on-page-select]}]
-  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (partial cutils/localized (tr))]
-    [:> Stack {:direction "column"}
-     [:> List {:sx #js{:minWidth "200px"
-                       :maxWidth "350px"
-                       :width "100%"
-                       :overflow "auto"}}
-      (map-indexed
-       (fn [idx {:keys [slug title]}]
-         ^{:key (name slug)}
+(r/defc FrontPage
+  [{:keys [tree]}]
+  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])]
+    [:> Stack {:spacing 2}
+     [:> Typography {:variant "h4" :component "h1" :sx title-sx}
+      (tr :help/headline)]
+     [:> Paper {:variant "outlined"}
+      [:> List {:disablePadding true}
+       (map-indexed
+        (fn [idx {:keys [slug title summary pages]}]
+          ^{:key slug}
+          [:<>
+           (when (pos? idx) [:> Divider])
+           [:> ListItemButton
+            {:onClick #(==> [::events/select-section slug])
+             :sx #js{:py 1.5}}
+            [:> ListItemText
+             {:primary title
+              :secondary (if (empty? summary)
+                           (str (count pages) " " (if (= 1 (count pages)) "sivu" "sivua"))
+                           summary)
+              :primaryTypographyProps #js{:sx #js{:fontWeight 700}}}]]])
+        tree)]]]))
+
+;;; ——— Navigation ————————————————————————————————————————————————————
+
+(r/defc NavTree
+  [{:keys [tree on-navigate]}]
+  (let [selected-section-slug @(rf/subscribe [::subs/selected-section-slug])
+        selected-page-slug @(rf/subscribe [::subs/selected-page-slug])
+        expanded @(rf/subscribe [::subs/expanded-sections])]
+    [:> List {:disablePadding true :sx #js{:pb 2}}
+     (for [{:keys [slug title pages]} tree]
+       (let [expanded? (contains? expanded slug)]
+         ^{:key slug}
          [:<>
-          [:> Divider]
-          [:> ListItem
-           {:key (name slug)
-            :disablePadding true
-            :component "a"
-            :sx #js{:transition "border-color 0.2s"
-                    :border "2px solid"
-                    :borderColor (if (= selected-page idx) "secondary.main" "transparent")
-                    ":hover" #js{:borderColor "secondary.main"}}}
-           [:> ListItemButton {:on-click #(on-page-select idx slug)
-                               :sx #js{:padding "8px 16px"}}
-            (when (= selected-page idx)
-              [:> ListItemIcon
-               [:> ArrowForwadIosIcon {:color "secondary"}]])
-            [:> ListItemText {:primary (locale title)
-                              :primaryTypographyProps #js{:noWrap false}}]]]])
-       pages)]]))
+          [:> ListItemButton
+           {:onClick #(do (==> [::events/select-section slug])
+                          (when on-navigate (on-navigate)))
+            :selected (and (= slug selected-section-slug)
+                           (nil? selected-page-slug))
+            :sx #js{:alignItems "flex-start" :py 1}}
+           [:> ListItemText
+            {:primary title
+             :primaryTypographyProps
+             #js{:sx #js{:fontWeight 700 :fontSize "0.875rem" :lineHeight 1.35}}}]
+           [:> IconButton
+            {:size "small"
+             :edge "end"
+             :aria-label (if expanded? "collapse" "expand")
+             :onClick (fn [e]
+                        (.stopPropagation e)
+                        (==> [::events/toggle-section slug]))
+             :sx #js{:mt 0.25
+                     :transform (if expanded? "rotate(180deg)" "rotate(0deg)")
+                     :transition "transform 0.2s"}}
+            [:> ExpandMoreIcon {:fontSize "small"}]]]
+          [:> Collapse {:in expanded? :timeout "auto"}
+           [:> List {:disablePadding true}
+            (for [page pages]
+              ^{:key (:slug page)}
+              [:> ListItemButton
+               {:onClick #(do (==> [::events/select-page slug (:slug page)])
+                              (when on-navigate (on-navigate)))
+                :selected (and (= slug selected-section-slug)
+                               (= (:slug page) selected-page-slug))
+                :sx #js{:pl 4 :py 0.75}}
+               [:> ListItemText
+                {:primary (:title page)
+                 :primaryTypographyProps
+                 #js{:sx #js{:fontSize "0.85rem" :lineHeight 1.35}}}]])]]]))]))
 
-(r/defc HelpSection
-  [{:keys [pages] :as _section}]
-  (let [selected-page-idx @(rf/subscribe [::subs/selected-page-idx])
-        selected-page (when (and (number? selected-page-idx)
-                                 (< selected-page-idx (count pages)))
-                        (nth pages selected-page-idx))]
-    [:> Stack {:direction "row" :spacing 2}
+(r/defc SearchResults
+  [{:keys [on-navigate]}]
+  (let [results @(rf/subscribe [::subs/search-results])
+        tr @(rf/subscribe [:lipas.ui.subs/translator])]
+    (if (empty? results)
+      [:> Typography {:variant "body2" :color "text.secondary" :sx #js{:p 2}}
+       (tr :search/results-count 0)]
+      [:> List {:disablePadding true :sx #js{:pb 2}}
+       ;; results come in tree order; partition-by keeps it
+       (for [matches (partition-by :section-slug results)]
+         ^{:key (:section-slug (first matches))}
+         [:<>
+          [:> ListSubheader {:disableSticky true} (:section-title (first matches))]
+          (for [{:keys [section-slug page]} matches]
+            ^{:key (:slug page)}
+            [:> ListItemButton
+             {:onClick #(do (==> [::events/select-page section-slug (:slug page)])
+                            (when on-navigate (on-navigate)))
+              :sx #js{:py 0.75}}
+             [:> ListItemText
+              {:primary (:title page)
+               :primaryTypographyProps
+               #js{:sx #js{:fontSize "0.85rem" :lineHeight 1.35}}}]])])])))
 
-     [HelpMenu {:pages pages
-                :selected-page selected-page-idx
-                :on-page-select #(==> [::events/select-page %1 %2])}]
+(r/defc NavPanel
+  [{:keys [tree on-navigate]}]
+  (let [search-term @(rf/subscribe [::subs/search-term])
+        tr @(rf/subscribe [:lipas.ui.subs/translator])]
+    [:> Box
+     [:> Box {:sx #js{:p 2 :pb 1}}
+      [:> TextField
+       {:fullWidth true
+        :size "small"
+        :placeholder (tr :search/search)
+        :value search-term
+        :onChange #(==> [::events/set-search-term (.. % -target -value)])
+        :InputProps #js{:startAdornment
+                        (r/as-element
+                         [:> InputAdornment {:position "start"}
+                          [:> SearchIcon {:fontSize "small"}]])}}]]
+     (if (empty? search-term)
+       [NavTree {:tree tree :on-navigate on-navigate}]
+       [SearchResults {:on-navigate on-navigate}])]))
 
-     (if selected-page
-       [HelpContent selected-page]
-       [SummaryGrid {:pages pages
-                     :on-page-select #(==> [::events/select-page %1 %2])}])]))
+;;; ——— Dialog ————————————————————————————————————————————————————————
 
 (r/defc HelpManageButton []
   (let [has-permission? @(rf/subscribe [::user-subs/check-privilege nil :help/manage])
@@ -526,80 +627,96 @@
         :on-click #(==> [::events/open-edit-mode])}
        (tr :help/manage-content)])))
 
+(r/defc ReadView
+  [{:keys [mobile?]}]
+  (let [tree @(rf/subscribe [::subs/display-tree])
+        fallback? @(rf/subscribe [::subs/fallback?])
+        selected-section @(rf/subscribe [::subs/selected-section])
+        selected-page @(rf/subscribe [::subs/selected-page])
+        tr @(rf/subscribe [:lipas.ui.subs/translator])
+        [drawer-open? set-drawer-open!] (hooks/use-state false)
+        close-drawer! #(set-drawer-open! false)]
+    [:> Box {:sx #js{:display "flex" :flex 1 :minHeight 0}}
+
+     ;; Navigation: permanent panel on desktop, drawer on mobile
+     (if mobile?
+       [:> Drawer {:open drawer-open?
+                   :onClose close-drawer!
+                   :ModalProps #js{:keepMounted true}
+                   :PaperProps #js{:sx #js{:width 300}}}
+        [NavPanel {:tree tree :on-navigate close-drawer!}]]
+       [:> Box {:sx #js{:width 320
+                        :minWidth 280
+                        :borderRight 1
+                        :borderColor "divider"
+                        :overflowY "auto"}}
+        [NavPanel {:tree tree}]])
+
+     ;; Content column
+     [:> Box {:sx #js{:flex 1 :overflowY "auto" :minWidth 0}}
+      [:> Box {:sx #js{:maxWidth 900 :px #js{:xs 2 :md 4} :py 3}}
+
+       ;; Mobile: nav opener + breadcrumb back
+       (when mobile?
+         [:> Stack {:direction "row" :spacing 1 :alignItems "center" :sx #js{:mb 2}}
+          [:> Button {:variant "outlined"
+                      :size "small"
+                      :startIcon (r/as-element [:> MenuIcon])
+                      :onClick #(set-drawer-open! true)}
+           (tr :help/headline)]
+          (when selected-page
+            [:> Button {:size "small"
+                        :startIcon (r/as-element [:> ArrowBackIcon])
+                        :onClick #(==> [::events/select-section (:slug selected-section)])}
+             (tr :actions/back)])])
+
+       (when fallback?
+         [:> Alert {:severity "info" :sx #js{:mb 2}}
+          (tr :help/only-in-finnish)])
+
+       (cond
+         selected-page [PageView {:page selected-page}]
+         selected-section [SectionLanding {:section selected-section}]
+         :else [FrontPage {:tree tree}])]]]))
+
 (r/defc dialog
   ;; Mounted once at app root (lipas.ui.views/main-panel) so ?ohje= deep
   ;; links open the help center on any route.
   []
-  (let [sections @(rf/subscribe [::subs/help-data])
-        mode @(rf/subscribe [::subs/mode])
+  (let [mode @(rf/subscribe [::subs/mode])
         dialog-open? @(rf/subscribe [::subs/dialog-open?])
-        selected-section-idx @(rf/subscribe [::subs/selected-section-idx])
-        selected-page-idx @(rf/subscribe [::subs/selected-page-idx])
-        selected-section (when (and sections (number? selected-section-idx)
-                                    (< selected-section-idx (count sections)))
-                           (nth sections selected-section-idx))
-        selected-pages (when selected-section
-                         (:pages selected-section))
-        selected-page (when (and selected-pages (number? selected-page-idx)
-                                 (< selected-page-idx (count selected-pages)))
-                        (nth selected-pages selected-page-idx))
         tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale-kw (partial cutils/localized (tr))]
+        mobile? (useMediaQuery "(max-width:899.95px)")]
 
     [:> Dialog
-      {:fullScreen true
-       :keepMounted true
-       :open dialog-open?
-       :onClose #(==> [::events/close-dialog])}
+     {:fullScreen true
+      :keepMounted true
+      :open dialog-open?
+      :onClose #(==> [::events/close-dialog])}
 
-      [:> AppBar {:sx #js {:position "relative"}}
-       [:> Toolbar {}
-        [:> Typography {:variant "h6" :color "inherit" :sx #js{:flexGrow 1}}
-         (tr :help/headline)]
+     [:> AppBar {:sx #js{:position "relative"}}
+      [:> Toolbar {}
+       [:> Typography {:variant "h6" :color "inherit" :sx #js{:flexGrow 1}
+                       :component "button"
+                       :onClick #(==> [::events/go-home])
+                       :style {:background "none" :border 0 :cursor "pointer"
+                               :textAlign "left" :color "inherit"}}
+        (tr :help/headline)]
 
-        ;; Manage content button (only visible with permission)
-        [HelpManageButton]
+       ;; Manage content button (only visible with permission)
+       [HelpManageButton]
 
-        [:> IconButton
-         {:edge "start"
-          :color "inherit"
-          :onClick #(==> [::events/close-dialog])}
-         [:> CloseIcon]]]]
+       [:> IconButton
+        {:edge "start"
+         :color "inherit"
+         :onClick #(==> [::events/close-dialog])}
+        [:> CloseIcon]]]]
 
-      [:> DialogContent {:sx #js {:display "flex" :flexDirection "column" :gap 2}}
-
-       (when (= :edit mode)
-         [manage/view])
-
-       (when (= :read mode)
-         [:<>
-          [:> Tabs {:value selected-section-idx
-                    :onChange #(==> [::events/select-section %2 (get-in (nth sections %2) [:slug])])
-                    :variant "scrollable"
-                    :scrollButtons true}
-           (map-indexed
-            (fn [idx section]
-              [:> Tab {:key idx
-                       :value idx
-                       :label (locale-kw (:title section))
-                       :wrapped true}])
-            sections)]
-
-          [:> Breadcrumbs {:sx #js{:mt 1}}
-           [:> Typography (tr :help/headline)]
-
-           (when selected-section
-             [:> Link {:underline "hover"
-                       :color "inherit"
-                       :on-click #(==> [::events/select-page nil nil])}
-              (locale-kw (:title selected-section))])
-
-           (when selected-page
-             [:> Typography {:color "text.primary"}
-              (locale-kw (:title selected-page))])]
-
-          (when selected-section
-            [HelpSection selected-section])])]]))
+     (if (= :edit mode)
+       [:> DialogContent {:sx #js{:display "flex" :flexDirection "column"}}
+        [manage/view]]
+       [:> DialogContent {:sx #js{:p 0 :display "flex" :overflow "hidden"}}
+        [ReadView {:mobile? mobile?}]])]))
 
 (r/defc view
   ;; Help icon button for the (mini-)navbar; the dialog itself is mounted

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -41,6 +41,8 @@
    ["@mui/material/Toolbar$default" :as Toolbar]
    ["@mui/material/Tooltip$default" :as Tooltip]
    ["@mui/material/Typography$default" :as Typography]
+   ["react-markdown$default" :as ReactMarkdown]
+   [lipas.utils :as cutils]
    [lipas.ui.help.events :as events]
    [lipas.ui.help.manage :as manage]
    [lipas.ui.help.subs :as subs]
@@ -373,10 +375,15 @@
 (r/defc ContentBlock
   [{:keys [block]}]
   (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (tr)]
+        locale (partial cutils/localized (tr))]
     (case (:type block)
       :text
-      [:> Typography (locale (:content block))]
+      [:> Box {:sx #js{:typography "body1"
+                       "& p" #js{:mt 0 :mb 1.5}
+                       "& p:last-child" #js{:mb 0}
+                       "& a" #js{:color "secondary.main"}
+                       "& img" #js{:maxWidth "100%"}}}
+       [:> ReactMarkdown (locale (:content block))]]
 
       :video
       [YoutubeIframe {:video-id (:video-id block)
@@ -403,7 +410,7 @@
 (r/defc HelpContent
   [{:keys [title blocks]}]
   (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (tr)]
+        locale (partial cutils/localized (tr))]
     [:> Stack {:direction "column" :spacing 2 :sx #js{:pl 4 :flex 1}}
      [:> Typography {:variant :h6} (locale title)]
 
@@ -416,7 +423,7 @@
 (r/defc SummaryGrid
   [{:keys [pages on-page-select]}]
   (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (tr)]
+        locale (partial cutils/localized (tr))]
     [:> Grid {:container true :spacing 2 :sx #js{:pl 4 :flex 1}}
      [:> Grid {:item true :xs 12}
       [:> Typography
@@ -461,7 +468,7 @@
 (r/defc HelpMenu
   [{:keys [pages selected-page on-page-select]}]
   (let [tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale (tr)]
+        locale (partial cutils/localized (tr))]
     [:> Stack {:direction "column"}
      [:> List {:sx #js{:minWidth "200px"
                        :maxWidth "350px"
@@ -537,7 +544,7 @@
                                  (< selected-page-idx (count selected-pages)))
                         (nth selected-pages selected-page-idx))
         tr @(rf/subscribe [:lipas.ui.subs/translator])
-        locale-kw (tr)]
+        locale-kw (partial cutils/localized (tr))]
 
     [:> Dialog
       {:fullScreen true

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -18,12 +18,12 @@
    ["@mui/material/Breadcrumbs$default" :as Breadcrumbs]
    ["@mui/material/Button$default" :as Button]
    ["@mui/material/Card$default" :as Card]
+   ["@mui/material/CardActionArea$default" :as CardActionArea]
    ["@mui/material/CardContent$default" :as CardContent]
    ["@mui/material/Chip$default" :as Chip]
    ["@mui/material/Collapse$default" :as Collapse]
    ["@mui/material/Dialog$default" :as Dialog]
    ["@mui/material/DialogContent$default" :as DialogContent]
-   ["@mui/material/Divider$default" :as Divider]
    ["@mui/material/Drawer$default" :as Drawer]
    ["@mui/material/GridLegacy$default" :as Grid]
    ["@mui/material/IconButton$default" :as IconButton]
@@ -32,7 +32,6 @@
    ["@mui/material/List$default" :as List]
    ["@mui/material/ListItemButton$default" :as ListItemButton]
    ["@mui/material/ListItemText$default" :as ListItemText]
-   ["@mui/material/ListSubheader$default" :as ListSubheader]
    ["@mui/material/Paper$default" :as Paper]
    ["@mui/material/Stack$default" :as Stack]
    ["@mui/material/Table$default" :as Table]
@@ -443,6 +442,10 @@
 
 ;;; ——— Content area ———————————————————————————————————————————————————
 
+(def ^:private full-width-block-types
+  ;; Interactive/wide blocks that shouldn't be squeezed into a column
+  #{:type-code-explorer :data-model-excel-download})
+
 (r/defc PageView
   [{:keys [page]}]
   [:> Stack {:spacing 3}
@@ -452,36 +455,62 @@
     (when-not (empty? (:summary page))
       [:> Typography {:variant "body1" :color "text.secondary" :sx #js{:mt 1}}
        (:summary page)])]
-   (for [block (:blocks page)]
-     ^{:key (:block-id block)}
-     [BlockView {:block block}])])
+   ;; On large screens the blocks flow into two columns to use the
+   ;; horizontal space; below lg they stack in a single column.
+   [:> Box {:sx #js{:display "grid"
+                    :gap 3
+                    :alignItems "start"
+                    :gridTemplateColumns #js{:xs "1fr"
+                                             :lg "repeat(2, minmax(0, 1fr))"}}}
+    (for [block (:blocks page)]
+      ^{:key (:block-id block)}
+      [:> Box {:sx (when (full-width-block-types (:type block))
+                     #js{:gridColumn "1 / -1"})}
+       [BlockView {:block block}]])]])
+
+(r/defc LandingCardGrid
+  ;; Landing grid: title + summary cards, 1–3 columns depending on
+  ;; screen width. Theme-colored so it works in both light and dark
+  ;; mode; the orange sentence-case titles echo the LIPAS front page
+  ;; cards.
+  [{:keys [items on-select]}]
+  [:> Grid {:container true :spacing 2}
+   (for [{:keys [slug title text]} items]
+     ^{:key slug}
+     [:> Grid {:item true :xs 12 :md 6 :lg 4}
+      [:> Card {:sx #js{:height "100%"}}
+       [:> CardActionArea {:onClick #(on-select slug)
+                           :sx #js{:height "100%"
+                                   :display "flex"
+                                   :flexDirection "column"
+                                   :alignItems "stretch"
+                                   :justifyContent "flex-start"}}
+        [:> CardContent
+         [:> Typography {:variant "h6"
+                         :component "h2"
+                         :color "secondary"
+                         :gutterBottom true
+                         :sx title-sx}
+          title]
+         (when-not (empty? text)
+           [:> Typography {:variant "body1"
+                           :sx #js{:overflow "hidden"
+                                   :textOverflow "ellipsis"
+                                   :display "-webkit-box"
+                                   :WebkitLineClamp 3
+                                   :WebkitBoxOrient "vertical"}}
+            text])]]]])])
 
 (r/defc PageList
-  ;; Landing list: page titles + summaries, theme-colored (the v1 cards
-  ;; hardcoded a light gradient that was unreadable in dark mode).
   [{:keys [section]}]
-  [:> Paper {:variant "outlined"}
-   [:> List {:disablePadding true}
-    (map-indexed
-     (fn [idx {:keys [slug title summary blocks]}]
-       ^{:key slug}
-       [:<>
-        (when (pos? idx) [:> Divider])
-        [:> ListItemButton
-         {:onClick #(==> [::events/select-page (:slug section) slug])
-          :sx #js{:py 1.5}}
-         [:> ListItemText
-          {:primary title
-           :secondary (if (empty? summary)
-                        (some #(when (= :text (:type %)) (:content %)) blocks)
-                        summary)
-           :primaryTypographyProps #js{:sx #js{:fontWeight 700}}
-           :secondaryTypographyProps #js{:sx #js{:overflow "hidden"
-                                                 :textOverflow "ellipsis"
-                                                 :display "-webkit-box"
-                                                 :WebkitLineClamp 2
-                                                 :WebkitBoxOrient "vertical"}}}]]])
-     (:pages section))]])
+  [LandingCardGrid
+   {:items (for [{:keys [slug title summary blocks]} (:pages section)]
+             {:slug slug
+              :title title
+              :text (if (empty? summary)
+                      (some #(when (= :text (:type %)) (:content %)) blocks)
+                      summary)})
+    :on-select #(==> [::events/select-page (:slug section) %])}])
 
 (r/defc SectionLanding
   [{:keys [section]}]
@@ -502,23 +531,14 @@
     [:> Stack {:spacing 2}
      [:> Typography {:variant "h4" :component "h1" :sx title-sx}
       (tr :help/headline)]
-     [:> Paper {:variant "outlined"}
-      [:> List {:disablePadding true}
-       (map-indexed
-        (fn [idx {:keys [slug title summary pages]}]
-          ^{:key slug}
-          [:<>
-           (when (pos? idx) [:> Divider])
-           [:> ListItemButton
-            {:onClick #(==> [::events/select-section slug])
-             :sx #js{:py 1.5}}
-            [:> ListItemText
-             {:primary title
-              :secondary (if (empty? summary)
-                           (str (count pages) " " (if (= 1 (count pages)) "sivu" "sivua"))
-                           summary)
-              :primaryTypographyProps #js{:sx #js{:fontWeight 700}}}]]])
-        tree)]]]))
+     [LandingCardGrid
+      {:items (for [{:keys [slug title summary pages]} tree]
+                {:slug slug
+                 :title title
+                 :text (if (empty? summary)
+                         (str (count pages) " " (if (= 1 (count pages)) "sivu" "sivua"))
+                         summary)})
+       :on-select #(==> [::events/select-section %])}]]))
 
 ;;; ——— Navigation ————————————————————————————————————————————————————
 
@@ -576,17 +596,25 @@
       [:> Typography {:variant "body2" :color "text.secondary" :sx #js{:p 2}}
        (tr :search/results-count 0)]
       [:> List {:disablePadding true :sx #js{:pb 2}}
-       ;; results come in tree order; partition-by keeps it
-       (for [matches (partition-by :section-slug results)]
-         ^{:key (:section-slug (first matches))}
+       (for [{:keys [section-slug section-title pages]} results]
+         ^{:key section-slug}
          [:<>
-          [:> ListSubheader {:disableSticky true} (:section-title (first matches))]
-          (for [{:keys [section-slug page]} matches]
+          ;; Section header navigates to the section landing — a match
+          ;; on the section title itself is a valid result.
+          [:> ListItemButton
+           {:onClick #(do (==> [::events/select-section section-slug])
+                          (when on-navigate (on-navigate)))
+            :sx #js{:py 1}}
+           [:> ListItemText
+            {:primary section-title
+             :primaryTypographyProps
+             #js{:sx #js{:fontWeight 700 :fontSize "0.875rem" :lineHeight 1.35}}}]]
+          (for [page pages]
             ^{:key (:slug page)}
             [:> ListItemButton
              {:onClick #(do (==> [::events/select-page section-slug (:slug page)])
                             (when on-navigate (on-navigate)))
-              :sx #js{:py 0.75}}
+              :sx #js{:pl 4 :py 0.75}}
              [:> ListItemText
               {:primary (:title page)
                :primaryTypographyProps
@@ -654,7 +682,7 @@
 
      ;; Content column
      [:> Box {:sx #js{:flex 1 :overflowY "auto" :minWidth 0}}
-      [:> Box {:sx #js{:maxWidth 900 :px #js{:xs 2 :md 4} :py 3}}
+      [:> Box {:sx #js{:maxWidth 1560 :px #js{:xs 2 :md 4} :py 3}}
 
        ;; Mobile: nav opener + breadcrumb back
        (when mobile?

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -692,7 +692,10 @@
      {:fullScreen true
       :keepMounted true
       :open dialog-open?
-      :onClose #(==> [::events/close-dialog])}
+      :onClose #(==> [::events/close-dialog])
+      ;; The assistant panel lives outside this dialog's portal — without
+      ;; this the modal focus trap steals every keystroke from it.
+      :disableEnforceFocus true}
 
      [:> AppBar {:sx #js{:position "relative"}}
       [:> Toolbar {}

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -519,8 +519,10 @@
         :on-click #(==> [::events/open-edit-mode])}
        (tr :help/manage-content)])))
 
-(r/defc view
-  [{:keys []}]
+(r/defc dialog
+  ;; Mounted once at app root (lipas.ui.views/main-panel) so ?ohje= deep
+  ;; links open the help center on any route.
+  []
   (let [sections @(rf/subscribe [::subs/help-data])
         mode @(rf/subscribe [::subs/mode])
         dialog-open? @(rf/subscribe [::subs/dialog-open?])
@@ -537,15 +539,7 @@
         tr @(rf/subscribe [:lipas.ui.subs/translator])
         locale-kw (tr)]
 
-    [:<>
-     ;; Help button in main UI
-     [:> Tooltip {:title (tr :help/headline)}
-      [:> IconButton {:size "large"
-                      :on-click #(==> [::events/open-dialog])}
-       [:> Help]]]
-
-     ;; Help dialog
-     [:> Dialog
+    [:> Dialog
       {:fullScreen true
        :keepMounted true
        :open dialog-open?
@@ -594,10 +588,18 @@
               (locale-kw (:title selected-section))])
 
            (when selected-page
-             [:> Link {:underline "hover"
-                       :color "inherit"
-                       :href "/"}
+             [:> Typography {:color "text.primary"}
               (locale-kw (:title selected-page))])]
 
           (when selected-section
-            [HelpSection selected-section])])]]]))
+            [HelpSection selected-section])])]]))
+
+(r/defc view
+  ;; Help icon button for the (mini-)navbar; the dialog itself is mounted
+  ;; at app root.
+  [{:keys []}]
+  (let [tr @(rf/subscribe [:lipas.ui.subs/translator])]
+    [:> Tooltip {:title (tr :help/headline)}
+     [:> IconButton {:size "large"
+                     :on-click #(==> [::events/open-dialog])}
+      [:> Help]]]))

--- a/webapp/src/cljs/lipas/ui/help/views.cljs
+++ b/webapp/src/cljs/lipas/ui/help/views.cljs
@@ -448,25 +448,50 @@
 
 (r/defc PageView
   [{:keys [page]}]
-  [:> Stack {:spacing 3}
-   [:> Box
-    [:> Typography {:variant "h4" :component "h1" :sx title-sx}
-     (:title page)]
-    (when-not (empty? (:summary page))
-      [:> Typography {:variant "body1" :color "text.secondary" :sx #js{:mt 1}}
-       (:summary page)])]
-   ;; On large screens the blocks flow into two columns to use the
-   ;; horizontal space; below lg they stack in a single column.
-   [:> Box {:sx #js{:display "grid"
-                    :gap 3
-                    :alignItems "start"
-                    :gridTemplateColumns #js{:xs "1fr"
-                                             :lg "repeat(2, minmax(0, 1fr))"}}}
-    (for [block (:blocks page)]
-      ^{:key (:block-id block)}
-      [:> Box {:sx (when (full-width-block-types (:type block))
-                     #js{:gridColumn "1 / -1"})}
-       [BlockView {:block block}]])]])
+  (let [xl? (useMediaQuery (fn [theme] (.up (.-breakpoints theme) "xl")))
+        blocks   (:blocks page)
+        video?   (fn [b] (= :video (:type b)))
+        wide?    (fn [b] (full-width-block-types (:type b)))
+        videos   (filter video? blocks)
+        others   (remove #(or (video? %) (wide? %)) blocks)
+        ;; Two columns only on xl screens, and only when both columns
+        ;; would have content: other content stacks left, videos stack
+        ;; right. The structures differ, so this is a media-query branch
+        ;; rather than responsive sx.
+        grouped? (and xl? (seq videos) (seq others))]
+    [:> Stack {:spacing 3}
+     [:> Box
+      [:> Typography {:variant "h4" :component "h1" :sx title-sx}
+       (:title page)]
+      (when-not (empty? (:summary page))
+        [:> Typography {:variant "body1" :color "text.secondary" :sx #js{:mt 1}}
+         (:summary page)])]
+     (if grouped?
+       [:> Box {:sx #js{:display "grid"
+                        :gap 3
+                        :alignItems "start"
+                        :gridTemplateColumns "repeat(2, minmax(0, 1fr))"}}
+        [:> Stack {:spacing 3}
+         (for [block others]
+           ^{:key (:block-id block)}
+           [BlockView {:block block}])]
+        [:> Stack {:spacing 3}
+         (for [block videos]
+           ^{:key (:block-id block)}
+           [BlockView {:block block}])]
+        ;; Interactive/wide blocks span both columns below the grouped
+        ;; content.
+        (for [block blocks
+              :when (wide? block)]
+          ^{:key (:block-id block)}
+          [:> Box {:sx #js{:gridColumn "1 / -1"}}
+           [BlockView {:block block}]])]
+       ;; Below xl (or when a page has only one kind of content) the
+       ;; blocks stack in a single column in authored order.
+       [:> Stack {:spacing 3}
+        (for [block blocks]
+          ^{:key (:block-id block)}
+          [BlockView {:block block}])])]))
 
 (r/defc LandingCardGrid
   ;; Landing grid: title + summary cards, 1–3 columns depending on

--- a/webapp/src/cljs/lipas/ui/map/routes.cljs
+++ b/webapp/src/cljs/lipas/ui/map/routes.cljs
@@ -15,7 +15,6 @@
      :controllers
      [{:start
        (fn [_]
-         (==> [:lipas.ui.help.events/get-help-data])
          (==> [:lipas.ui.map.events/show-sports-site* nil]))}]}]
 
    ["/loi/:loi-id"

--- a/webapp/src/cljs/lipas/ui/map/views.cljs
+++ b/webapp/src/cljs/lipas/ui/map/views.cljs
@@ -63,6 +63,7 @@
             ["@mui/material/Tabs$default" :as Tabs]
             ["@mui/material/Toolbar$default" :as Toolbar]
             ["@mui/material/Tooltip$default" :as Tooltip]
+            [lipas.ui.assistant.views :as assistant-views]
             [lipas.ui.mui :as mui]
             [lipas.ui.navbar :as nav]
             [lipas.ui.org.views :as org-views]
@@ -2197,44 +2198,54 @@
        :right "3.5em"
        :background-color "transparent"}
 
-      [:> Grid2
-       {:container true
+      [:> Stack
+       {:direction "row"
         :spacing 1
-        :sx #js {:bgcolor mui/gray2
-                 :padding 1
-                 :justifyContent "center"
-                 :alignItems "center"
-                 :border-radius 4}
-        :wrap "nowrap"}
+        :alignItems "center"}
 
-       ;; Feedback btn
-       #_[:> Grid
-          [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
-           [feedback/feedback-btn]]]
+       [:> Grid2
+        {:container true
+         :spacing 1
+         :sx #js {:bgcolor mui/gray2
+                  :padding 1
+                  :justifyContent "center"
+                  :alignItems "center"
+                  :border-radius 4}
+         :wrap "nowrap"}
 
-       ;; Zoom to users location btn
-       [:> Grid
-        [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
-         [user-location-btn {:tr tr}]]]
+        ;; Feedback btn
+        #_[:> Grid
+           [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
+            [feedback/feedback-btn]]]
 
-       ;; Overlay selector
-       [:> Grid
-        [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
-         [overlay-selector {:tr tr}]]]
+        ;; Zoom to users location btn
+        [:> Grid
+         [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
+          [user-location-btn {:tr tr}]]]
 
-       ;; Basemap opacity selector
-       [:> Grid
-        [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
-         [basemap-transparency-selector {:tr tr}]]]
+        ;; Overlay selector
+        [:> Grid
+         [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
+          [overlay-selector {:tr tr}]]]
 
-       ;; Basemap switcher
-       [:> Grid
-        [:> Paper
-         {:elevation 1
-          :style
-          {:background-color "rgba(255,255,255,0.9)"
-           :padding-left "0.5em" :padding-right "0.5em"}}
-         [layer-switcher {:tr tr}]]]]]
+        ;; Basemap opacity selector
+        [:> Grid
+         [:> Paper {:style {:background-color "rgba(255,255,255,0.9)"}}
+          [basemap-transparency-selector {:tr tr}]]]
+
+        ;; Basemap switcher
+        [:> Grid
+         [:> Paper
+          {:elevation 1
+           :style
+           {:background-color "rgba(255,255,255,0.9)"
+            :padding-left "0.5em" :padding-right "0.5em"}}
+          [layer-switcher {:tr tr}]]]]
+
+       ;; AI assistant launcher — next to (not inside) the control
+       ;; cluster so it pops against the map; here rather than the
+       ;; viewport corner because the corner is already crowded
+       [assistant-views/MapLauncher]]]
 
      [popup
       {:popup-ref popup-ref}]

--- a/webapp/src/cljs/lipas/ui/navbar.cljs
+++ b/webapp/src/cljs/lipas/ui/navbar.cljs
@@ -28,8 +28,10 @@
             [reitit.frontend.easy :as rfe]))
 
 (def links
-  {:help "https://www.jyu.fi/sport/fi/yhteistyo/lipas-liikuntapaikat.fi"
-   :privacy-policy "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"})
+  {:privacy-policy "https://lipas.fi/pdf/tietosuojailmoitus_lipas.pdf"})
+
+(defn open-help! []
+  (==> [:lipas.ui.help.events/open-dialog]))
 
 (defn logout! []
   (==> [:lipas.ui.login.events/logout]))
@@ -104,7 +106,7 @@
 
      ;; Help
      [:> MenuItem {:id "account-menu-item-help"
-                   :on-click (comp close #(navigate! (:help links)))}
+                   :on-click (comp close open-help!)}
       [:> ListItemIcon
        [:> Icon "help"]]
       [:> ListItemText {:primary (tr :help/headline)}]]
@@ -210,7 +212,7 @@
          [:> ListItemText {:primary (tr :lipas.admin/headline)}]])
 
       ;; Help
-      [:> ListItemButton {:on-click #(hide-and-navigate! (:help links))}
+      [:> ListItemButton {:on-click (comp close-drawer open-help!)}
        [:> ListItemIcon
         [:> Icon "help"]]
        [:> ListItemText {:primary (tr :help/headline)}]]

--- a/webapp/src/cljs/lipas/ui/project_devtools.cljs
+++ b/webapp/src/cljs/lipas/ui/project_devtools.cljs
@@ -135,8 +135,14 @@
       [dev-tools/dev-tool {:toggle-btn (fn [open-fn]
                                          [:button.reagent-dev-tools__nav-li-a.reagent-dev-tools__toggle-btn
                                           {:on-click open-fn
-                                           :style {:margin-bottom "75px"
-                                                   :margin-right "5px"
+                                           ;; right edge, vertically centered: both bottom
+                                           ;; corners are taken (assistant Fab, map controls)
+                                           :style {:position "fixed"
+                                                   :top "50%"
+                                                   :right "0px"
+                                                   :bottom "auto"
+                                                   :left "auto"
+                                                   :transform "translateY(-50%)"
                                                    :box-shadow "1px 1px 5px rgba(0, 0, 0, 0.5)"}}
                                           "dev"])
                            :panels (into (dev-tools/create-default-panels {:state-atom  re-frame.db/app-db})

--- a/webapp/src/cljs/lipas/ui/ptv/events.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/events.cljs
@@ -174,6 +174,36 @@
         (assoc-in [:ptv :selected-tab] "wizard")
         (update :ptv dissoc :candidates-search :selected-step))))
 
+(def ^:private assistant-tab-labels
+  "Dialog tab values → the labels the user sees (fi UI labels)."
+  {"wizard" "Käyttöönotto (ohjattu vienti PTV:hen)"
+   "services" "Palvelut"
+   "sports-sites" "Liikuntapaikat"
+   "audit" "Auditointi"})
+
+(def ^:private assistant-wizard-step-labels
+  ["1. Valitse liikuntapaikat"
+   "2. Luo PTV-palvelut"
+   "3. Luo liikuntapaikoista palvelupaikat"])
+
+(defn dialog-context
+  "Open PTV-export-dialog state for the assistant's context snapshot,
+   or nil when the dialog is closed."
+  [db]
+  (when (get-in db [:ptv :dialog :open?])
+    (let [ptv (:ptv db)
+          tab (:selected-tab ptv)]
+      (cond-> {:open? true}
+        (-> ptv :selected-org :name)
+        (assoc :org (-> ptv :selected-org :name))
+
+        tab
+        (assoc :tab (get assistant-tab-labels tab tab))
+
+        (= "wizard" tab)
+        (assoc :wizard-step (get assistant-wizard-step-labels
+                                 (:selected-step ptv 0)))))))
+
 (rf/reg-event-fx ::select-org
   (fn [{:keys [db]} [_ lipas-org]]
     {:db (-> db

--- a/webapp/src/cljs/lipas/ui/ptv/views.cljs
+++ b/webapp/src/cljs/lipas/ui/ptv/views.cljs
@@ -2201,7 +2201,10 @@
     [:> Dialog
      {:open open?
       :fullScreen true
-      :max-width "xl"}
+      :max-width "xl"
+      ;; The assistant panel lives outside this dialog's portal — without
+      ;; this the modal focus trap steals every keystroke from it.
+      :disableEnforceFocus true}
 
      [:> AppBar
       {:sx #js {:position "relative"}}

--- a/webapp/src/cljs/lipas/ui/search/events.cljs
+++ b/webapp/src/cljs/lipas/ui/search/events.cljs
@@ -468,6 +468,21 @@
                      {:db (update db :search merge defaults)
                       :dispatch [::filters-updated fit-view?]})))
 
+(rf/reg-event-fx ::replace-filters
+                 ;; Replace the whole search spec (string + filters) starting
+                 ;; from clean defaults and run a single search. Used by the
+                 ;; AI assistant's action buttons.
+                 (fn [{:keys [db]} [_ {:keys [search-text city-codes type-codes edit-permission?]}]]
+                   (let [defaults (-> (if (:logged-in? db) db/default-db-logged-in db/default-db)
+                                      (select-keys [:filters :sort :string]))
+                         spec (cond-> defaults
+                                search-text (assoc :string search-text)
+                                (seq city-codes) (assoc-in [:filters :city-codes] (set city-codes))
+                                (seq type-codes) (assoc-in [:filters :type-codes] (set type-codes))
+                                edit-permission? (assoc-in [:filters :edit-permission?] true))]
+                     {:db (update db :search merge spec)
+                      :dispatch [::filters-updated :fit-view]})))
+
 (rf/reg-event-fx ::create-report-from-current-search
                  (fn [{:keys [db]} [_ fmt]]
                    (let [params (-> db

--- a/webapp/src/cljs/lipas/ui/views.cljs
+++ b/webapp/src/cljs/lipas/ui/views.cljs
@@ -131,10 +131,12 @@
               [:> Typography {:variant "body2"}
                disclaimer]]]])])
 
-      ;; Help center dialog — global so ?ohje= deep links work on any route
-      [help/dialog]
-
       [mui/mui-theme-provider {:theme mui/jyu-theme-light}
+
+       ;; Help center dialog — global so ?ohje= deep links work on any
+       ;; route. Lives inside the light theme so it matches the rest of
+       ;; the app content.
+       [help/dialog]
 
        ;; Main panel
        (when view

--- a/webapp/src/cljs/lipas/ui/views.cljs
+++ b/webapp/src/cljs/lipas/ui/views.cljs
@@ -1,5 +1,6 @@
 (ns lipas.ui.views
-  (:require [lipas.ui.components.dialogs :as dialogs]
+  (:require [lipas.ui.assistant.views :as assistant]
+            [lipas.ui.components.dialogs :as dialogs]
             [lipas.ui.components.notifications :as notifications]
             [lipas.ui.events :as events]
             [lipas.ui.help.views :as help]
@@ -141,6 +142,9 @@
 
        ;; Reminders dialog
        [reminders/dialog]
+
+       ;; AI assistant launcher + panel (privilege-gated inside)
+       [assistant/view]
 
        ;; Global UI-blocking confirmation dialog
        (when confirmation

--- a/webapp/src/cljs/lipas/ui/views.cljs
+++ b/webapp/src/cljs/lipas/ui/views.cljs
@@ -2,6 +2,7 @@
   (:require [lipas.ui.components.dialogs :as dialogs]
             [lipas.ui.components.notifications :as notifications]
             [lipas.ui.events :as events]
+            [lipas.ui.help.views :as help]
             ["@mui/material/Button$default" :as Button]
             ["@mui/material/Card$default" :as Card]
             ["@mui/material/CardContent$default" :as CardContent]
@@ -128,6 +129,9 @@
              [:> CardContent
               [:> Typography {:variant "body2"}
                disclaimer]]]])])
+
+      ;; Help center dialog — global so ?ohje= deep links work on any route
+      [help/dialog]
 
       [mui/mui-theme-provider {:theme mui/jyu-theme-light}
 

--- a/webapp/test/clj/lipas/backend/assistant_test.clj
+++ b/webapp/test/clj/lipas/backend/assistant_test.clj
@@ -5,11 +5,28 @@
    not tested here — these are the deterministic parts around it."
   (:require [clojure.test :refer [deftest is testing]]
             [lipas.backend.assistant :as assistant]
-            [lipas.schema.assistant :as assistant-schema]))
+            [lipas.schema.assistant :as assistant-schema]
+            [malli.core :as m]))
 
 (def run-tool* #'assistant/run-tool*)
 (def describe-roles #'assistant/describe-roles)
 (def sanitize-answer-links #'assistant/sanitize-answer-links)
+
+(deftest context-schema-test
+  (testing "widget snapshot with an open PTV dialog validates"
+    (is (m/validate assistant/context-schema
+                    {:locale "fi"
+                     :route ":lipas.ui.routes.map/map"
+                     :view "PTV export dialog 'Vie Palvelutietovarantoon' (covers the map view)"
+                     :ptv {:open? true
+                           :org "Utajärven kunta"
+                           :tab "Käyttöönotto (ohjattu vienti PTV:hen)"
+                           :wizard-step "2. Luo PTV-palvelut"}})))
+  (testing "junk keys are refused — the map is closed at every level"
+    (is (not (m/validate assistant/context-schema
+                         {:ptv {:open? true :password "hunter2"}})))
+    (is (not (m/validate assistant/context-schema
+                         {:evil "payload"})))))
 
 (deftest describe-roles-test
   (testing "roles get official names and code→name resolved scopes"

--- a/webapp/test/clj/lipas/backend/assistant_test.clj
+++ b/webapp/test/clj/lipas/backend/assistant_test.clj
@@ -1,0 +1,148 @@
+(ns lipas.backend.assistant-test
+  "The UI-action layer of the assistant: the closed action vocabulary
+   (lipas.schema.assistant) and the tool handlers that resolve and
+   validate model output into client actions. The Gemini loop itself is
+   not tested here — these are the deterministic parts around it."
+  (:require [clojure.test :refer [deftest is testing]]
+            [lipas.backend.assistant :as assistant]
+            [lipas.schema.assistant :as assistant-schema]))
+
+(def run-tool* #'assistant/run-tool*)
+(def describe-roles #'assistant/describe-roles)
+(def sanitize-answer-links #'assistant/sanitize-answer-links)
+
+(deftest describe-roles-test
+  (testing "roles get official names and code→name resolved scopes"
+    (is (= [{:role "Kuntakäyttäjä (city-manager)"
+             :cities ["320 Kemijärvi"]}
+            {:role "Paikkakäyttäjä (site-manager)"
+             :sites [75100]}]
+           (describe-roles {:permissions {:roles [{:role "city-manager" :city-code #{320}}
+                                                  {:role :site-manager :lipas-id #{75100}}]}})))))
+
+(deftest sanitize-answer-links-test
+  (let [sources [{:deep-link "?ohje=tallentajille/kohteen-kopiointi"}]]
+    (testing "retrieved ?ohje= links survive"
+      (is (= "Katso [ohje](?ohje=tallentajille/kohteen-kopiointi)."
+             (sanitize-answer-links
+              "Katso [ohje](?ohje=tallentajille/kohteen-kopiointi)." sources))))
+    (testing "invented ?ohje= links degrade to plain text"
+      (is (= "Katso Käyttöoikeudet."
+             (sanitize-answer-links
+              "Katso [Käyttöoikeudet](?ohje=peruskasitteet/kayttooikeudet)." sources))))
+    (testing "fabricated tool-call schemes degrade to plain text"
+      (is (= "Avaa profiili"
+             (sanitize-answer-links "[Avaa profiili](navigate_to_view:profile)" sources))))
+    (testing "normal web and mail links survive"
+      (is (= "[video](https://youtu.be/x?t=10) ja [posti](mailto:a@b.fi)"
+             (sanitize-answer-links
+              "[video](https://youtu.be/x?t=10) ja [posti](mailto:a@b.fi)" sources))))))
+
+(deftest action-schema-test
+  (testing "valid actions"
+    (is (assistant-schema/valid? {:type "apply-search"
+                                  :label "Hae: uimahallit Äänekoski"
+                                  :city-codes [992]
+                                  :type-codes [3110]}))
+    (is (assistant-schema/valid? {:type "apply-search"
+                                  :label "Omat kohteet"
+                                  :only-editable true}))
+    (is (assistant-schema/valid? {:type "show-site"
+                                  :label "Näytä kartalla"
+                                  :lipas-id 75100}))
+    (is (assistant-schema/valid? {:type "pan-to-location"
+                                  :label "Siirry: Nallikari"
+                                  :location "Nallikari, Oulu"}))
+    (is (assistant-schema/valid? {:type "navigate-to-view"
+                                  :label "Avaa tilastot"
+                                  :view "stats-finance"})))
+
+  (testing "apply-search requires at least one filter"
+    (is (not (assistant-schema/valid? {:type "apply-search" :label "Hae"}))))
+
+  (testing "codes come from the canonical enums"
+    (is (not (assistant-schema/valid? {:type "apply-search" :label "Hae"
+                                       :city-codes [99999]})))
+    (is (not (assistant-schema/valid? {:type "show-site" :label "Näytä"
+                                       :lipas-id 0}))))
+
+  (testing "views are a closed set"
+    (is (not (assistant-schema/valid? {:type "navigate-to-view" :label "Avaa"
+                                       :view "admin"}))))
+
+  (testing "maps are closed — junk keys don't pass through to the widget"
+    (is (not (assistant-schema/valid? {:type "navigate-to-view" :label "Avaa"
+                                       :view "stats" :extra "smuggled"}))))
+
+  (testing "every view in the registry maps to a valid action"
+    (doseq [view (keys assistant-schema/views)]
+      (is (assistant-schema/valid? {:type "navigate-to-view" :label "x" :view view})
+          (str "view " view)))))
+
+(deftest apply-search-tool-test
+  (testing "city names resolve to city codes server-side"
+    (let [result (run-tool* {} "apply_search" {:label "Hae: Äänekoski"
+                                               :city-names ["Äänekoski"]})]
+      (is (= {:type "apply-search" :label "Hae: Äänekoski" :city-codes [992]}
+             (:client-action result)))))
+
+  (testing "unknown municipality is an error the model can act on, not an action"
+    (let [result (run-tool* {} "apply_search" {:label "Hae"
+                                               :city-names ["Ääneskoski"]})]
+      (is (nil? (:client-action result)))
+      (is (re-find #"Ääneskoski" (:error result)))))
+
+  (testing "unknown type codes are rejected with a hint"
+    (let [result (run-tool* {} "apply_search" {:label "Hae" :type-codes [9999]})]
+      (is (nil? (:client-action result)))
+      (is (re-find #"9999" (:error result)))))
+
+  (testing "only-editable produces a filterless editable search"
+    (is (= {:type "apply-search" :label "Omat kohteet" :only-editable true}
+           (:client-action (run-tool* {} "apply_search" {:label "Omat kohteet"
+                                                         :only-editable true}))))))
+
+(deftest navigation-tool-test
+  (testing "known view"
+    (is (= {:type "navigate-to-view" :label "Avaa tilastot" :view "stats"}
+           (:client-action (run-tool* {} "navigate_to_view" {:label "Avaa tilastot"
+                                                             :view "stats"})))))
+  (testing "unknown view is refused by the schema"
+    (is (some? (:error (run-tool* {} "navigate_to_view" {:label "Avaa"
+                                                         :view "adminland"}))))))
+
+(deftest empty-model-response-test
+  ;; Gemini sometimes treats a proposed button as the whole answer and
+  ;; returns no text in its final turn. Stubbing the one nondeterministic
+  ;; external call is the only way to pin this deterministically.
+  (testing "actions + empty final text → button-referencing text, not an apology"
+    (let [calls (atom 0)
+          fake (fn [_ _ _]
+                 (if (= 1 (swap! calls inc))
+                   {:candidates [{:content {:parts [{:functionCall
+                                                     {:name "apply_search"
+                                                      :args {:label "Hae Äänekosken liikuntapaikat"
+                                                             :city-names ["Äänekoski"]}}}]}}]}
+                   {:candidates [{:content {:parts []}}]}))
+          result (with-redefs-fn {(var assistant/gemini-chat) fake}
+                   #(assistant/answer! {:db nil :search nil :user {}
+                                        :message "test" :history [] :context {}}))]
+      (is (= "Voit jatkaa painamalla alla olevaa painiketta." (:answer-md result)))
+      (is (= [{:type "apply-search" :label "Hae Äänekosken liikuntapaikat" :city-codes [992]}]
+             (:actions result)))))
+
+  (testing "nothing at all → the apology"
+    (let [fake (fn [_ _ _] {:candidates [{:content {:parts []}}]})
+          result (with-redefs-fn {(var assistant/gemini-chat) fake}
+                   #(assistant/answer! {:db nil :search nil :user {}
+                                        :message "test" :history [] :context {}}))]
+      (is (re-find #"Pahoittelut" (:answer-md result)))
+      (is (empty? (:actions result))))))
+
+(deftest pan-tool-test
+  (is (= {:type "pan-to-location" :label "Siirry" :location "Äänekoski"}
+         (:client-action (run-tool* {} "pan_map_to_location" {:label "Siirry"
+                                                              :location "Äänekoski"}))))
+  (testing "too-short location is refused"
+    (is (some? (:error (run-tool* {} "pan_map_to_location" {:label "Siirry"
+                                                            :location "x"}))))))

--- a/webapp/test/clj/lipas/backend/assistant_test.clj
+++ b/webapp/test/clj/lipas/backend/assistant_test.clj
@@ -26,7 +26,23 @@
     (is (not (m/validate assistant/context-schema
                          {:ptv {:open? true :password "hunter2"}})))
     (is (not (m/validate assistant/context-schema
-                         {:evil "payload"})))))
+                         {:evil "payload"}))))
+  (testing "live map-editor state validates"
+    (is (m/validate assistant/context-schema
+                    {:locale "fi"
+                     :edit-mode? true
+                     :edit {:new-site? true
+                            :sub-mode "editing"
+                            :geometry-type "LineString"
+                            :segments 2
+                            :vertices 340
+                            :length-km 5.4
+                            :self-intersections 2
+                            :problem-locations [{:lon 25.701 :lat 62.241}]
+                            :invalid-fields ["location.address" "name"]}}))
+    (is (not (m/validate assistant/context-schema
+                         {:edit {:geoms {:type "FeatureCollection"}}}))
+        "raw geometries don't belong in the snapshot")))
 
 (deftest describe-roles-test
   (testing "roles get official names and code→name resolved scopes"
@@ -72,7 +88,18 @@
                                   :location "Nallikari, Oulu"}))
     (is (assistant-schema/valid? {:type "navigate-to-view"
                                   :label "Avaa tilastot"
-                                  :view "stats-finance"})))
+                                  :view "stats-finance"}))
+    (is (assistant-schema/valid? {:type "pan-to-coordinates"
+                                  :label "Näytä ongelmakohta 1"
+                                  :lon 25.701
+                                  :lat 62.241
+                                  :zoom 16})))
+
+  (testing "pan-to-coordinates is bounded to ~Finland"
+    (is (not (assistant-schema/valid? {:type "pan-to-coordinates" :label "x"
+                                       :lon 5.0 :lat 40.0})))
+    (is (not (assistant-schema/valid? {:type "pan-to-coordinates" :label "x"
+                                       :lon 25.0 :lat 62.0 :zoom 99}))))
 
   (testing "apply-search requires at least one filter"
     (is (not (assistant-schema/valid? {:type "apply-search" :label "Hae"}))))
@@ -163,3 +190,16 @@
   (testing "too-short location is refused"
     (is (some? (:error (run-tool* {} "pan_map_to_location" {:label "Siirry"
                                                             :location "x"}))))))
+
+(deftest zoom-to-coordinates-tool-test
+  (is (= {:type "pan-to-coordinates" :label "Näytä ongelmakohta 1"
+          :lon 25.701 :lat 62.241 :zoom 16}
+         (:client-action (run-tool* {} "zoom_map_to_coordinates"
+                                    {:label "Näytä ongelmakohta 1"
+                                     :lon 25.701 :lat 62.241 :zoom 16}))))
+  (testing "zoom is optional"
+    (is (some? (:client-action (run-tool* {} "zoom_map_to_coordinates"
+                                          {:label "Näytä" :lon 25.0 :lat 62.0})))))
+  (testing "coordinates outside Finland are refused — the model cannot pan the user into the void"
+    (is (some? (:error (run-tool* {} "zoom_map_to_coordinates"
+                                  {:label "x" :lon 5.0 :lat 40.0}))))))

--- a/webapp/test/clj/lipas/backend/gis_test.clj
+++ b/webapp/test/clj/lipas/backend/gis_test.clj
@@ -787,3 +787,67 @@
                                                  (* (- max-x min-x) (- max-y min-y)))
                                                chunks))
                                 1e-6)))))
+
+;;; Route geometry quality analysis ;;;
+
+(defn- route-fc [& lines]
+  {:type "FeatureCollection"
+   :features (mapv (fn [coords]
+                     {:type "Feature"
+                      :geometry {:type "LineString" :coordinates coords}})
+                   lines)})
+
+(deftest route-geometry-report-test
+  (testing "a clean route reports ok with sane totals"
+    (let [r (gis/route-geometry-report
+             (route-fc [[25.70 62.24] [25.701 62.241] [25.702 62.241] [25.703 62.242]]))]
+      (is (true? (:ok? r)))
+      (is (= 1 (:feature-count r)))
+      (is (= 4 (:vertex-count r)))
+      (is (< 0.2 (:length-km r) 0.5))
+      (is (false? (:needs-simplification? r)))))
+
+  (testing "a figure-eight crossing is found at the crossing point"
+    (let [r (gis/route-geometry-report
+             (route-fc [[25.70 62.24] [25.702 62.242] [25.702 62.24] [25.70 62.242]]))
+          locs (-> r :self-intersections :locations)]
+      (is (false? (:ok? r)))
+      (is (= 1 (count locs)))
+      (is (< 25.700 (:lon (first locs)) 25.702))
+      (is (< 62.240 (:lat (first locs)) 62.242))))
+
+  (testing "a closed loop (start = end) is legitimate, not a kink"
+    (is (true? (:ok? (gis/route-geometry-report
+                      (route-fc [[25.70 62.24] [25.701 62.241]
+                                 [25.702 62.24] [25.70 62.24]]))))))
+
+  (testing "consecutive vertices under a meter apart are duplicates"
+    (let [r (gis/route-geometry-report
+             (route-fc [[25.70 62.24] [25.70 62.24]
+                        [25.701 62.241] [25.7010000001 62.2410000001]
+                        [25.702 62.242]]))]
+      (is (= 2 (-> r :duplicate-vertices :count)))))
+
+  (testing "endpoints of different features that almost touch are gaps"
+    (let [r (gis/route-geometry-report
+             (route-fc [[25.70 62.24] [25.701 62.241]]
+                       [[25.70105 62.24105] [25.702 62.242]]))
+          gap (-> r :endpoint-gaps :locations first)]
+      (is (= 1 (-> r :endpoint-gaps :count)))
+      (is (= [0 1] (:features gap)))
+      (is (<= 1 (:distance-m gap) 25))))
+
+  (testing "GPS-density tracks are flagged for simplification"
+    (let [step 0.00005 ; ~2.7m between vertices ≈ 370/km
+          coords (mapv (fn [i] [(+ 25.70 (* i step)) 62.24]) (range 400))
+          r (gis/route-geometry-report (route-fc coords))]
+      (is (true? (:needs-simplification? r)))
+      (is (true? (:ok? r)))))
+
+  (testing "point geometries yield an empty but well-formed report"
+    (let [r (gis/route-geometry-report
+             {:type "FeatureCollection"
+              :features [{:type "Feature"
+                          :geometry {:type "Point" :coordinates [25.70 62.24]}}]})]
+      (is (zero? (:feature-count r)))
+      (is (true? (:ok? r))))))

--- a/webapp/test/clj/lipas/backend/help_test.clj
+++ b/webapp/test/clj/lipas/backend/help_test.clj
@@ -1,0 +1,101 @@
+(ns lipas.backend.help-test
+  "Pure-function tests for the help v1→v2 migration transform and the
+   KB doc builder that consumes v2 trees."
+  (:require [clojure.test :refer [deftest is testing]]
+            [lipas.backend.help :as help]
+            [lipas.backend.kb :as kb]
+            [lipas.schema.help :as help-schema]
+            [lipas.utils :as utils]
+            [malli.core :as m]))
+
+(def v1-fixture
+  "Shape of prod v1 data: shared structure, {:fi :se :en} leaves,
+   placeholder junk in untranslated locales, timestamp slugs."
+  [{:slug :new-section-1745834399585
+    :title {:fi "Työkaluja monialaiseen liikuntasuunnitteluun"
+            :se "Ny sektion"
+            :en "New Section"}
+    :pages [{:slug :new-page-1
+             :title {:fi "Pistemäisen liikuntapaikan lisääminen ja muokkaaminen"
+                     :se "Ny sida"
+                     :en "New Page"}
+             :blocks [{:block-id "7e97f983-5da6-410c-a080-8f652a75330b"
+                       :type :pdf
+                       :url "https://example.com/a.pdf"
+                       :title {:fi "Ohje" :se "" :en ""}
+                       :caption {:fi "" :se "" :en ""}}
+                      {:block-id "67c45c1e-9e68-457d-b9d4-c07c5ba04fb5"
+                       :type :video
+                       :provider :youtube
+                       :video-id "cDaGW3EOrsI"
+                       :title {:fi "Video-ohje" :se "" :en ""}}
+                      {:block-id "2437b8b8-3379-4710-89c6-fd336f0989b3"
+                       :type :text
+                       :content {:fi "Sisältöä." :se "" :en ""}}]}
+            {:slug :welcome
+             :title {:fi "Toinen sivu" :se "Välkommen" :en "Welcome"}
+             :blocks [{:block-id "51a966a0-8874-4853-8ef7-644f072e534d"
+                       :type :type-code-explorer}]}]}
+   {:slug :general
+    ;; identical fi titles → slug collision must be resolved
+    :title {:fi "Työkaluja monialaiseen liikuntasuunnitteluun" :se "" :en ""}
+    :pages []}])
+
+(deftest ->slug-test
+  (is (= "pistemaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+         (utils/->slug "Pistemäisen liikuntapaikan lisääminen ja muokkaaminen")))
+  (is (= "tyokaluja-ylli-hankkeen-tuloksia"
+         (utils/->slug "Työkaluja (YLLI-hankkeen tuloksia)")))
+  (is (= "" (utils/->slug nil)))
+  (is (= "" (utils/->slug "!!!"))))
+
+(deftest v1->v2-tree-test
+  (let [tree (help/v1->v2-tree v1-fixture :fi)]
+    (testing "validates against the v2 schema"
+      (is (m/validate help-schema/LocaleTree tree)))
+
+    (testing "slugs regenerated from fi titles, old slugs kept as aliases"
+      (is (= "tyokaluja-monialaiseen-liikuntasuunnitteluun"
+             (-> tree first :slug)))
+      (is (= ["new-section-1745834399585"] (-> tree first :aliases)))
+      (is (= "pistemaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+             (-> tree first :pages first :slug))))
+
+    (testing "slug collisions get a numeric suffix"
+      (is (= "tyokaluja-monialaiseen-liikuntasuunnitteluun-2"
+             (-> tree second :slug))))
+
+    (testing "localized leaves collapse to plain strings"
+      (is (= "Ohje" (-> tree first :pages first :blocks first :title)))
+      (is (= "Sisältöä." (-> tree first :pages first :blocks (nth 2) :content))))
+
+    (testing "every node gets a stable id"
+      (is (every? some? (map :id tree)))
+      (is (every? some? (mapcat #(map :id (:pages %)) tree))))
+
+    (testing "se tree drops fi-only text but keeps structure decisions to editors"
+      (let [se-tree (help/v1->v2-tree v1-fixture :se)]
+        ;; text block with blank se content is dropped; media blocks stay
+        (is (= [:pdf :video] (->> se-tree first :pages first :blocks (map :type))))))))
+
+(deftest help-cms->docs-test
+  (let [fi-tree (help/v1->v2-tree v1-fixture :fi)
+        docs (kb/help-cms->docs {:fi fi-tree :se [] :en []})]
+    (testing "one doc per page with real text content, fi only"
+      (is (= #{"fi"} (set (map :lang docs))))
+      ;; page 2 has only a type-code-explorer block → no body → skipped;
+      ;; empty section produces nothing
+      (is (= 1 (count docs))))
+
+    (testing "doc carries canonical deep link"
+      (let [doc (first docs)]
+        (is (= "tyokaluja-monialaiseen-liikuntasuunnitteluun/pistemaisen-liikuntapaikan-lisaaminen-ja-muokkaaminen"
+               (:source-ref doc)))
+        (is (= (str "?ohje=" (:source-ref doc)) (:deep-link doc)))
+        (is (re-find #"Video-ohje" (:body doc)))
+        (is (re-find #"PDF: Ohje" (:body doc)))))
+
+    (testing "bare media URLs never leak into languages without titles"
+      (is (empty? (kb/help-cms->docs
+                   {:fi [] :se (help/v1->v2-tree v1-fixture :se) :en []}
+                   ))))))

--- a/webapp/test/clj/lipas/jobs/scheduler_test.clj
+++ b/webapp/test/clj/lipas/jobs/scheduler_test.clj
@@ -83,10 +83,13 @@
 
         (testing "Scheduler tasks do not enqueue maintenance jobs"
           ;; The old design routed reminder checks and cleanup through the
-          ;; queue as job rows; the new design calls them directly
+          ;; queue as job rows; the new design calls them directly. Real
+          ;; work still becomes jobs: the nightly KB sync enqueues exactly
+          ;; one (deduplicated) help-kb-sync job on its startup tick.
           (Thread/sleep 500)
-          (is (empty? (test-utils/get-all-jobs db))
-              "No queue churn from scheduler ticks"))
+          (let [jobs (test-utils/get-all-jobs db)]
+            (is (= ["help-kb-sync"] (mapv :jobs/type jobs))
+                "No queue churn from scheduler ticks beyond the KB sync")))
 
         (finally
           (scheduler/stop-scheduler!)))

--- a/webapp/test/clj/lipas/test_utils.clj
+++ b/webapp/test/clj/lipas/test_utils.clj
@@ -492,16 +492,18 @@
                 (assoc-in [:search :create-indices] false)
                 (update-in [:db :dbname] test-suffix)
                 (assoc-in [:db :dev] true) ;; No connection pool
-                (update-in [:search :indices :sports-site :search] test-suffix)
-                (update-in [:search :indices :sports-site :analytics] test-suffix)
-                (update-in [:search :indices :report :subsidies] test-suffix)
-                (update-in [:search :indices :report :city-stats] test-suffix)
-                (update-in [:search :indices :analysis :schools] test-suffix)
-                (update-in [:search :indices :analysis :population] test-suffix)
-                (update-in [:search :indices :analysis :population-high-def] test-suffix)
-                (update-in [:search :indices :analysis :diversity] test-suffix)
-                (update-in [:search :indices :lois :search] test-suffix)
-                (update-in [:search :indices :legacy-sports-site :search] test-suffix)))
+                ;; Suffix EVERY configured index, whatever gets added later.
+                ;; prune-es! empties all indices in the test system's config
+                ;; between tests — an unsuffixed entry here means tests wipe
+                ;; the real dev index (this happened with lipas_kb_v1).
+                (update-in [:search :indices]
+                           (fn [indices]
+                             (into {}
+                                   (map (fn [[group m]]
+                                          [group (into {}
+                                                       (map (fn [[k v]] [k (test-suffix v)]))
+                                                       m)]))
+                                   indices)))))
 
 ;; Enhanced database initialization with migration status checking
 (defn init-db!


### PR DESCRIPTION
## What & why

Adds a context-aware AI help assistant for registered LIPAS users: a floating chat widget on every route, answering from a grounded knowledge base rather than the model's own world knowledge. It ships alongside a full rewrite of the built-in help center (v2), since the help CMS is the KB's canonical content source — the two features share a data model and shipped together.

> **Silent release**: the assistant is gated behind a new `:ai-assistant/use` privilege, currently granted to admins only (`lipas.roles`). GA is a one-line change (add the privilege to `roles/basic`) once content coverage and eval numbers are where we want them.

## Highlights

**Knowledge base** (`lipas.backend.kb`) — a hybrid-search (BM25 + kNN, client-side RRF) Elasticsearch index built from three sources: published help-CMS content, code-derived docs (sports-site types, prop-types, roles — including colloquial `:tags`), and a one-off ingestion of JYU PDFs and Lipasinfo YouTube transcripts (with a Gemini video-transcript fallback for the 9 caption-less videos). `kb/sync!` is a deterministic function of Postgres + code: hash-diffs content, embeds only what changed, deletes orphans (~20s full rebuild, ~2s no-op). Eval harness (`dev/lipas/kb_eval.clj`, 41 golden questions) currently at hybrid 40/41 hit@3.

**Assistant agent** (`lipas.backend.assistant`) — a Gemini function-calling loop, first turn forced to call a tool so answers are always grounded. Tools cover KB search/fetch, type/field lookups, site-maintenance queries, and a permission check whose verdict comes from the real `roles/check-privilege` engine, never LLM reasoning. Escalation to human support (Lipasinfo) is two-phase: the agent drafts, the UI shows a confirmation card, and only an explicit user click sends the email. Per-user rate limits (30 chat/h, 5 escalations/day).

**UI actions, propose-only** (`lipas.schema.assistant`) — the model can't dispatch re-frame events directly. It calls one of 4 closed-vocabulary action tools (search, show-site, pan-to-location, navigate-to-view); the backend validates against a canonical Malli schema (real city/type/lipas-id enums, site existence checked); the frontend renders a button; only a user click executes it. Blocked during unsaved map edits.

**Answer safety** — names are always resolved server-side and injected into tool results/prompts (the model invents wrong city names from bare codes otherwise); `?ohje=` links in answers are allow-listed against this conversation's actual retrievals, not just any-looking-valid slug (the model fabricated links in testing).

**Help center v2** — per-locale (fi/se/en) independent content trees (sections → pages → blocks), replacing v1's shared structure whose untranslated slots had accumulated placeholder junk that leaked into both the UI and the KB. Stable IDs + slugs with alias history so old `?ohje=` links and citations keep resolving. Docs-site read view (tree sidebar, nav search, mobile drawer, fi-fallback banner), draft/publish/version-history editor per locale. `lipas.backend.help/migrate-v1->v2!` is a one-shot, idempotent migration (run once per environment).

**`lipas.backend.llm`** — generic LLM plumbing (provider registry, `complete`/`gemini-complete` with retry + OpenAI fallback, Gemini embeddings) extracted out of `lipas.backend.ptv.ai`, which now wraps it with PTV-specific schema defaults. Shared by the assistant and PTV AI features.

## Notable decisions & gotchas

- **Grounding discipline over recall**: KB snippets are truncated, so the agent must fetch the full document before answering how-tos; the prompt explicitly forbids inventing steps/UI details; no coverage → offer escalation, don't fall back to general knowledge.
- **Context adaptation is omission-only**: the assistant knows the user is logged in and what page/site they're on, and skips already-satisfied steps — but never adds anything not backed by a source.
- **Ingestion is a migration, not a mirror**: ingested content lands in `versioned_data` with `review-status "machine"` until a human reviews it; a separate grounding verifier rejected unsupported claims at ingest time (2/89 rejected).
- **Test fixture footgun (fixed here)**: `test-utils` used to suffix ES indices from a hardcoded list; a new `:kb` index wasn't on it, so `prune-es!` was silently wiping the real dev KB between test runs. It now walks the full configured index map — never go back to a list.
- **REPL gotcha**: `(user/reset)` occasionally hits a `clj-reload`/`integrant.repl` arity bug in this environment — `(integrant.repl/halt)` + `(integrant.repl/go)` recovers. Documented in `docs/wip/ai-assistant-implementation.md`.

## Testing

Backend: `lipas.backend.assistant-test` (action-schema validation + tool handlers), `lipas.backend.help-test`. KB retrieval eval via `dev/lipas/kb_eval.clj`. Manually verified in-browser end-to-end: grounded how-to answers with citations (including `&t=` video timestamps), context adaptation, type-code disambiguation, out-of-scope refusal, stale-sites listing, two-turn escalation, chat logging, and UI actions via Playwright (search+map-fit, view navigation, edit-mode action gating).

## Follow-ups (out of scope)

- GA privilege flip (`:ai-assistant/use` → `roles/basic`) once coverage/eval numbers clear the bar.
- Real help-center content authoring by Lipasinfo — current CMS content is a small dev seed, not production copy.
- The one persistent eval miss ("paikka missä voi heittää koreja" → type 1310) is a pre-existing RRF-merge ranking issue, not a regression — prompt-iteration backlog.
