### PR TITLE
perf(infra): brotli compression for static bundles and API responses

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -175,6 +175,7 @@ jobs:
           docker compose run --rm backend-build
           docker compose run --rm frontend-npm-deps
           docker compose run --rm frontend-build
+          docker compose run --rm frontend-precompress
 
       - name: Run database migrations
         working-directory: /var/lipas
@@ -192,7 +193,17 @@ jobs:
           source /var/lipas/.env.sh
           docker compose rm -sf backend worker
           docker compose up -d backend worker
-          docker compose restart proxy
+          # The proxy must be recreated after the backend so nginx re-resolves
+          # the new backend container IP. --build picks up nginx/Dockerfile
+          # changes (brotli modules ship in the image) and is a cached no-op
+          # otherwise. Hosts run different proxy variants, so detect the
+          # running one instead of hardcoding a service name.
+          PROXY_SVC=$(docker compose ps --services | grep -E '^proxy(-dev|-local)?$' || true)
+          if [ -n "$PROXY_SVC" ]; then
+            docker compose up -d --no-deps --build --force-recreate "$PROXY_SVC"
+          else
+            echo "No running proxy service found; skipping proxy restart"
+          fi
           echo "Deployed $(git -C /var/lipas rev-parse --short HEAD)"
 
       - name: Re-index Elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
 
   proxy-base:
-    image: nginx:stable
+    # Stock nginx + ngx_brotli dynamic modules (see nginx/Dockerfile).
+    # Built on each host, not pulled: docker compose build proxy|proxy-dev|proxy-local
+    build: ./nginx
+    image: lipas/proxy
     environment:
       DIGITRANSIT_SUBSCRIPTION_KEY:
     ports:
@@ -314,6 +317,13 @@ services:
     extends:
       service: node-base
     command: npm install --quiet
+
+  # Writes .br/.gz siblings next to the release bundles for nginx
+  # brotli_static/gzip_static. Run after frontend-build.
+  frontend-precompress:
+    extends:
+      service: node-base
+    command: node scripts/precompress.mjs
 
   frontend-build:
     extends:

--- a/docs/wip/brotli-compression.md
+++ b/docs/wip/brotli-compression.md
@@ -1,0 +1,93 @@
+# Brotli compression (static precompression + in-flight)
+
+Branch: `feat/brotli-compression`. Follow-up to the bundle-splitting work
+(PR #215): switch transfer compression from gzip-only to brotli-first with
+gzip fallback.
+
+## Measured impact
+
+Baseline was nginx on-the-fly `gzip_comp_level 6` for everything (including
+recompressing the immutable hashed bundles on every request; no
+`gzip_static`).
+
+Static JS, latest release build (13 modules):
+
+| payload                          | gzip -6 (old) | brotli -q11 | delta  |
+|----------------------------------|---------------|-------------|--------|
+| initial load (app + map + geo)   | 1 244 KB      | 987 KB      | −21 %  |
+| all 13 modules                   | 1 784 KB      | 1 424 KB    | −20 %  |
+
+Dynamic JSON (real `/api/actions/search` response, 500 sites, 3.1 MB raw):
+
+| codec        | size    | CPU/request |
+|--------------|---------|-------------|
+| gzip -6 (old)| 713 KB  | 66 ms       |
+| brotli -q5   | 397 KB  | 32 ms       |
+| brotli -q11  | 279 KB  | 1.9 s (precompression only, never in-flight) |
+
+The JSON/transit win (−44 %) is bigger than the JS win because the search
+responses are full of repeated keys and brotli's window (up to 4 MB) sees all
+of it, unlike gzip's 32 KB. In-flight brotli q5 also costs *half* the CPU of
+the gzip -6 it replaces. Precompressing the whole module set at q11 takes
+~8 s at build time.
+
+## How it works
+
+- **`nginx/Dockerfile`** (new): two-stage build compiling google/ngx_brotli
+  as dynamic modules against the exact `nginx:stable` of the base image.
+  `proxy-base` in docker-compose now uses `build: ./nginx` /
+  `image: lipas/proxy`; the image is built on each host, never pulled.
+- **`nginx/nginx.conf`**: `load_module` for the two brotli modules. This
+  config no longer starts on a stock nginx image — image and config must
+  move together.
+- **`nginx/proxy*.conf`**: `brotli on; brotli_comp_level 5;` +
+  `brotli_types` mirroring the gzip block in every server block, and
+  `brotli_static on; gzip_static on;` in the SPA-serving blocks. Clients
+  without `Accept-Encoding: br` keep getting gzip; nothing breaks for old
+  API consumers.
+- **`webapp/scripts/precompress.mjs`** (new): after a release build, writes
+  `.br` (q11) and `.gz` (-9) siblings next to every content-hashed bundle
+  listed in manifest.edn. Node built-ins only. Dev builds are exempt by
+  design: unhashed `app.js` never gets a sibling, because `brotli_static`
+  prefers the sibling without mtime comparison and a stale `app.js.br`
+  would shadow fresh dev code.
+
+## Deploy paths (both covered)
+
+1. **Manual (`webapp/bb.edn`)**: `npm run build` now runs precompress;
+   `-do-deploy` uploads *all* module bundles + `.br`/`.gz` siblings (this
+   also fixes a gap where only the `:app` bundle was scp'd — lazy modules
+   were missing from manual frontend deploys after code splitting). The
+   remote install/restart now runs as a script over ssh stdin, and the
+   proxy is recreated with `up -d --no-deps --build --force-recreate`
+   against whichever proxy variant the host is running.
+2. **Automated (deploy-dev.yml)**: new `frontend-precompress` compose run
+   after `frontend-build`; proxy restart replaced with the same
+   detect + `up --build --force-recreate` logic.
+
+`--force-recreate` preserves the old `restart proxy` semantics: nginx caches
+the backend container IP, so the proxy must bounce whenever backend/worker
+are recreated.
+
+## Rollout notes
+
+- First deploy per host compiles ngx_brotli (~1–3 min, then cached). Both
+  deploy paths run `docker compose up -d --build` for the proxy, so no
+  manual host prep is needed — but the *first* proxy restart after merging
+  must go through a deploy (or a manual `docker compose build proxy` +
+  `up -d proxy`), never a bare `docker compose restart proxy` with the old
+  image, which would fail on the new `load_module` lines.
+- Local dev: `docker compose build proxy-local` once, then
+  `docker compose up -d --force-recreate --no-deps proxy-local`.
+- Rollback = revert the branch and `docker compose up -d --no-deps --build
+  --force-recreate <proxy-svc>` — compose rebuilds from the reverted config
+  (plain nginx:stable, no load_module).
+
+## Verification (local, release build + real backend)
+
+- `app.<hash>.js` with `Accept-Encoding: br` → `Content-Encoding: br`,
+  byte size identical to the on-disk `.br` (brotli_static serving, not
+  recompression); with `gzip` → `.gz` file served; correct
+  `Content-Type`, `Cache-Control: immutable`, `Vary: Accept-Encoding`.
+- `POST /api/actions/search` with `br` → in-flight brotli (~q5 size);
+  with `gzip` → gzip as before.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,42 @@
+# nginx + ngx_brotli dynamic modules.
+#
+# The official nginx image ships no brotli support and nginx.org provides no
+# prebuilt package for it, so we compile google/ngx_brotli as dynamic modules
+# in a throwaway build stage and copy the two .so files into an otherwise
+# stock image. Both stages use the same base tag, so the modules are always
+# built against the exact nginx version they get loaded into (--with-compat
+# guarantees binary compatibility).
+#
+# nginx.conf loads the modules; the brotli/brotli_static directives live in
+# the proxy*.conf server blocks. Rebuild with: docker compose build proxy
+# (or proxy-dev / proxy-local — all three share this image).
+
+FROM nginx:stable AS builder
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates cmake gcc git libc6-dev libpcre2-dev make wget zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
+      https://github.com/google/ngx_brotli /usr/src/ngx_brotli
+
+# Prebuild the bundled brotli library (static) for the module to link against
+RUN cd /usr/src/ngx_brotli/deps/brotli \
+ && mkdir out && cd out \
+ && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. \
+ && cmake --build . --config Release --target brotlienc
+
+# NGINX_VERSION comes from the base image, so the module source always
+# matches the binary that will load it
+RUN wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -O- \
+      | tar -xz -C /usr/src \
+ && cd "/usr/src/nginx-${NGINX_VERSION}" \
+ && ./configure --with-compat --add-dynamic-module=/usr/src/ngx_brotli \
+ && make modules
+
+FROM nginx:stable
+
+COPY --from=builder /usr/src/nginx-*/objs/ngx_http_brotli_filter_module.so \
+                    /usr/src/nginx-*/objs/ngx_http_brotli_static_module.so \
+                    /usr/lib/nginx/modules/

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,12 @@
 user             nginx;
 worker_processes 1;
 
+# Brotli modules are not part of stock nginx — they ship in the custom image
+# built from nginx/Dockerfile. Loading them here means this config only works
+# with that image (lipas/proxy), never with plain nginx:stable.
+load_module modules/ngx_http_brotli_filter_module.so;
+load_module modules/ngx_http_brotli_static_module.so;
+
 error_log        /var/log/nginx/error.log warn;
 pid              /var/run/nginx.pid;
 

--- a/nginx/proxy.conf
+++ b/nginx/proxy.conf
@@ -48,12 +48,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # Serve build-time precompressed .br/.gz siblings of the js bundles
   # (written by webapp/scripts/precompress.mjs) instead of recompressing
@@ -226,12 +226,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # Route /api/* to backend /v1/* (legacy API now in main backend)
   location ~ ^/api/(.*)$ {
@@ -289,12 +289,12 @@ server {
     gzip_http_version 1.0;
     gzip_comp_level 6;
     gzip_min_length 1024;
-    gzip_types application/javascript application/json application/transit+json;
+    gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
     brotli on;
     brotli_comp_level 5;
     brotli_min_length 1024;
-    brotli_types application/javascript application/json application/transit+json;
+    brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
     # Route v1 requests to backend (legacy API now in main backend)
     location /v1/ {

--- a/nginx/proxy.conf
+++ b/nginx/proxy.conf
@@ -50,6 +50,17 @@ server {
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
 
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
+
+  # Serve build-time precompressed .br/.gz siblings of the js bundles
+  # (written by webapp/scripts/precompress.mjs) instead of recompressing
+  # the immutable files on every request.
+  brotli_static on;
+  gzip_static on;
+
   if ($host = "liikuntapaikat.fi") {
     return 301 https://liikuntapaikat.lipas.fi$request_uri;
   }
@@ -217,6 +228,11 @@ server {
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
 
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
+
   # Route /api/* to backend /v1/* (legacy API now in main backend)
   location ~ ^/api/(.*)$ {
     proxy_set_header X-Forwarded-Prefix /api;
@@ -274,6 +290,11 @@ server {
     gzip_comp_level 6;
     gzip_min_length 1024;
     gzip_types application/javascript application/json application/transit+json;
+
+    brotli on;
+    brotli_comp_level 5;
+    brotli_min_length 1024;
+    brotli_types application/javascript application/json application/transit+json;
 
     # Route v1 requests to backend (legacy API now in main backend)
     location /v1/ {

--- a/nginx/proxy_dev.conf
+++ b/nginx/proxy_dev.conf
@@ -53,6 +53,17 @@ server {
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
 
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
+
+  # Serve build-time precompressed .br/.gz siblings of the js bundles
+  # (written by webapp/scripts/precompress.mjs) instead of recompressing
+  # the immutable files on every request.
+  brotli_static on;
+  gzip_static on;
+
   if ($host = "liikuntapaikat.fi") {
     return 301 https://liikuntapaikat.lipas.fi$request_uri;
   }
@@ -161,6 +172,11 @@ server {
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
 
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
+
   # Route /api/* to backend /v1/* (legacy API now in main backend)
   location ~ ^/api/(.*)$ {
     proxy_set_header X-Forwarded-Prefix /api;
@@ -211,6 +227,11 @@ server {
     gzip_comp_level 6;
     gzip_min_length 1024;
     gzip_types application/javascript application/json application/transit+json;
+
+    brotli on;
+    brotli_comp_level 5;
+    brotli_min_length 1024;
+    brotli_types application/javascript application/json application/transit+json;
 
     # Route v1 requests to backend (legacy API now in main backend)
     location /v1/ {

--- a/nginx/proxy_dev.conf
+++ b/nginx/proxy_dev.conf
@@ -51,12 +51,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # Serve build-time precompressed .br/.gz siblings of the js bundles
   # (written by webapp/scripts/precompress.mjs) instead of recompressing
@@ -170,12 +170,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # Route /api/* to backend /v1/* (legacy API now in main backend)
   location ~ ^/api/(.*)$ {
@@ -226,12 +226,12 @@ server {
     gzip_http_version 1.0;
     gzip_comp_level 6;
     gzip_min_length 1024;
-    gzip_types application/javascript application/json application/transit+json;
+    gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
     brotli on;
     brotli_comp_level 5;
     brotli_min_length 1024;
-    brotli_types application/javascript application/json application/transit+json;
+    brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
     # Route v1 requests to backend (legacy API now in main backend)
     location /v1/ {

--- a/nginx/proxy_local.conf
+++ b/nginx/proxy_local.conf
@@ -41,6 +41,18 @@ server {
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
 
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
+
+  # Serve build-time precompressed .br/.gz siblings of the js bundles
+  # (written by webapp/scripts/precompress.mjs) instead of recompressing
+  # the immutable files on every request. Dev builds produce unhashed
+  # app.js with no siblings, so this is inert in watch-mode development.
+  brotli_static on;
+  gzip_static on;
+
   if ($host = "liikuntapaikat.fi") {
     return 301 https://liikuntapaikat.lipas.fi$request_uri;
   }
@@ -172,6 +184,11 @@ server {
   gzip_comp_level 6;
   gzip_min_length 1024;
   gzip_types application/javascript application/json application/transit+json;
+
+  brotli on;
+  brotli_comp_level 5;
+  brotli_min_length 1024;
+  brotli_types application/javascript application/json application/transit+json;
 
   # FIXME: Now the path prefix has to be same as in the Reitit tree
   location /api-v2/ {

--- a/nginx/proxy_local.conf
+++ b/nginx/proxy_local.conf
@@ -39,12 +39,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # Serve build-time precompressed .br/.gz siblings of the js bundles
   # (written by webapp/scripts/precompress.mjs) instead of recompressing
@@ -183,12 +183,12 @@ server {
   gzip_http_version 1.0;
   gzip_comp_level 6;
   gzip_min_length 1024;
-  gzip_types application/javascript application/json application/transit+json;
+  gzip_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   brotli on;
   brotli_comp_level 5;
   brotli_min_length 1024;
-  brotli_types application/javascript application/json application/transit+json;
+  brotli_types application/javascript application/json application/transit+json text/css image/svg+xml;
 
   # FIXME: Now the path prefix has to be same as in the Reitit tree
   location /api-v2/ {

--- a/webapp/bb.edn
+++ b/webapp/bb.edn
@@ -16,11 +16,11 @@
                     :urls {:dev "https://lipas-dev.cc.jyu.fi"
                            :prod "https://lipas.fi"}})
 
-                 (defn frontend-bundle-name
+                 (defn frontend-module-files
                    "Reads manifest.edn (written by shadow-cljs on every build) and
-                    returns the resolved :app bundle filename — e.g. \"app.0EA395B3.js\"
-                    in release mode, \"app.js\" in dev. Exits with an error message if
-                    the manifest is missing or malformed."
+                    returns all module bundle filenames — with code splitting the
+                    lazy modules must reach the server too, not just :app. Exits
+                    with an error message if the manifest is missing or empty."
                    []
                    (let [path (get-in deploy-config [:paths :frontend-manifest])
                          f    (java.io.File. path)]
@@ -28,11 +28,11 @@
                        (println (str "❌ Frontend manifest not found at " path
                                      " — did the build run?"))
                        (System/exit 1))
-                     (let [manifest (edn/read-string (slurp f))
-                           app-mod  (first (filter (fn [m] (= :app (:module-id m))) manifest))]
-                       (or (:output-name app-mod)
-                           (do (println "❌ No :app module found in manifest.edn")
-                               (System/exit 1)))))))
+                     (let [names (mapv :output-name (edn/read-string (slurp f)))]
+                       (when (empty? names)
+                         (println "❌ No modules found in manifest.edn")
+                         (System/exit 1))
+                       names))))
 
          cljs-watch {:task (shell "npm run watch")}
          bundle-size-check
@@ -140,17 +140,34 @@
                                (println "🏗️  Building frontend release bundle...")
                                (shell "npm run build"))
 
-                             ;; Resolve hashed bundle name from manifest.edn (post-build)
-                             (let [bundle        (when deploy-frontend? (frontend-bundle-name))
+                             ;; Resolve module bundles from manifest.edn (post-build)
+                             (let [modules       (when deploy-frontend? (frontend-module-files))
                                    compiled-dir  (get-in deploy-config [:paths :frontend-compiled-dir])
-                                   bundle-local  (when bundle (str compiled-dir "/" bundle))
                                    index-local   (get-in deploy-config [:paths :frontend-index])
-                                   remote-public (get-in deploy-config [:paths :remote-public])]
+                                   remote-public (get-in deploy-config [:paths :remote-public])
+                                   ;; Each bundle plus its precompressed .br/.gz siblings
+                                   ;; (written by scripts/precompress.mjs during npm run build).
+                                   ;; nginx falls back to on-the-fly compression when a sibling
+                                   ;; is missing, so warn but proceed.
+                                   frontend-files
+                                   (when deploy-frontend?
+                                     (vec (mapcat
+                                            (fn [m]
+                                              (let [f (str compiled-dir "/" m)]
+                                                (when-not (.exists (java.io.File. f))
+                                                  (println (str "❌ Frontend bundle not found at " f))
+                                                  (System/exit 1))
+                                                (into [f]
+                                                      (for [ext [".br" ".gz"]
+                                                            :let [c (str f ext)]
+                                                            :when (if (.exists (java.io.File. c))
+                                                                    true
+                                                                    (do (println (str "⚠️  " c " missing — nginx will compress on the fly"))
+                                                                        false))]
+                                                        c))))
+                                            modules)))]
 
                                (when deploy-frontend?
-                                 (when-not (.exists (java.io.File. bundle-local))
-                                   (println (str "❌ Frontend bundle not found at " bundle-local))
-                                   (System/exit 1))
                                  (when-not (.exists (java.io.File. index-local))
                                    (println (str "❌ Frontend index.html not found at " index-local
                                                  " — build hook should have rendered it"))
@@ -161,25 +178,44 @@
                                (when deploy-backend?
                                  (shell (str "scp " (get-in deploy-config [:paths :backend-jar]) " " host ":/tmp/")))
                                (when deploy-frontend?
-                                 ;; Upload both the hashed JS bundle and the rendered index.html.
-                                 ;; Bundle filename is content-addressed so it never collides with
-                                 ;; previous deploys; index.html is rewritten in place.
-                                 (shell (str "scp " bundle-local " " index-local " " host ":/tmp/")))
+                                 ;; Upload every module bundle (+ compressed siblings) and the
+                                 ;; rendered index.html. Bundle filenames are content-addressed
+                                 ;; so they never collide with previous deploys; index.html is
+                                 ;; rewritten in place.
+                                 (shell (str "scp " (str/join " " frontend-files) " " index-local " " host ":/tmp/")))
 
-                               ;; Deploy files and restart if needed
+                               ;; Deploy files and restart if needed. The script runs remotely
+                               ;; as root via stdin, which avoids nested ssh/sudo quoting.
                                (println (str "🔄 Deploying " type-str " on " host "..."))
-                               (let [backend-commands (when deploy-backend?
-                                                        (str "sudo cp /tmp/backend.jar " (get-in deploy-config [:paths :remote-backend])))
-                                     ;; Order matters: install the new bundle BEFORE rewriting index.html
-                                     ;; so users never see an index.html that points to a missing bundle.
-                                     frontend-commands (when deploy-frontend?
-                                                         (str "sudo cp /tmp/" bundle " " remote-public "/js/compiled/" bundle
-                                                              " && sudo cp /tmp/index.html " remote-public "/index.html"))
-                                     restart-commands (when deploy-backend?
-                                                        "sudo bash -c \"source /var/lipas/.env.sh && docker compose -f /var/lipas/docker-compose.yml rm -sf backend worker && docker compose -f /var/lipas/docker-compose.yml up -d backend worker && docker compose -f /var/lipas/docker-compose.yml restart proxy\"")
-                                     all-commands (str/join " && " (filter some? [backend-commands frontend-commands restart-commands]))]
+                               (let [basename (fn [p] (.getName (java.io.File. p)))
+                                     script
+                                     (str "set -eo pipefail\n"
+                                          (when deploy-backend?
+                                            (str "cp /tmp/backend.jar " (get-in deploy-config [:paths :remote-backend]) "\n"))
+                                          ;; Order matters: install the new bundles BEFORE rewriting
+                                          ;; index.html so users never see an index.html that points
+                                          ;; to a missing bundle.
+                                          (when deploy-frontend?
+                                            (str (str/join (map (fn [f] (str "cp /tmp/" (basename f) " " remote-public "/js/compiled/\n"))
+                                                                frontend-files))
+                                                 "cp /tmp/index.html " remote-public "/index.html\n"))
+                                          (when deploy-backend?
+                                            (str "source /var/lipas/.env.sh\n"
+                                                 "docker compose -f /var/lipas/docker-compose.yml rm -sf backend worker\n"
+                                                 "docker compose -f /var/lipas/docker-compose.yml up -d backend worker\n"
+                                                 ;; The proxy must be recreated after the backend so nginx
+                                                 ;; re-resolves the new backend container IP. --build picks
+                                                 ;; up nginx/Dockerfile changes (brotli modules ship in the
+                                                 ;; image) and is a cached no-op otherwise. Hosts run
+                                                 ;; different proxy variants, so detect the running one.
+                                                 "PROXY_SVC=$(docker compose -f /var/lipas/docker-compose.yml ps --services | grep -E '^proxy(-dev|-local)?$' || true)\n"
+                                                 "if [ -n \"$PROXY_SVC\" ]; then\n"
+                                                 "  docker compose -f /var/lipas/docker-compose.yml up -d --no-deps --build --force-recreate \"$PROXY_SVC\"\n"
+                                                 "else\n"
+                                                 "  echo 'no running proxy service found; skipping proxy restart'\n"
+                                                 "fi\n")))]
 
-                                 (shell (str "ssh " host " 'set -e && " all-commands "'"))))
+                                 (shell {:in script} "ssh" host "sudo bash -s")))
 
                              (println (str "✅ " (str/capitalize type-str) " deployment to " env " completed successfully!"))
                              (println (str "🌐 " (get-in deploy-config [:urls env-key]))))}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "npx shadow-cljs watch app",
-    "build": "npx shadow-cljs release app",
+    "build": "npx shadow-cljs release app && node scripts/precompress.mjs",
     "build-report": "npx shadow-cljs run shadow.cljs.build-report app report.html"
   },
   "keywords": [],

--- a/webapp/scripts/precompress.mjs
+++ b/webapp/scripts/precompress.mjs
@@ -1,0 +1,70 @@
+// Precompress release bundles for nginx brotli_static / gzip_static.
+//
+// Reads the module list from manifest.edn and writes a .br (brotli -q11) and
+// .gz (gzip -9) sibling next to each bundle. nginx serves these directly
+// instead of recompressing the immutable bundles on every request; clients
+// without brotli support get the .gz, and if a sibling is missing nginx
+// falls back to on-the-fly gzip.
+//
+// Only content-hashed filenames (app.A1B2C3D4.js) are compressed. Dev builds
+// produce unhashed app.js, which must never get a precompressed sibling — a
+// stale app.js.br would shadow fresh dev code, since brotli_static prefers
+// the sibling without comparing mtimes.
+//
+// Runs via `npm run build` (manual deploys) and the frontend-precompress
+// compose service (lipas-dev deploy workflow). Uses only node built-ins so
+// it works in both node and the CI container without npm deps.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, unlinkSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { brotliCompressSync, gzipSync, constants } from 'node:zlib';
+
+const compiledDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'resources', 'public', 'js', 'compiled');
+const manifestPath = join(compiledDir, 'manifest.edn');
+
+if (!existsSync(manifestPath)) {
+  console.error(`[precompress] ${manifestPath} not found — did the release build run?`);
+  process.exit(1);
+}
+
+// manifest.edn is EDN, but :output-name values are plain quoted strings
+// written by shadow-cljs, so a regex extraction is safe here
+const manifest = readFileSync(manifestPath, 'utf8');
+const names = [...manifest.matchAll(/:output-name\s+"([^"]+)"/g)].map((m) => m[1]);
+const hashed = names.filter((n) => /\.[0-9A-Fa-f]{4,}\.js$/.test(n));
+
+if (hashed.length === 0) {
+  console.log('[precompress] no content-hashed bundles in manifest.edn (dev build?) — nothing to do');
+  process.exit(0);
+}
+
+// Prune orphaned .br/.gz whose source bundle is gone
+for (const f of readdirSync(compiledDir)) {
+  if ((f.endsWith('.js.br') || f.endsWith('.js.gz')) && !existsSync(join(compiledDir, f.replace(/\.(br|gz)$/, '')))) {
+    unlinkSync(join(compiledDir, f));
+    console.log(`[precompress] pruned orphan ${f}`);
+  }
+}
+
+const kb = (n) => `${Math.round(n / 1000)} KB`;
+let totals = { raw: 0, gz: 0, br: 0 };
+
+for (const name of hashed) {
+  const src = readFileSync(join(compiledDir, name));
+  const br = brotliCompressSync(src, {
+    params: {
+      [constants.BROTLI_PARAM_QUALITY]: 11,
+      [constants.BROTLI_PARAM_SIZE_HINT]: src.length,
+    },
+  });
+  const gz = gzipSync(src, { level: 9 });
+  writeFileSync(join(compiledDir, `${name}.br`), br);
+  writeFileSync(join(compiledDir, `${name}.gz`), gz);
+  totals.raw += src.length;
+  totals.gz += gz.length;
+  totals.br += br.length;
+  console.log(`[precompress] ${name}: ${kb(src.length)} raw, ${kb(gz.length)} gz, ${kb(br.length)} br`);
+}
+
+console.log(`[precompress] total: ${kb(totals.raw)} raw, ${kb(totals.gz)} gz, ${kb(totals.br)} br (${hashed.length} bundles)`);


### PR DESCRIPTION
## Summary

Follow-up to #215: switch transfer compression from gzip-only to brotli-first with gzip fallback, measured against the previous on-the-fly `gzip -6` baseline:

| payload | gzip -6 (old) | brotli | delta |
|---|---|---|---|
| initial JS load (app + map + geo), precompressed q11 | 1 244 KB | 987 KB | **−21 %** |
| all 13 modules, precompressed q11 | 1 784 KB | 1 424 KB | −20 % |
| map search response (3.1 MB JSON, 500 sites), in-flight q5 | 713 KB | 397 KB | **−44 %** |

The dynamic side is the bigger win: repetitive JSON keys + brotli's 4 MB window (vs gzip's 32 KB) nearly halve the heaviest recurring payloads — and in-flight brotli q5 costs *half* the CPU of the gzip -6 it replaces (32 ms vs 66 ms per 3.1 MB response). Precompressing the whole module set at q11 adds ~8 s to the release build. Clients without `Accept-Encoding: br` keep getting gzip; nothing changes for old API consumers.

## How

- **`nginx/Dockerfile`** (new): two-stage build compiling google/ngx_brotli as dynamic modules against the exact `nginx:stable` of the base image (`--with-compat`). `proxy-base` is now `build: ./nginx` / `image: lipas/proxy`, built on each host like `lipas/htpasswd` — never pulled.
- **`nginx/nginx.conf`**: `load_module` for the two brotli modules — config and image must move together from here on.
- **`nginx/proxy*.conf`**: `brotli on; brotli_comp_level 5;` + `brotli_types` mirroring every gzip block; `brotli_static on; gzip_static on;` in the SPA-serving blocks, which also stops nginx recompressing the immutable hashed bundles on every request.
- **`webapp/scripts/precompress.mjs`** (new, node built-ins only): writes `.br` (q11) / `.gz` (-9) siblings for every content-hashed bundle in manifest.edn. Dev builds are exempt by design — `brotli_static` prefers a sibling without comparing mtimes, so unhashed `app.js` must never get one.

## Both deploy paths covered

1. **Manual (`webapp/bb.edn`)**: `npm run build` now runs precompress; `-do-deploy` uploads *all* module bundles + siblings. This also fixes a latent bug: since code splitting, manual frontend deploys scp'd only the `:app` bundle — the 12 lazy modules never reached the server. Remote install/restart now runs as a script over ssh stdin instead of triple-nested quoting.
2. **Automated (deploy-dev.yml)**: new `frontend-precompress` compose run after `frontend-build`; proxy restart replaced with detect-running-variant + `up -d --no-deps --build --force-recreate` (plain `docker compose restart <service>` exits 0 silently when the service has no containers, so the old hardcoded `restart proxy` may have been a no-op depending on host). `--force-recreate` preserves the old restart's load-bearing side effect: nginx re-resolves the backend container IP after backend/worker are recreated.

## Verification (local stack, release build)

- `brotli_static` serves byte-exact precompressed files (`Content-Length` == on-disk `.br`/`.gz`), correct `Content-Type`, `Vary: Accept-Encoding`, `Cache-Control: immutable` preserved; decoded payload sha256-identical to source.
- `POST /api/actions/search`: 408 KB br vs 730 KB gzip live; gzip/identity fallbacks intact.
- Browser smoke through the new proxy: frontpage + map view load, 48 716 sites render, lazy modules fetch as brotli, zero console errors.
- `frontend-precompress` compose service verified in the node:16-alpine container; `docker compose config` and workflow YAML validated.

## Rollout caution

After merge, the first proxy bounce on each host must go through a deploy (both paths build the image automatically) or a manual `docker compose build proxy && docker compose up -d --no-deps --force-recreate proxy`. A bare `docker compose restart proxy` while the old stock image is still in place will fail on the new `load_module` lines. Details + rollback in `docs/wip/brotli-compression.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)