### PR TITLE
GDPR: nightly removal job + impersonation history email scrub

### DIFF
--- a/webapp/resources/migrations/20260802130000-scrub-impersonation-emails-from-history.down.sql
+++ b/webapp/resources/migrations/20260802130000-scrub-impersonation-emails-from-history.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible by design: the point of the up migration is that the
+-- scrubbed email addresses no longer exist anywhere in account.history.
+SELECT 1;

--- a/webapp/resources/migrations/20260802130000-scrub-impersonation-emails-from-history.up.sql
+++ b/webapp/resources/migrations/20260802130000-scrub-impersonation-emails-from-history.up.sql
@@ -1,0 +1,22 @@
+-- GDPR: impersonation history events used to embed the impersonator's /
+-- target's email address in the OTHER party's account.history row —
+-- exactly where gdpr-remove-user! (which only anonymizes the removed
+-- account's own row) can never reach them. The events now record only
+-- account UUIDs, which degrade gracefully: after a removal the UUID
+-- resolves to the anonymized account. This scrubs the emails that were
+-- already written.
+UPDATE account
+SET history = jsonb_set(
+  history,
+  '{events}',
+  (SELECT jsonb_agg(evt.value - 'impersonator-email' - 'target-email'
+                    ORDER BY evt.ordinality)
+   FROM jsonb_array_elements(history->'events')
+     WITH ORDINALITY AS evt(value, ordinality)))
+-- jsonb_exists() instead of the ? operator: migration runners and JDBC
+-- treat a bare ? as a bind-parameter placeholder.
+WHERE jsonb_typeof(history->'events') = 'array'
+  AND EXISTS (
+    SELECT 1 FROM jsonb_array_elements(history->'events') AS e
+    WHERE jsonb_exists(e, 'impersonator-email')
+       OR jsonb_exists(e, 'target-email'));

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -270,13 +270,15 @@
               (roles/check-privilege target-conformed nil :users/impersonate))
       (throw (ex-info "Impersonation not allowed for this user"
                       {:type :impersonation-not-allowed})))
-    (log/info "Impersonation started:" (:email admin) "->" (:email target))
+    (log/info "Impersonation started:" (:id admin) "->" (:id target))
+    ;; Ids only, no emails: each event lands in the OTHER party's history
+    ;; row, where GDPR removal (which only anonymizes the removed account's
+    ;; own row) could never scrub an embedded address. The id resolves to
+    ;; the — possibly since-anonymized — account when actually needed.
     (add-user-event! db target "impersonation-started"
-                     {:impersonator-id (str (:id admin))
-                      :impersonator-email (:email admin)})
+                     {:impersonator-id (str (:id admin))})
     (add-user-event! db admin "impersonated-user"
-                     {:target-id (str (:id target))
-                      :target-email (:email target)})
+                     {:target-id (str (:id target))})
     (merge (dissoc target :password)
            {:token (jwt/create-token target
                                      :valid-seconds impersonation-token-valid-seconds
@@ -328,6 +330,16 @@
       (update-user-status! tx (assoc user :status "archived"))))
   {:status "OK"})
 
+(def non-activity-events
+  "History events that are not the account owner's own doing and must not
+  postpone GDPR removal. impersonation-started is written by an admin onto
+  the dormant target's history; without this exclusion impersonating an
+  account would reset its 5-year inactivity clock. impersonated-user sits
+  on the admin's own account but always co-occurs with the admin's login
+  event, so excluding it too loses nothing and keeps the rule simple:
+  impersonation never counts as activity."
+  #{"impersonation-started" "impersonated-user"})
+
 (defn gdpr-remove?
   "User data is removed if the user has been inactive for > 5 years.
   Fails closed: an account with no created-at (the column is nullable,
@@ -341,7 +353,11 @@
                                  (.plus 5 java.time.temporal.ChronoUnit/YEARS)
                                  (.toInstant))]
            (.isAfter now created-at+5y))
-         (let [last-event (->> history :events (map :event-date) (sort utils/reverse-cmp) first)]
+         (let [last-event (->> history :events
+                               (remove (comp non-activity-events :event))
+                               (map :event-date)
+                               (sort utils/reverse-cmp)
+                               first)]
            (or (nil? last-event)
                (let [last-event+5y (-> (java.time.Instant/parse last-event)
                                        (.atZone (java.time.ZoneId/of "UTC"))

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -329,14 +329,18 @@
   {:status "OK"})
 
 (defn gdpr-remove?
-  "User data is removed if the user has been inactive for > 5 years."
+  "User data is removed if the user has been inactive for > 5 years.
+  Fails closed: an account with no created-at (the column is nullable,
+  legacy rows may lack it) is never eligible."
   [now {:keys [created-at history] :as user}]
-  (let [created-at+5y (-> (.toInstant created-at)
-                          (.atZone (java.time.ZoneId/of "UTC"))
-                          (.plus 5 java.time.temporal.ChronoUnit/YEARS)
-                          (.toInstant))]
-    (and (not (str/ends-with? (:email user) "@lipas.fi"))
-         (.isAfter now created-at+5y)
+  (boolean
+    (and created-at
+         (not (str/ends-with? (:email user) "@lipas.fi"))
+         (let [created-at+5y (-> (.toInstant created-at)
+                                 (.atZone (java.time.ZoneId/of "UTC"))
+                                 (.plus 5 java.time.temporal.ChronoUnit/YEARS)
+                                 (.toInstant))]
+           (.isAfter now created-at+5y))
          (let [last-event (->> history :events (map :event-date) (sort utils/reverse-cmp) first)]
            (or (nil? last-event)
                (let [last-event+5y (-> (java.time.Instant/parse last-event)
@@ -345,20 +349,62 @@
                                        (.toInstant))]
                  (.isAfter now last-event+5y)))))))
 
+(def gdpr-removals-default-limit
+  "Max removals in one process-gdpr-removals! run. GDPR removal is
+  irreversible, so a bug in the eligibility predicate must not be able to
+  anonymize the whole user base in one sweep; the nightly job drains a
+  legitimate backlog within days."
+  50)
+
 (defn process-gdpr-removals!
-  [db]
+  "Anonymize every user gdpr-remove? deems inactive, at most `limit` per run.
+
+  This is a bulk-destructive operation, so it is deliberately fenced in:
+  - an eligibility check that throws (legacy rows with odd data) skips that
+    user, never removes it
+  - at most `limit` users are removed per run
+  - :dry-run? true writes nothing and only reports what a live run would do
+  - a failed removal doesn't stop the batch, but the batch then throws at
+    the end so the job system retries / dead-letters it visibly; users
+    already removed are excluded from the rerun by gdpr-remove? itself
+    (their email becomes @lipas.fi)
+
+  Returns {:eligible :batch :removed :failed :check-errors :dry-run?}."
+  [db & [{:keys [limit dry-run?] :or {limit gdpr-removals-default-limit}}]]
   (let [now (java.time.Instant/now)
-        users (->> (get-users db)
-                   (filter (partial gdpr-remove? now)))]
-    (log/info "Found" (count users) "users to GDPR remove.")
-
-    (doseq [user users]
-      (log/info "GDPR removing user" (:id user))
-      (log/info (:created-at user)
-                (->> user :history :events (map :event-date) (sort utils/reverse-cmp) first))
-      #_(gdpr-remove-user! db user))
-
-    (log/info "GDPR removals DONE!")))
+        checked (mapv (fn [user]
+                        (try
+                          {:user user :eligible? (gdpr-remove? now user)}
+                          (catch Exception ex
+                            (log/warn ex "GDPR eligibility check failed - skipping user"
+                                      {:user-id (:id user)})
+                            {:user user :error? true})))
+                      (get-users db))
+        eligible (into [] (comp (filter :eligible?) (map :user)) checked)
+        batch (into [] (take limit) eligible)
+        summary {:eligible (count eligible)
+                 :batch (count batch)
+                 :check-errors (count (filter :error? checked))
+                 :dry-run? (boolean dry-run?)}]
+    (log/info "GDPR removal batch starting" (assoc summary :limit limit))
+    (let [result (reduce
+                   (fn [acc user]
+                     (if dry-run?
+                       (do (log/info "GDPR dry-run - would remove user" {:user-id (:id user)})
+                           acc)
+                       (try
+                         (log/info "GDPR removing user" {:user-id (:id user)})
+                         (gdpr-remove-user! db user)
+                         (update acc :removed inc)
+                         (catch Exception ex
+                           (log/error ex "GDPR removal failed" {:user-id (:id user)})
+                           (update acc :failed inc)))))
+                   (assoc summary :removed 0 :failed 0)
+                   batch)]
+      (log/info "GDPR removal batch done" result)
+      (when (pos? (:failed result))
+        (throw (ex-info "GDPR removal batch had failures" result)))
+      result)))
 
 ;;; Sports-sites ;;;
 

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -353,17 +353,20 @@
                                  (.plus 5 java.time.temporal.ChronoUnit/YEARS)
                                  (.toInstant))]
            (.isAfter now created-at+5y))
-         (let [last-event (->> history :events
-                               (remove (comp non-activity-events :event))
-                               (map :event-date)
-                               (sort utils/reverse-cmp)
-                               first)]
-           (or (nil? last-event)
-               (let [last-event+5y (-> (java.time.Instant/parse last-event)
-                                       (.atZone (java.time.ZoneId/of "UTC"))
-                                       (.plus 5 java.time.temporal.ChronoUnit/YEARS)
-                                       (.toInstant))]
-                 (.isAfter now last-event+5y)))))))
+         (let [activity-dates (->> history :events
+                                   (remove (comp non-activity-events :event))
+                                   (map :event-date))]
+           ;; An activity event with no date is unprovable inactivity - fail
+           ;; closed, consistent with unparseable dates (which throw and get
+           ;; the user skipped at the batch level).
+           (and (every? some? activity-dates)
+                (let [last-event (first (sort utils/reverse-cmp activity-dates))]
+                  (or (nil? last-event)
+                      (let [last-event+5y (-> (java.time.Instant/parse last-event)
+                                              (.atZone (java.time.ZoneId/of "UTC"))
+                                              (.plus 5 java.time.temporal.ChronoUnit/YEARS)
+                                              (.toInstant))]
+                        (.isAfter now last-event+5y)))))))))
 
 (def gdpr-removals-default-limit
   "Max removals in one process-gdpr-removals! run. GDPR removal is

--- a/webapp/src/clj/lipas/jobs/dispatcher.clj
+++ b/webapp/src/clj/lipas/jobs/dispatcher.clj
@@ -90,6 +90,10 @@
     ;; Default email handling
     (email/send! emailer payload)))
 
+(defmethod handle-job "gdpr-removals"
+  [{:keys [db]} {:keys [payload]}]
+  (core/process-gdpr-removals! db payload))
+
 (defmethod handle-job "help-kb-sync"
   [{:keys [db search]} _job]
   (kb/sync! db search))

--- a/webapp/src/clj/lipas/jobs/registry.clj
+++ b/webapp/src/clj/lipas/jobs/registry.clj
@@ -127,6 +127,19 @@
     :priority 95
     :max-attempts 3}
 
+   "gdpr-removals"
+   {:doc "Anonymize users inactive for >5 years (GDPR retention)."
+    :payload-schema [:map
+                     [:dry-run? {:optional true} :boolean]
+                     [:limit {:optional true} pos-int?]]
+    :lane :slow
+    :timeout-min 15
+    :priority 50
+    :max-attempts 3
+    ;; One batch in flight at a time; the nightly producer re-enqueueing
+    ;; while a run is still pending coalesces into that run.
+    :dedup-key-fn (fn [_] "gdpr-removals")}
+
    "help-kb-sync"
    {:doc "Sync help CMS + code-derived docs into the lipas_kb search index."
     :payload-schema [:map]

--- a/webapp/src/clj/lipas/jobs/scheduler.clj
+++ b/webapp/src/clj/lipas/jobs/scheduler.clj
@@ -42,6 +42,13 @@
    {:interval-seconds 86400
     :task-fn (fn [db] (jobs/enqueue-job! db "help-kb-sync" {}))}
 
+   :nightly-gdpr-removals
+   ;; Anonymize users inactive for >5 years. The batch is idempotent and
+   ;; capped (see core/process-gdpr-removals!), so the interval anchoring
+   ;; to worker restarts is harmless.
+   {:interval-seconds 86400
+    :task-fn (fn [db] (jobs/enqueue-job! db "gdpr-removals" {}))}
+
    :recover-stuck-jobs
    {:interval-seconds 600
     :task-fn (fn [db] (jobs/recover-stuck-jobs! db jobs/stuck-job-timeout-minutes))}

--- a/webapp/test/clj/lipas/backend/business_logic_test.clj
+++ b/webapp/test/clj/lipas/backend/business_logic_test.clj
@@ -1,5 +1,8 @@
 (ns lipas.backend.business-logic-test
   (:require [clojure.test :as t :refer [deftest is testing]]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
             [lipas.backend.core :as core]
             [lipas.roles :as roles]))
 
@@ -67,6 +70,163 @@
         (is (false? (core/gdpr-remove?
                       now
                       (assoc-in user [:history :events 0 :event] "login"))))))))
+
+;;; --- gdpr-remove? generative spec -------------------------------------------
+;;;
+;;; The predicate decides irreversible bulk anonymization, so it gets a
+;;; property-based spec on top of the examples above. Users are built from
+;;; blocks that are KNOWN recent or ancient by construction: every generated
+;;; timestamp stays a 40-day guard band away from the 5-year boundary, so no
+;;; property depends on leap-day arithmetic and the expected outcome needs no
+;;; oracle. Exact boundary semantics are pinned by gdpr-boundary-semantics-test.
+
+(def ^:private spec-now (java.time.Instant/parse "2026-08-02T00:00:00Z"))
+
+(def ^:private five-years-days (* 5 365))
+(def ^:private margin-days 40)
+
+(defn- days-ago-ts [days]
+  (java.sql.Timestamp/from (.minus spec-now days java.time.temporal.ChronoUnit/DAYS)))
+
+(defn- days-ago-str [days]
+  (str (.minus spec-now days java.time.temporal.ChronoUnit/DAYS)))
+
+(def ^:private gen-recent-days
+  "Clearly within the 5-year window."
+  (gen/choose 0 (- five-years-days margin-days)))
+
+(def ^:private gen-ancient-days
+  "Clearly beyond the 5-year window."
+  (gen/choose (+ five-years-days margin-days) (* 30 365)))
+
+(def ^:private gen-owner-event-type
+  ;; Alphanumeric strings can't collide with the dashed names in
+  ;; core/non-activity-events, so anything generated here must count as the
+  ;; owner's own activity.
+  (gen/one-of [(gen/elements ["login" "password-reset" "permissions-updated"
+                              "status-changed" "magic-link-sent"])
+               gen/string-alphanumeric]))
+
+(def ^:private gen-impersonation-event-type
+  (gen/elements (vec core/non-activity-events)))
+
+(defn- event [type days] {:event type :event-date (days-ago-str days)})
+
+(def ^:private gen-ancient-owner-events
+  (gen/vector (gen/fmap (fn [[t d]] (event t d))
+                        (gen/tuple gen-owner-event-type gen-ancient-days))
+              0 5))
+
+(def ^:private gen-impersonation-events
+  "Impersonation events at ANY age, sometimes without a date at all - none
+  of it may count as the owner's activity."
+  (gen/vector (gen/fmap (fn [[t d dateless?]]
+                          (if dateless? {:event t} (event t d)))
+                        (gen/tuple gen-impersonation-event-type
+                                   (gen/choose 0 (* 30 365))
+                                   (gen/frequency [[4 (gen/return false)]
+                                                   [1 (gen/return true)]])))
+              0 5))
+
+(def ^:private gen-email
+  (gen/fmap #(str % "@example.com") (gen/not-empty gen/string-alphanumeric)))
+
+(def ^:private gen-dormant-user
+  "The by-construction-eligible case: created long ago, every owner event
+  long ago, impersonated whenever."
+  (gen/fmap (fn [[email created-days evts ievts]]
+              {:email email
+               :created-at (days-ago-ts created-days)
+               :history {:events (vec (concat evts ievts))}})
+            (gen/tuple gen-email gen-ancient-days
+                       gen-ancient-owner-events gen-impersonation-events)))
+
+(def ^:private gen-mixed-user
+  "Arbitrary shape: any email (incl. @lipas.fi), any event mix, sometimes no
+  created-at. For properties about the predicate's form, not its outcome."
+  (gen/fmap (fn [[email created-days nil-created? evts]]
+              {:email email
+               :created-at (when-not nil-created? (days-ago-ts created-days))
+               :history {:events evts}})
+            (gen/tuple (gen/one-of [gen-email
+                                    (gen/fmap #(str % "@lipas.fi") gen/string-alphanumeric)])
+                       (gen/one-of [gen-recent-days gen-ancient-days])
+                       (gen/frequency [[9 (gen/return false)] [1 (gen/return true)]])
+                       (gen/vector
+                         (gen/fmap (fn [[t d]] (event t d))
+                                   (gen/tuple (gen/one-of [gen-owner-event-type
+                                                           gen-impersonation-event-type])
+                                              (gen/one-of [gen-recent-days gen-ancient-days])))
+                         0 6))))
+
+(defspec dormant-user-is-eligible 300
+  ;; Completeness: the predicate must not silently become "never remove
+  ;; anyone" - and impersonation at any age must not protect the account.
+  (prop/for-all [user gen-dormant-user]
+                (true? (core/gdpr-remove? spec-now user))))
+
+(defspec any-recent-owner-activity-protects 300
+  (prop/for-all [user gen-dormant-user
+                 evt-type gen-owner-event-type
+                 days gen-recent-days]
+                (false? (core/gdpr-remove?
+                          spec-now
+                          (update-in user [:history :events] conj (event evt-type days))))))
+
+(defspec recent-account-age-protects 300
+  (prop/for-all [user gen-mixed-user
+                 days gen-recent-days]
+                (false? (core/gdpr-remove? spec-now (assoc user :created-at (days-ago-ts days))))))
+
+(defspec lipas-fi-email-always-protects 300
+  (prop/for-all [user gen-dormant-user
+                 local gen/string-alphanumeric]
+                (false? (core/gdpr-remove? spec-now (assoc user :email (str local "@lipas.fi"))))))
+
+(defspec nil-created-at-always-protects 300
+  (prop/for-all [user gen-mixed-user]
+                (false? (core/gdpr-remove? spec-now (assoc user :created-at nil)))))
+
+(defspec dateless-owner-event-fails-closed 300
+  ;; An owner event with no date is unprovable inactivity: garbage dates
+  ;; already fail closed (throw -> batch skips), a missing date must too.
+  (prop/for-all [user gen-dormant-user
+                 evt-type gen-owner-event-type]
+                (false? (core/gdpr-remove?
+                          spec-now
+                          (update-in user [:history :events] conj {:event evt-type})))))
+
+(defspec event-order-is-irrelevant 200
+  (prop/for-all [[user shuffled]
+                 (gen/let [user gen-mixed-user
+                           evts (gen/shuffle (-> user :history :events))]
+                   [user (assoc-in user [:history :events] (vec evts))])]
+                (= (core/gdpr-remove? spec-now user)
+                   (core/gdpr-remove? spec-now shuffled))))
+
+(defspec eligibility-is-monotone-in-time 300
+  ;; Once dormant long enough, waiting longer can never flip the decision
+  ;; back - the batch cap relies on this to drain a backlog across nights.
+  (prop/for-all [user gen-mixed-user
+                 extra-days (gen/choose 0 3650)]
+                (if (core/gdpr-remove? spec-now user)
+                  (core/gdpr-remove? (.plus spec-now extra-days java.time.temporal.ChronoUnit/DAYS) user)
+                  true)))
+
+(deftest gdpr-boundary-semantics-test
+  (let [now (java.time.Instant/parse "2026-08-02T00:00:00Z")
+        at-boundary (java.sql.Timestamp/from (java.time.Instant/parse "2021-08-02T00:00:00Z"))]
+    (testing "exactly 5 years of account age is not yet eligible - strictly after"
+      (is (false? (core/gdpr-remove? now {:email "a@b.fi" :created-at at-boundary :history {}}))))
+    (testing "one second past 5 years is eligible"
+      (is (true? (core/gdpr-remove? (.plusSeconds now 1)
+                                    {:email "a@b.fi" :created-at at-boundary :history {}}))))
+    (testing "an activity event exactly 5 years old still protects; a second later it doesn't"
+      (let [user {:email "a@b.fi"
+                  :created-at (java.sql.Timestamp/from (java.time.Instant/parse "2015-01-01T00:00:00Z"))
+                  :history {:events [{:event "login" :event-date "2021-08-02T00:00:00Z"}]}}]
+        (is (false? (core/gdpr-remove? now user)))
+        (is (true? (core/gdpr-remove? (.plusSeconds now 1) user)))))))
 
 ;;; --- Ownership & edit-grant authorization (core business rule) --------------
 ;;; Pure predicates, so we can enumerate the cases exhaustively (handler tests in

--- a/webapp/test/clj/lipas/backend/business_logic_test.clj
+++ b/webapp/test/clj/lipas/backend/business_logic_test.clj
@@ -44,6 +44,13 @@
           user          {:email      "whatever@lipas.fi"
                          :created-at (java.sql.Timestamp/from long-time-ago)
                          :history    {}}]
+      (is (false? (core/gdpr-remove? now user)))))
+
+  (testing "Account without created-at is never eligible (nullable column, fail closed)"
+    (let [now  (java.time.Instant/now)
+          user {:email      "kissa@koira.fi"
+                :created-at nil
+                :history    {}}]
       (is (false? (core/gdpr-remove? now user))))))
 
 ;;; --- Ownership & edit-grant authorization (core business rule) --------------

--- a/webapp/test/clj/lipas/backend/business_logic_test.clj
+++ b/webapp/test/clj/lipas/backend/business_logic_test.clj
@@ -51,7 +51,22 @@
           user {:email      "kissa@koira.fi"
                 :created-at nil
                 :history    {}}]
-      (is (false? (core/gdpr-remove? now user))))))
+      (is (false? (core/gdpr-remove? now user)))))
+
+  (testing "Impersonation events are not the owner's activity and don't reset the clock"
+    (let [now           (java.time.Instant/now)
+          long-time-ago (java.time.Instant/parse "2015-01-01T00:00:00.000Z")
+          recent        (str (.minus now 30 java.time.temporal.ChronoUnit/DAYS))
+          user          {:email      "kissa@koira.fi"
+                         :created-at (java.sql.Timestamp/from long-time-ago)
+                         :history    {:events [{:event-date recent
+                                                :event "impersonation-started"
+                                                :impersonator-id "an-admin-uuid"}]}}]
+      (is (true? (core/gdpr-remove? now user)))
+      (testing "but the owner's own recent event still protects the account"
+        (is (false? (core/gdpr-remove?
+                      now
+                      (assoc-in user [:history :events 0 :event] "login"))))))))
 
 ;;; --- Ownership & edit-grant authorization (core business rule) --------------
 ;;; Pure predicates, so we can enumerate the cases exhaustively (handler tests in

--- a/webapp/test/clj/lipas/backend/gdpr_test.clj
+++ b/webapp/test/clj/lipas/backend/gdpr_test.clj
@@ -77,6 +77,12 @@
 (deftest process-gdpr-removals!-end-to-end-test
   (let [db (test-db)
         eligible (gen-user-created-ago! db six-years-days [])
+        ;; Dormant account an admin recently impersonated: admin activity
+        ;; must not reset the owner's inactivity clock.
+        impersonated (gen-user-created-ago! db six-years-days
+                                            [{:event-date (str (instant-ago 30))
+                                              :event "impersonation-started"
+                                              :impersonator-id "an-admin-uuid"}])
         old-active (gen-user-created-ago! db six-years-days
                                           [{:event-date (str (instant-ago 30))
                                             :event "login"}])
@@ -95,10 +101,12 @@
         before (mapv #(row-fingerprint db %) untouchables)
         result (core/process-gdpr-removals! db)]
 
-    (testing "exactly the one eligible user is removed"
-      (is (= {:eligible 1 :batch 1 :removed 1 :failed 0 :check-errors 1 :dry-run? false}
+    (testing "exactly the eligible users are removed"
+      (is (= {:eligible 2 :batch 2 :removed 2 :failed 0 :check-errors 1 :dry-run? false}
              result))
-      (is (anonymized? db eligible)))
+      (is (anonymized? db eligible))
+      (is (anonymized? db impersonated)
+          "a recent impersonation must not have protected the dormant account"))
 
     (testing "an unparseable history fails closed: skipped, reported, never removed"
       (is (= 1 (:check-errors result))))

--- a/webapp/test/clj/lipas/backend/gdpr_test.clj
+++ b/webapp/test/clj/lipas/backend/gdpr_test.clj
@@ -1,0 +1,158 @@
+(ns lipas.backend.gdpr-test
+  "End-to-end tests for the GDPR removal batch — the only bulk-destructive
+  operation in LIPAS. The batch must anonymize exactly the eligible users
+  and provably leave every other account byte-for-byte untouched."
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [lipas.backend.core :as core]
+    [lipas.backend.db.db :as db]
+    [lipas.test-utils :as tu]
+    [next.jdbc :as jdbc]))
+
+(defonce test-system (atom nil))
+
+(let [{:keys [once each]} (tu/db-only-fixture test-system)]
+  (use-fixtures :once once)
+  (use-fixtures :each each))
+
+(defn test-db [] (:lipas/db @test-system))
+
+(defn- instant-ago [days]
+  (.minus (java.time.Instant/now) days java.time.temporal.ChronoUnit/DAYS))
+
+(def ^:private six-years-days 2200)
+
+(defn- gen-user-created-ago!
+  "A persisted user whose account is `days` old with exactly `events` in its
+  history (generated users get random history, which would make eligibility
+  nondeterministic)."
+  [db days events]
+  (let [user (tu/gen-regular-user :db-component db)]
+    (tu/backdate-user-created-at! db (:id user) (instant-ago days))
+    (db/update-user-history! db (assoc user :history {:events events}))
+    user))
+
+(defn- fetch [db user]
+  (db/get-user-by-id db {:id (:id user)}))
+
+(defn- row-fingerprint
+  "The full account row with every column stringified, so equality means
+  'nothing about this row changed' without depending on PGobject/timestamp
+  equality semantics."
+  [db user]
+  (update-vals
+    (first (jdbc/execute! db ["SELECT * FROM account WHERE id = ?::uuid"
+                              (str (:id user))]))
+    str))
+
+(defn- anonymized? [db user]
+  (let [{:keys [email username status user-data]} (fetch db user)]
+    (and (str/starts-with? email "gdpr_removed_")
+         (str/ends-with? email "@lipas.fi")
+         (str/starts-with? username "gdpr_removed_")
+         (= "archived" status)
+         (empty? user-data))))
+
+(deftest gdpr-remove-user!-removes-exactly-the-personal-data-test
+  (let [db (test-db)
+        user (tu/gen-regular-user :db-component db)
+        before (fetch db user)
+        password-before (:account/password (row-fingerprint db user))]
+    (core/gdpr-remove-user! db user)
+    (let [after (fetch db user)]
+      (testing "personal data is gone"
+        (is (anonymized? db user))
+        (is (not= (:email before) (:email after)))
+        (is (not= (:username before) (:username after)))
+        (is (empty? (:user-data after))))
+      (testing "the removal is recorded in the user's history"
+        (is (some #(= "GDPR removal" (:event %)) (-> after :history :events))))
+      (testing "nothing else is touched"
+        (is (= (:id before) (:id after)))
+        (is (= (:permissions before) (:permissions after)))
+        (is (= (:created-at before) (:created-at after)))
+        (is (= password-before (:account/password (row-fingerprint db user))))))))
+
+(deftest process-gdpr-removals!-end-to-end-test
+  (let [db (test-db)
+        eligible (gen-user-created-ago! db six-years-days [])
+        old-active (gen-user-created-ago! db six-years-days
+                                          [{:event-date (str (instant-ago 30))
+                                            :event "login"}])
+        recent (gen-user-created-ago! db 30 [])
+        system-user (let [u (gen-user-created-ago! db six-years-days [])]
+                      (db/update-user-email! db (assoc u :email "robot-gdpr-test@lipas.fi"))
+                      u)
+        no-created-at (let [u (gen-user-created-ago! db six-years-days [])]
+                        (jdbc/execute! db ["UPDATE account SET created_at = NULL WHERE id = ?::uuid"
+                                           (str (:id u))])
+                        u)
+        broken-history (gen-user-created-ago! db six-years-days
+                                              [{:event-date "not-a-timestamp"
+                                                :event "login"}])
+        untouchables [old-active recent system-user no-created-at broken-history]
+        before (mapv #(row-fingerprint db %) untouchables)
+        result (core/process-gdpr-removals! db)]
+
+    (testing "exactly the one eligible user is removed"
+      (is (= {:eligible 1 :batch 1 :removed 1 :failed 0 :check-errors 1 :dry-run? false}
+             result))
+      (is (anonymized? db eligible)))
+
+    (testing "an unparseable history fails closed: skipped, reported, never removed"
+      (is (= 1 (:check-errors result))))
+
+    (testing "every ineligible account is byte-for-byte untouched"
+      (is (= before (mapv #(row-fingerprint db %) untouchables))))
+
+    (testing "a second run is a no-op"
+      (is (= {:eligible 0 :batch 0 :removed 0 :failed 0 :check-errors 1 :dry-run? false}
+             (core/process-gdpr-removals! db)))
+      (is (= before (mapv #(row-fingerprint db %) untouchables))))))
+
+(deftest process-gdpr-removals!-cap-test
+  (let [db (test-db)
+        users (vec (repeatedly 3 #(gen-user-created-ago! db six-years-days [])))
+        removed-count (fn [] (count (filter #(anonymized? db %) users)))]
+
+    (testing "a run removes at most :limit users"
+      (is (= {:eligible 3 :batch 2 :removed 2 :failed 0 :check-errors 0 :dry-run? false}
+             (core/process-gdpr-removals! db {:limit 2})))
+      (is (= 2 (removed-count))))
+
+    (testing "the next run drains the remainder"
+      (is (= {:eligible 1 :batch 1 :removed 1 :failed 0 :check-errors 0 :dry-run? false}
+             (core/process-gdpr-removals! db {:limit 2})))
+      (is (= 3 (removed-count))))))
+
+(deftest process-gdpr-removals!-dry-run-test
+  (let [db (test-db)
+        user (gen-user-created-ago! db six-years-days [])
+        before (row-fingerprint db user)]
+    (testing "dry run reports what a live run would do but writes nothing"
+      (is (= {:eligible 1 :batch 1 :removed 0 :failed 0 :check-errors 0 :dry-run? true}
+             (core/process-gdpr-removals! db {:dry-run? true})))
+      (is (= before (row-fingerprint db user))))))
+
+(deftest process-gdpr-removals!-failure-isolation-test
+  ;; Fault injection: a removal that blows up for one user must not stop the
+  ;; batch, but the batch must then fail loudly so the job system retries /
+  ;; dead-letters it instead of reporting quiet success.
+  (let [db (test-db)
+        user-a (gen-user-created-ago! db six-years-days [])
+        user-b (gen-user-created-ago! db six-years-days [])
+        orig core/gdpr-remove-user!
+        ex (with-redefs [core/gdpr-remove-user!
+                         (fn [db user]
+                           (if (= (:id user-a) (:id user))
+                             (throw (ex-info "injected removal failure" {}))
+                             (orig db user)))]
+             (is (thrown? clojure.lang.ExceptionInfo
+                          (core/process-gdpr-removals! db))))]
+    (testing "the batch summary rides on the exception"
+      (is (= {:removed 1 :failed 1} (select-keys (ex-data ex) [:removed :failed]))))
+    (testing "the healthy user was still removed, the failed one left intact"
+      (is (anonymized? db user-b))
+      (is (not (anonymized? db user-a)))
+      (is (not (str/starts-with? (:email (fetch db user-a)) "gdpr_removed_"))))))

--- a/webapp/test/clj/lipas/backend/handler_test.clj
+++ b/webapp/test/clj/lipas/backend/handler_test.clj
@@ -541,11 +541,18 @@
 
     (testing "audit events are recorded on both users"
       (let [target-events (->> (core/get-user (test-db) (:email target))
-                               :history :events (map :event) set)
+                               :history :events)
             admin-events (->> (core/get-user (test-db) (:email admin))
-                              :history :events (map :event) set)]
-        (is (contains? target-events "impersonation-started"))
-        (is (contains? admin-events "impersonated-user"))))))
+                              :history :events)
+            started (first (filter #(= "impersonation-started" (:event %)) target-events))
+            performed (first (filter #(= "impersonated-user" (:event %)) admin-events))]
+        (is (= (str (:id admin)) (:impersonator-id started)))
+        (is (= (str (:id target)) (:target-id performed)))
+        (testing "events reference the other party by id only, never email"
+          ;; The events land in the OTHER party's history row, where GDPR
+          ;; removal could never scrub an embedded address.
+          (is (nil? (:impersonator-email started)))
+          (is (nil? (:target-email performed))))))))
 
 (deftest impersonate-requires-privilege-test
   (let [user (tu/gen-regular-user :db-component (test-db))

--- a/webapp/test/clj/lipas/jobs/dispatcher_test.clj
+++ b/webapp/test/clj/lipas/jobs/dispatcher_test.clj
@@ -5,6 +5,7 @@
     [clojure.test :refer [deftest testing is use-fixtures]]
     [lipas.backend.analysis.diversity :as diversity]
     [lipas.backend.core :as core]
+    [lipas.backend.db.db :as db]
     [lipas.backend.email :as email]
     [lipas.backend.gis :as gis]
     [lipas.integration.utp.webhook :as utp-webhook]
@@ -115,6 +116,31 @@
                                 :payload {:lipas-ids [1 2]
                                           :operation-type "test-update"}})
         (is (= [1 2] (:lipas-ids @received)))))))
+
+(deftest gdpr-removals-job-handler-test
+  ;; Real DB, no mocks: the handler drives the actual removal batch.
+  (let [db (test-db)
+        user (test-utils/gen-regular-user :db-component db)
+        _ (test-utils/backdate-user-created-at!
+            db (:id user)
+            (.minus (java.time.Instant/now) 2200 java.time.temporal.ChronoUnit/DAYS))
+        _ (db/update-user-history! db (assoc user :history {:events []}))
+        system {:db db :search (create-mock-search)}]
+
+    (testing "dry-run payload reports without removing"
+      (let [result (dispatcher/handle-job system {:id 1 :type "gdpr-removals"
+                                                  :payload {:dry-run? true}})]
+        (is (= {:eligible 1 :removed 0 :dry-run? true}
+               (select-keys result [:eligible :removed :dry-run?])))
+        (is (= (:email user) (:email (core/get-user db (:email user)))))))
+
+    (testing "empty payload runs the batch live with defaults"
+      (let [result (dispatcher/handle-job system {:id 2 :type "gdpr-removals"
+                                                  :payload {}})]
+        (is (= {:eligible 1 :removed 1 :failed 0 :dry-run? false}
+               (select-keys result [:eligible :removed :failed :dry-run?])))
+        (is (nil? (core/get-user db (:email user)))
+            "the eligible user's email must no longer resolve to an account")))))
 
 (deftest unknown-job-type-handler-test
   (testing "Unknown job types throw"

--- a/webapp/test/clj/lipas/jobs/scheduler_test.clj
+++ b/webapp/test/clj/lipas/jobs/scheduler_test.clj
@@ -63,6 +63,20 @@
     (is (= 0 (scheduler/produce-reminder-emails! (test-db))))
     (is (empty? (test-utils/get-all-jobs (test-db))))))
 
+(deftest nightly-gdpr-removals-produces-one-job-test
+  (testing "The nightly task enqueues a gdpr-removals job; re-runs coalesce"
+    (let [db (test-db)
+          task-fn (get-in scheduler/schedule-configs
+                          [:nightly-gdpr-removals :task-fn])]
+      (is (some? task-fn))
+      (task-fn db)
+      (task-fn db)
+      (let [jobs (filter #(= "gdpr-removals" (:jobs/type %))
+                         (test-utils/get-all-jobs db))]
+        (is (= 1 (count jobs))
+            "The dedup key must coalesce producer re-runs into one pending job")
+        (is (= "pending" (:jobs/status (first jobs))))))))
+
 (deftest scheduler-lifecycle-test
   (testing "Scheduler starts, runs its tasks and stops"
     (let [db (test-db)]
@@ -84,12 +98,14 @@
         (testing "Scheduler tasks do not enqueue maintenance jobs"
           ;; The old design routed reminder checks and cleanup through the
           ;; queue as job rows; the new design calls them directly. Real
-          ;; work still becomes jobs: the nightly KB sync enqueues exactly
-          ;; one (deduplicated) help-kb-sync job on its startup tick.
+          ;; work still becomes jobs: the nightly KB sync and the nightly
+          ;; GDPR removal batch each enqueue exactly one (deduplicated)
+          ;; job on their startup tick.
           (Thread/sleep 500)
           (let [jobs (test-utils/get-all-jobs db)]
-            (is (= ["help-kb-sync"] (mapv :jobs/type jobs))
-                "No queue churn from scheduler ticks beyond the KB sync")))
+            (is (= {"help-kb-sync" 1 "gdpr-removals" 1}
+                   (frequencies (mapv :jobs/type jobs)))
+                "No queue churn from scheduler ticks beyond the nightly real work")))
 
         (finally
           (scheduler/stop-scheduler!)))

--- a/webapp/test/clj/lipas/test_utils.clj
+++ b/webapp/test/clj/lipas/test_utils.clj
@@ -920,6 +920,13 @@
          (assoc user :id (:id (core/get-user db-component (:email user)))))
        user))))
 
+(defn backdate-user-created-at!
+  "Set account.created_at for a user. gen-user always stamps rows with now;
+  GDPR retention tests need accounts that look years old."
+  [db user-id inst]
+  (next-jdbc/execute! db ["UPDATE account SET created_at = ? WHERE id = ?::uuid"
+                          (java.sql.Timestamp/from inst) (str user-id)]))
+
 (defn gen-loi! []
   (-> (mg/generate loi-schema/loi)
       (assoc :status "active")


### PR DESCRIPTION
## What

Makes the long-dormant GDPR removal batch real, schedules it through the jobs system, and closes the one PII leak it couldn't reach (emails embedded in impersonation history events).

### 1. Nightly GDPR removal job (`184d47e7`)

`process-gdpr-removals!` had been a dry-run stub since it was written: the actual `gdpr-remove-user!` call was `#_`-commented out and nothing scheduled it. Now live and deliberately fenced in, since it is the only bulk-destructive operation in LIPAS:

- **Fail-closed eligibility** — a user whose check throws (nullable `created_at`, unparseable history dates) is skipped and reported in `:check-errors`, never removed
- **Cap of 50 removals per run** (`:limit` payload override available)
- **`:dry-run?` payload flag** reports what a live run would do, writes nothing
- **Per-user error isolation** — one failed removal doesn't stop the batch, but the batch then throws so the job system retries / dead-letters it visibly; reruns are idempotent (removed users get `@lipas.fi` emails, which the predicate excludes)

New `"gdpr-removals"` job type (slow lane, dedup key) + daily scheduler producer following the `help-kb-sync` pattern.

### 2. Impersonation history: ids only + scrub + no clock reset (`9a57e898`)

Impersonation events embedded the other party's **email** in the counterpart account's history row — exactly where `gdpr-remove-user!` (which only anonymizes the removed account's own row) could never reach it. Nothing consumed those fields (admin history table whitelists event + date columns; the banner/dev-tools emails come from the live JWT claim), so:

- events now record only account UUIDs, which degrade gracefully to the anonymized account after a removal
- migration `20260802130000` scrubs the emails already written (uses `jsonb_exists()` — JDBC eats the jsonb `?` operator as a bind placeholder)
- impersonation events are excluded from the inactivity deduction, so an admin impersonating a dormant account no longer resets its 5-year GDPR clock

## Testing

- New `lipas.backend.gdpr-test`: runs the batch for real against the test DB and asserts every ineligible account row is **byte-for-byte untouched** (stringified full-row fingerprints); covers cap + drain across runs, dry-run, double-run idempotency, and fault injection (mid-batch failure removes the healthy user, surfaces the failure)
- `gdpr-remove-user!` now has a test asserting it wipes exactly email/username/user-data and leaves permissions, `created_at` and the password hash alone
- Dispatcher/scheduler/handler tests cover queue wiring, payload validation, dedup and id-only events
- Migration verified against the dev DB's real impersonation events: 18 events with embedded emails → 0, all id references intact, unrelated events byte-identical
- `bb check` clean (zero warnings)

## Deploy notes

- A dev-DB (prod-like) dry run found **774 eligible users** — the nightly job drains that in ~16 days at 50/day. The first live batch fires on the worker's first startup tick after deploy; consider manually enqueueing a `{"dry-run?": true}` job on prod first to eyeball the count.
- The migration will do real scrubbing on prod (impersonation has been used by admins); it runs with the normal migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)