### PR TITLE
Localized sports site names in search results

### DIFF
--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -111,6 +111,11 @@
          :owner-org-id {:type "keyword"}
          :edit-grants {:type "keyword"}
          :name {:type "text" :fields {:keyword {:type "keyword"}}}  ; full-text search
+         ;; Queried by the UI as name-localized.*^3 — sub-fields must be
+         ;; indexed or Swedish/English names are unsearchable. The schema
+         ;; allows only :se and :en (Finnish lives in :name).
+         :name-localized.se {:type "text" :fields {:keyword {:type "keyword"}}}
+         :name-localized.en {:type "text" :fields {:keyword {:type "keyword"}}}
          :marketing-name {:type "text" :fields {:keyword {:type "keyword"}}}
          :comment {:type "text" :fields {:keyword {:type "keyword"}}}
          ;; Location fields that ARE QUERIED
@@ -187,7 +192,6 @@
          :reservations-link {:enabled false}
          :renovation-years {:enabled false}
          :renovations {:enabled false}
-         :name-localized {:enabled false}
          :fields {:enabled false}
          :locker-rooms {:enabled false}
          :circumstances {:enabled false}

--- a/webapp/src/clj/lipas/backend/search.clj
+++ b/webapp/src/clj/lipas/backend/search.clj
@@ -113,9 +113,10 @@
          :name {:type "text" :fields {:keyword {:type "keyword"}}}  ; full-text search
          ;; Queried by the UI as name-localized.*^3 — sub-fields must be
          ;; indexed or Swedish/English names are unsearchable. The schema
-         ;; allows only :se and :en (Finnish lives in :name).
-         :name-localized.se {:type "text" :fields {:keyword {:type "keyword"}}}
-         :name-localized.en {:type "text" :fields {:keyword {:type "keyword"}}}
+         ;; allows only :se and :en (Finnish lives in :name). Sortable in
+         ;; the results table, hence text-with-sort.
+         :name-localized.se (text-with-sort "sv")
+         :name-localized.en (text-with-sort "en")
          :marketing-name {:type "text" :fields {:keyword {:type "keyword"}}}
          :comment {:type "text" :fields {:keyword {:type "keyword"}}}
          ;; Location fields that ARE QUERIED

--- a/webapp/src/cljc/lipas/utils.cljc
+++ b/webapp/src/cljc/lipas/utils.cljc
@@ -257,3 +257,11 @@
         (not-empty (:fi m))
         (not-empty (:en m))
         (not-empty (:se m)))))
+
+(defn display-name
+  "Sports site name in `locale`, falling back to the mandatory Finnish
+  `:name` when a localized name doesn't exist. Unlike `localized` this
+  never falls back to another translation."
+  [site locale]
+  (or (not-empty (get-in site [:name-localized locale]))
+      (:name site)))

--- a/webapp/src/cljs/lipas/ui/map/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/map/subs.cljs
@@ -106,9 +106,11 @@
   ;; NOTE: This is JSON.parse result from the ajax call
   :<- [:lipas.ui.search.subs/search-results-fast]
   :<- [::editing-lipas-id]
-  (fn [[^js results lipas-id'] _]
+  :<- [:lipas.ui.subs/translator]
+  (fn [[^js results lipas-id' tr] _]
     (when results
-      (let [data (or (some-> results .-hits .-hits)
+      (let [locale-str (name (tr))
+            data (or (some-> results .-hits .-hits)
                      #js [])]
         (->> data
              (keep
@@ -129,7 +131,12 @@
                                                   (aget "features")))
                        type-code        (some-> obj (aget "type") (aget "type-code"))
                        lipas-id         (aget obj "lipas-id")
-                       name             (aget obj "name")
+                       ;; Localized name with mandatory Finnish :name as fallback
+                       name             (or (some-> obj
+                                                    (aget "name-localized")
+                                                    (aget locale-str)
+                                                    not-empty)
+                                            (aget obj "name"))
                        status           (aget obj "status")
                        travel-direction (aget obj "travel-direction")]
 

--- a/webapp/src/cljs/lipas/ui/search/events.cljs
+++ b/webapp/src/cljs/lipas/ui/search/events.cljs
@@ -147,6 +147,7 @@
                                  "status"
                                  "event-date"
                                  "name"
+                                 "name-localized"
                                  "marketing-name"
                                  "www"
                                  "phone-number"

--- a/webapp/src/cljs/lipas/ui/search/events.cljs
+++ b/webapp/src/cljs/lipas/ui/search/events.cljs
@@ -20,6 +20,8 @@
   (case k
     (:lipas-id) :lipas-id
     (:name) :search-meta.name.sort
+    (:name-localized.se
+      :name-localized.en) (-> k name (str ".sort") keyword)
     (:location.city.name
       :type.name
       :admin.name
@@ -564,7 +566,8 @@
   (-> kw name (str/split #"\.") (->> (mapv keyword))))
 
 (def data-keys
-  [:name :marketing-name :www :phone-numer :email :owner :admin :type.type-code
+  [:name :name-localized.se :name-localized.en :marketing-name :www
+   :phone-number :email :owner :admin :type.type-code
    :renovation-years :construction-year :location.address :location.postal-code
    :location.postal-office :location.city.city-code])
 

--- a/webapp/src/cljs/lipas/ui/search/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/search/subs.cljs
@@ -117,6 +117,9 @@
     {:lipas-id (-> site :lipas-id)
      :score (-> hit :_score)
      :name (-> site :name)
+     :name-localized.se (-> site :name-localized :se)
+     :name-localized.en (-> site :name-localized :en)
+     :marketing-name (-> site :marketing-name)
      :event-date (-> site :event-date utils/->short-date)
      :admin (-> site :admin)
      :owner (-> site :owner)
@@ -198,6 +201,9 @@
   :<- [:lipas.ui.subs/translator]
   (fn [tr _]
     [[:name {:label (tr :lipas.sports-site/name)}]
+     [:name-localized.se {:label (tr :lipas.sports-site/name-localized-se)}]
+     [:name-localized.en {:label (tr :lipas.sports-site/name-localized-en)}]
+     [:marketing-name {:label (tr :lipas.sports-site/marketing-name)}]
      [:type.name {:label (tr :type/name)}]
      [:type.main-category {:label (tr :type/main-category)}]
      [:type.sub-category {:label (tr :type/sub-category)}]
@@ -228,6 +234,9 @@
      :construction-year {:spec sports-sites-schema/construction-year}
      :renovation-years {:spec sports-sites-schema/renovation-years}
      :name {:spec sports-sites-schema/name :required? true}
+     ;; Same constraints as the site form uses for localized names
+     :name-localized.se {:spec sports-sites-schema/name}
+     :name-localized.en {:spec sports-sites-schema/name}
      :location.postal-office {:spec location-schema/postal-office}
      :location.postal-code {:spec location-schema/postal-code :required? true}
      :marketing-name {:spec sports-sites-schema/marketing-name}
@@ -244,6 +253,10 @@
       [[:score {:label "score"}]
        [:name {:label (tr :lipas.sports-site/name)
                :form {:component text-fields/text-field}}]
+       [:name-localized.se {:label (tr :lipas.sports-site/name-localized-se)
+                            :form {:component text-fields/text-field}}]
+       [:name-localized.en {:label (tr :lipas.sports-site/name-localized-en)
+                            :form {:component text-fields/text-field}}]
        [:marketing-name {:label (tr :lipas.sports-site/marketing-name)
                          :form {:component text-fields/text-field}}]
        [:type.name {:label (tr :type/name)

--- a/webapp/src/cljs/lipas/ui/search/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/search/subs.cljs
@@ -6,6 +6,7 @@
             [lipas.ui.components.text-fields :as text-fields]
             [lipas.ui.search.db :as db]
             [lipas.ui.utils :as utils]
+            [lipas.utils :as cutils]
             [re-frame.core :as rf]))
 
 (rf/reg-sub ::filters
@@ -170,7 +171,7 @@
         city-code (-> site :location :city :city-code)]
     {:lipas-id (-> site :lipas-id)
      :score (-> hit :_score)
-     :name (-> site :name)
+     :name (cutils/display-name site locale)
      :type.type-code type-code
      :type.name (get-in types [type-code :name locale])
      :location.city.city-code city-code

--- a/webapp/test/clj/lipas/backend/search_mapping_test.clj
+++ b/webapp/test/clj/lipas/backend/search_mapping_test.clj
@@ -106,6 +106,11 @@
 
       (is (= "text" (:type (get properties :name-localized.se))))
       (is (= "text" (:type (get properties :name-localized.en))))
+      (is (= "icu_collation_keyword"
+             (get-in properties [:name-localized.se :fields :sort :type]))
+          "results table sorts on the collated sub-field")
+      (is (= "icu_collation_keyword"
+             (get-in properties [:name-localized.en :fields :sort :type])))
       (is (nil? (get properties :name-localized)))))
 
   (testing "Disabled fields prevent index bloat"

--- a/webapp/test/clj/lipas/backend/search_mapping_test.clj
+++ b/webapp/test/clj/lipas/backend/search_mapping_test.clj
@@ -98,6 +98,16 @@
       (is (= "integer" (:type (get properties :location.city.city-code))))
       (is (= "integer" (:type (get properties :construction-year))))))
 
+  (testing "Localized names are indexed"
+    ;; The UI queries name-localized.*^3 — if these regress to
+    ;; {:enabled false}, Swedish/English names silently stop matching.
+    (let [mapping (:sports-site search/mappings)
+          properties (get-in mapping [:mappings :properties])]
+
+      (is (= "text" (:type (get properties :name-localized.se))))
+      (is (= "text" (:type (get properties :name-localized.en))))
+      (is (nil? (get properties :name-localized)))))
+
   (testing "Disabled fields prevent index bloat"
     (let [mapping (:sports-site search/mappings)
           properties (get-in mapping [:mappings :properties])]


### PR DESCRIPTION
## Summary

Sports site names in search results now follow the user's selected locale. Swedish/English speakers previously had no way to see (or even find) sites by their localized names, which pushed them to "abuse" the mandatory Finnish `:name` field by writing the Swedish name there.

- **Results list & map hover popup** show `name-localized.<locale>`, falling back to the Finnish `:name` when no translation exists (new `lipas.utils/display-name` helper; deliberately no cross-language fallback, so Finnish users never see a borrowed Swedish name).
- **ES mapping fix:** the UI has always queried `name-localized.*^3`, but the field was mapped `{:enabled false}` — localized names were silently unsearchable. `name-localized.se/en` are now indexed as text with locale-collated `.sort` sub-fields, so e.g. searching "Stora Fagerö friluftsområde" finds the site whose Finnish name is "Stora Fagerön virkistysalue".
- **Results table:** "Namn på svenska" / "Namn på engelska" are now selectable, quick-editable and sortable columns. The main name column intentionally stays the official Finnish `:name` (its Swedish label already reads "Namn på finska"), because quick-edit saves that column back to `:name` — and reports already expose the localized names as separate columns. Editable columns give Swedish-speaking maintainers a proper place to put Swedish names, draining the abuse pattern instead of just hiding it.

Adjacent pre-existing bugs fixed along the way:
- `:marketing-name` had an editable table header but was missing from the column selector and row data — the column was unselectable and would have rendered empty.
- A `:phone-numer` typo in the quick-edit save whitelist meant phone-number edits in the results table were silently dropped on save.

## Deploy note

⚠️ **Requires a full search reindex** after deploy — the mapping change (`name-localized` from `enabled: false` to indexed) only applies to reindexed documents.

## Test plan

- [x] Mapping regression tests: `name-localized.se/en` indexed as text with `icu_collation_keyword` sort sub-fields, no top-level disabled mapping (246 assertions green)
- [x] `bb check` (cljfmt + clj-kondo strict) passes; frontend compiles with no warnings
- [x] Browser-verified on local dev: Swedish UI shows "Onas friluftsområden" in list and "Infotavla" in hover popup; Finnish UI shows "Onas virkistysalue" (fallback)
- [x] Search by Swedish-only name returns the right site through the real UI query
- [x] Table quick-edit of a Swedish name persists correctly (deep-merge preserves sibling `:en`, Finnish `:name` untouched) and column sort returns collated order

🤖 Generated with [Claude Code](https://claude.com/claude-code)