### PR TITLE
Replace togpx with own GPX export, dropping GPL-licensed jxon

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -42,7 +42,6 @@
         "react-window": "^2.2.7",
         "recharts": "^3.0.0",
         "shpjs": "^6.1.0",
-        "togpx": "^0.5.4",
         "zipcelx": "^1.6.2"
       },
       "devDependencies": {
@@ -1314,24 +1313,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bops": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
-      "integrity": "sha512-EWD8/Ei9o/h/wmR3w/YL/8dGKe4rSFHlaO8VNNcuXnjXjeTgxdcmhjPf9hRCYlqTrBPZbKaht+FxZKahcob5UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
-      }
-    },
-    "node_modules/bops/node_modules/base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha512-Pj9L87dCdGcKlSqPVUjD+q96pbIx1zQQLb2CUiWURfjiBELv84YX+0nGnKmyT/9KkC7PQk7UN1w+Al8bBozaxQ==",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -2593,25 +2574,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/jxon": {
-      "version": "2.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/jxon/-/jxon-2.0.0-beta.5.tgz",
-      "integrity": "sha512-Ot7muZ0v2cmgQ1k+e6bpNcz6E3q2zHssvzYubbKTk5nIEvBLqJfiS6/uivU2ujqKZQlORcjKqcyx6D9X6BEAkQ==",
-      "license": "GPL v3",
-      "dependencies": {
-        "xmldom": "^0.1.21"
-      }
-    },
-    "node_modules/jxon/node_modules/xmldom": {
-      "name": "@xmldom/xmldom",
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
@@ -3387,15 +3349,6 @@
       "license": "MIT",
       "dependencies": {
         "quickselect": "^3.0.0"
-      }
-    },
-    "node_modules/optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "wordwrap": "~0.0.2"
       }
     },
     "node_modules/pako": {
@@ -4266,54 +4219,11 @@
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
     },
-    "node_modules/to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==",
-      "license": "MIT"
-    },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
-    },
-    "node_modules/togpx": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/togpx/-/togpx-0.5.4.tgz",
-      "integrity": "sha512-1LY9ZjBrCYbcWfD63ZaqRw53U0tkigGC9fOdhRaTZH6yrmhlQGbbsEVTyCFzagvbPO36sZuBz0SrEQ+paaCPiw==",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "~1.0.1",
-        "jxon": "~2.0.0-beta.5",
-        "optimist": "~0.3.5",
-        "xmldom": "~0.1.17"
-      },
-      "bin": {
-        "togpx": "togpx"
-      }
-    },
-    "node_modules/togpx/node_modules/concat-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.0.1.tgz",
-      "integrity": "sha512-nAHFsgeRVVvZ+aB3S1gLeN73fQ+tdOcw075BHbXMbC6MY0h6nqAkEeqPVCw8kRuDJJZDvaUjxI4jZv2FD0Tl8A==",
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "license": "BSD",
-      "dependencies": {
-        "bops": "0.0.6"
-      }
-    },
-    "node_modules/togpx/node_modules/xmldom": {
-      "name": "@xmldom/xmldom",
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -4598,15 +4508,6 @@
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
       "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
       "license": "MIT"
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/ws": {
       "version": "8.21.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -49,7 +49,6 @@
     "react-window": "^2.2.7",
     "recharts": "^3.0.0",
     "shpjs": "^6.1.0",
-    "togpx": "^0.5.4",
     "zipcelx": "^1.6.2"
   },
   "devDependencies": {

--- a/webapp/src/cljc/lipas/gpx.cljc
+++ b/webapp/src/cljc/lipas/gpx.cljc
@@ -1,0 +1,103 @@
+(ns lipas.gpx
+  "GeoJSON → GPX 1.1 conversion. Replaces the `togpx` npm package, whose
+  transitive dependency `jxon` is GPL-3.0 licensed and therefore
+  incompatible with distributing the frontend bundle under MIT."
+  (:require [clojure.string :as str]))
+
+(defn- xml-escape [x]
+  (-> (str x)
+      (str/replace "&" "&amp;")
+      (str/replace "<" "&lt;")
+      (str/replace ">" "&gt;")
+      (str/replace "\"" "&quot;")))
+
+(defn- emit-xml
+  "Serializes a hiccup-style node [tag attrs? & children] to an XML string.
+  Children are nodes or text; text is escaped here."
+  [[tag & more]]
+  (let [[attrs children] (if (map? (first more))
+                           [(first more) (rest more)]
+                           [nil more])
+        attrs-str (apply str (for [[k v] attrs]
+                               (str " " k "=\"" (xml-escape v) "\"")))]
+    (if (seq children)
+      (str "<" tag attrs-str ">"
+           (apply str (map #(if (vector? %) (emit-xml %) (xml-escape %)) children))
+           "</" tag ">")
+      (str "<" tag attrs-str "/>"))))
+
+(defn- feature-name [props]
+  (let [title (or (:name props) (:ref props) (:id props))]
+    (when (and (some? title) (not= "" title))
+      (str title))))
+
+(defn- feature-desc [props]
+  (let [desc (->> props
+                  (remove (fn [[_ v]] (or (nil? v) (coll? v))))
+                  (map (fn [[k v]] (str (name k) "=" v)))
+                  (str/join "\n"))]
+    (not-empty desc)))
+
+(defn- name-desc-elems [props]
+  (cond-> []
+    (feature-name props) (conj ["name" (feature-name props)])
+    (feature-desc props) (conj ["desc" (feature-desc props)])))
+
+(defn- wpt [props [lon lat ele]]
+  (into ["wpt" {"lat" lat "lon" lon}]
+        (concat
+          (when (some? ele) [["ele" ele]])
+          (name-desc-elems props))))
+
+(defn- trkpt [[lon lat ele]]
+  (cond-> ["trkpt" {"lat" lat "lon" lon}]
+    (some? ele) (conj ["ele" ele])))
+
+(defn- trkseg [coords]
+  (into ["trkseg"] (map trkpt coords)))
+
+(defn- trk
+  "One GPX trk from a seq of coordinate seqs (one trkseg each)."
+  [props segs]
+  (into ["trk"]
+        (concat (name-desc-elems props)
+                (map trkseg segs))))
+
+(defn- feature->elems
+  "Returns {:wpts [...] :trks [...]} of hiccup nodes for one GeoJSON feature.
+  Points become waypoints; lines and polygon rings become track segments."
+  [{:keys [geometry properties]}]
+  (let [{:keys [type coordinates geometries]} geometry]
+    (case type
+      "Point"           {:wpts [(wpt properties coordinates)]}
+      "MultiPoint"      {:wpts (mapv (partial wpt properties) coordinates)}
+      "LineString"      {:trks [(trk properties [coordinates])]}
+      "MultiLineString" {:trks [(trk properties coordinates)]}
+      "Polygon"         {:trks [(trk properties coordinates)]}
+      "MultiPolygon"    {:trks [(trk properties (apply concat coordinates))]}
+      "GeometryCollection"
+      (apply merge-with into {:wpts [] :trks []}
+             (map #(feature->elems {:geometry % :properties properties})
+                  geometries))
+      {})))
+
+(defn geojson->gpx
+  "Converts GeoJSON (Clojure data, keyword keys) to a GPX 1.1 XML string.
+  Accepts a FeatureCollection, a Feature or a bare geometry. A third
+  coordinate, when present, is written as elevation."
+  ([geojson] (geojson->gpx geojson {}))
+  ([geojson {:keys [creator] :or {creator "LIPAS"}}]
+   (let [features (case (:type geojson)
+                    "FeatureCollection" (:features geojson)
+                    "Feature"           [geojson]
+                    [{:type "Feature" :properties {} :geometry geojson}])
+         {:keys [wpts trks]} (apply merge-with into {:wpts [] :trks []}
+                                    (map feature->elems features))]
+     (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+          (emit-xml
+            (into ["gpx" {"xmlns"              "http://www.topografix.com/GPX/1/1"
+                          "xmlns:xsi"          "http://www.w3.org/2001/XMLSchema-instance"
+                          "xsi:schemaLocation" "http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+                          "version"            "1.1"
+                          "creator"            creator}]
+                  (concat wpts trks)))))))

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -637,7 +637,7 @@
           site (get-in db [:sports-sites lipas-id :history latest])
           data {:site site
                 :cities (-> db :cities)
-                :types (-> db :types)
+                :types (get-in db [:sports-sites :types])
                 :locale locale}
           fname (gstring/urlEncode (str (:name site) ".gpx"))
           xml-str (-> site :location :geometries

--- a/webapp/src/cljs/lipas/ui/map/events.cljs
+++ b/webapp/src/cljs/lipas/ui/map/events.cljs
@@ -1,10 +1,10 @@
 (ns lipas.ui.map.events
   (:require ["@turf/simplify$default" :as turf-simplify]
             ["ol/proj" :as proj]
-            ["togpx" :as togpx]
             [ajax.core :as ajax]
             [goog.string :as gstring]
             [goog.string.format]
+            [lipas.gpx :as gpx]
             [lipas.ui.map.hooks :as hooks]
             [lipas.ui.map.utils :as map-utils]
             [lipas.ui.utils :refer [==>] :as utils]
@@ -642,8 +642,7 @@
           fname (gstring/urlEncode (str (:name site) ".gpx"))
           xml-str (-> site :location :geometries
                       (update :features #(mapv (partial add-gpx-props data) %))
-                      clj->js
-                      (togpx #js {:creator "LIPAS"}))]
+                      (gpx/geojson->gpx {:creator "LIPAS"}))]
       {:lipas.ui.effects/save-as! {:blob (js/Blob. #js [xml-str])
                                    :filename fname}})))
 

--- a/webapp/test/clj/lipas/gpx_test.clj
+++ b/webapp/test/clj/lipas/gpx_test.clj
@@ -1,0 +1,119 @@
+(ns lipas.gpx-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.xml :as xml]
+            [lipas.gpx :as gpx])
+  (:import [java.io ByteArrayInputStream]))
+
+(defn- parse [^String s]
+  (xml/parse (ByteArrayInputStream. (.getBytes s "UTF-8"))))
+
+(defn- children [node tag]
+  (filter #(= tag (:tag %)) (:content node)))
+
+(defn- child [node tag]
+  (first (children node tag)))
+
+(defn- text [node]
+  (apply str (:content node)))
+
+(def route-fcoll
+  {:type "FeatureCollection"
+   :features
+   [{:type "Feature"
+     :properties {:name "Ähtärin \"kunto\" & <polku>"
+                  :type "Kuntorata"
+                  :city "Ähtäri"}
+     :geometry {:type "LineString"
+                :coordinates [[25.1 62.5 101.2]
+                              [25.2 62.6 103.0]]}}]})
+
+(deftest linestring-test
+  (let [s (gpx/geojson->gpx route-fcoll)
+        doc (parse s)]
+    (testing "document root"
+      (is (.startsWith ^String s "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
+      (is (= :gpx (:tag doc)))
+      (is (= "1.1" (-> doc :attrs :version)))
+      (is (= "LIPAS" (-> doc :attrs :creator)))
+      (is (= "http://www.topografix.com/GPX/1/1" (-> doc :attrs :xmlns))))
+    (testing "track structure"
+      (let [trk (child doc :trk)
+            seg (child trk :trkseg)
+            pts (children seg :trkpt)]
+        (is (some? trk))
+        (is (= 1 (count (children trk :trkseg))))
+        (is (= 2 (count pts)))
+        (testing "GeoJSON [lon lat ele] maps to lat/lon attrs + ele child"
+          (is (= "62.5" (-> pts first :attrs :lat)))
+          (is (= "25.1" (-> pts first :attrs :lon)))
+          (is (= "101.2" (text (child (first pts) :ele)))))))
+    (testing "name is escaped and round-trips"
+      (is (= "Ähtärin \"kunto\" & <polku>"
+             (text (child (child doc :trk) :name)))))
+    (testing "desc concatenates scalar props as k=v lines"
+      (is (= "name=Ähtärin \"kunto\" & <polku>\ntype=Kuntorata\ncity=Ähtäri"
+             (text (child (child doc :trk) :desc)))))))
+
+(deftest point-test
+  (let [doc (parse (gpx/geojson->gpx
+                     {:type "Feature"
+                      :properties {:name "Kenttä"}
+                      :geometry {:type "Point"
+                                 :coordinates [24.94 60.17 8.0]}}))
+        wpt (child doc :wpt)]
+    (is (some? wpt))
+    (is (= "60.17" (-> wpt :attrs :lat)))
+    (is (= "24.94" (-> wpt :attrs :lon)))
+    (testing "ele comes before name per GPX 1.1 schema order"
+      (is (= [:ele :name :desc] (mapv :tag (:content wpt)))))
+    (is (= "8.0" (text (child wpt :ele))))
+    (is (= "Kenttä" (text (child wpt :name))))))
+
+(deftest polygon-test
+  (testing "each ring becomes its own trkseg"
+    (let [doc (parse (gpx/geojson->gpx
+                       {:type "Feature"
+                        :properties {}
+                        :geometry {:type "Polygon"
+                                   :coordinates
+                                   [[[25.0 62.0] [25.1 62.0] [25.1 62.1] [25.0 62.0]]
+                                    [[25.02 62.02] [25.04 62.02] [25.04 62.04] [25.02 62.02]]]}}))
+          trk (child doc :trk)]
+      (is (= 1 (count (children doc :trk))))
+      (is (= 2 (count (children trk :trkseg))))
+      (testing "no name/desc elements when props are empty"
+        (is (empty? (children trk :name)))
+        (is (empty? (children trk :desc)))))))
+
+(deftest multi-geometry-test
+  (testing "MultiLineString becomes one trk with a trkseg per line"
+    (let [doc (parse (gpx/geojson->gpx
+                       {:type "MultiLineString"
+                        :coordinates [[[25.0 62.0] [25.1 62.1]]
+                                      [[26.0 63.0] [26.1 63.1]]]}))]
+      (is (= 1 (count (children doc :trk))))
+      (is (= 2 (count (children (child doc :trk) :trkseg))))))
+  (testing "GeometryCollection emits both wpts and trks"
+    (let [doc (parse (gpx/geojson->gpx
+                       {:type "Feature"
+                        :properties {:name "Monigeometria"}
+                        :geometry {:type "GeometryCollection"
+                                   :geometries
+                                   [{:type "Point" :coordinates [25.0 62.0]}
+                                    {:type "LineString"
+                                     :coordinates [[25.0 62.0] [25.1 62.1]]}]}}))]
+      (is (= 1 (count (children doc :wpt))))
+      (is (= 1 (count (children doc :trk)))))))
+
+(deftest options-test
+  (testing "creator option"
+    (is (= "Custom" (-> (parse (gpx/geojson->gpx
+                                 {:type "Point" :coordinates [25.0 62.0]}
+                                 {:creator "Custom"}))
+                        :attrs :creator))))
+  (testing "nil and collection props are dropped from desc"
+    (let [doc (parse (gpx/geojson->gpx
+                       {:type "Feature"
+                        :properties {:name "X" :type nil :tags ["a" "b"]}
+                        :geometry {:type "Point" :coordinates [25.0 62.0]}}))]
+      (is (= "name=X" (text (child (child doc :wpt) :desc)))))))


### PR DESCRIPTION
## Summary

License audit flagged `jxon@2.0.0-beta.5` (**GPL v3**), pulled in transitively by `togpx@0.5.4` and shipped in the `map.js` browser bundle — incompatible with distributing LIPAS under the MIT license.

togpx was used in exactly one place (the `::download-gpx` event), so this PR:

- Adds `lipas.gpx` (~100-line cljc namespace): GeoJSON → GPX 1.1 conversion with the same semantics as togpx — points → `wpt`, lines/polygon rings → `trk`/`trkseg`, third coordinate → `<ele>`, name + `k=v` description from properties
- Switches `::download-gpx` to it and removes `togpx` from package.json — `jxon` is gone from the dependency tree entirely
- Fixes a pre-existing bug found while validating output: the `type=` line was silently missing from every exported GPX `desc`, because the event read types from `(-> db :types)` which doesn't exist (types live at `[:sports-sites :types]`)

Small intentional improvements over togpx: output has a proper `<?xml … encoding="UTF-8"?>` declaration, and waypoints emit `<ele>` before `<name>`/`<desc>` as the GPX 1.1 XSD requires (togpx violated the schema ordering).

## Verification

- New JVM test suite `lipas.gpx-test` (5 tests, 29 assertions): escaping, elevation, all geometry types, GeometryCollection, options
- **Parity check against togpx itself**: both implementations run on the same fixture (route with elevations, point, polygon, Finnish + XML-special chars), outputs parsed and compared structurally → identical
- Real files exported from the UI (5 route sites incl. multi-segment and ~2000-point tracks) validate against the official GPX 1.1 XSD (`xmllint --schema`) and read cleanly with GDAL (`ogrinfo`): correct counts, extents, names, elevations
- ClojureScript release compile clean, zero clj-kondo warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)