### PR TITLE
fix: ::user-data returns nil when logged out

### DIFF
--- a/webapp/src/cljs/lipas/ui/user/subs.cljs
+++ b/webapp/src/cljs/lipas/ui/user/subs.cljs
@@ -17,12 +17,13 @@
   :<- [::user]
   :<- [::dev-overrides]
   (fn [[user overrides] _]
-    (assoc (:login user) :dev/overrides overrides)))
-
-(defn user-data
-  "Same as ::user-data, but for use in effects"
-  [db]
-  (assoc (:login (:user db)) :dev/overrides (:lipas.ui.project-devtools/privilege-override db)))
+    ;; nil when logged out. Guard the assoc: `(assoc nil :dev/overrides nil)`
+    ;; returns a truthy `{:dev/overrides nil}`, which made every
+    ;; `(when user ...)` check on this sub fire for anonymous visitors too.
+    ;; `roles/check-privilege` reads nil as the :default role, which is what
+    ;; an anonymous visitor should get.
+    (when-let [login (:login user)]
+      (assoc login :dev/overrides overrides))))
 
 (rf/reg-sub ::permission-to-cities
   :<- [::user-data]


### PR DESCRIPTION
Follow-up to #(commit `4eead14c` on master), which fixed the newsletter signup form. This removes the underlying trap that caused it.

## The problem

`::user-data` built its result with `(assoc (:login user) :dev/overrides overrides)`. For a logged-out visitor `(:login user)` is `nil`, and `(assoc nil :dev/overrides nil)` yields a truthy `{:dev/overrides nil}`.

So the sub could never signal "no user". Any `(when user ...)` check on it fired for anonymous visitors — which is what killed the newsletter email field for everyone.

### How it got here

Introduced in `bcb6e9a8` "Apply dev override privileges always" (2024-10-11). Before that commit the sub was `(:login user)`, correctly nil:

```diff
-(fn [user _]
-  (:login user)))
+(fn [[user overrides] _]
+  (assoc (:login user) :dev/overrides overrides)))
```

The commit's goal was moving dev-override handling out of `::check-privilege` and into `::user-data` so overrides apply everywhere. The truthiness change was invisible collateral of `assoc`-ing onto a possibly-nil value.

The newsletter form therefore broke in two stages: the `(when user ...)` guard was written in 2022 (`e08fdd81`), when it was correct, and was invalidated remotely 2.5 years later. The call site had no way to know — which is the argument for fixing the sub rather than hardening call sites.

## The change

```clj
(when-let [login (:login user)]
  (assoc login :dev/overrides overrides))
```

Fixing the sub was preferred over adding explicit `::logged-in?` checks because:

- It removes the trap at the source. Otherwise every future call site has to know this one sub lies about emptiness, and `(when user ...)` — which is what everyone will naturally write — stays wrong.
- All 14 consumers are already nil-tolerant. They either pass the value to `roles/check-privilege`, which reads `nil` as the `:default` role (exactly right for an anonymous visitor), or read a key off it.
- `::logged-in?` carries a TODO saying checks should go through `check-privilege`, which "indirectly also handles if the user is logged in". More `logged-in?` checks would push against that.

Also drops the `user-data` function below the sub ("same as `::user-data`, but for use in effects"). It carried an identical copy of the bug and has no callers anywhere in the repo.

## Behaviour change worth a look

Dev privilege overrides no longer apply while logged out. `project-devtools/start!` mounts regardless of login on localhost, so a logged-out developer toggling an override now gets silence instead of an effect.

My read is that this state isn't worth supporting — overrides on an anonymous session only fake the UI, and the backend rejects the requests anyway. Easy to reverse if you disagree:

```clj
(when (or (:login user) (seq overrides))
  (assoc (:login user) :dev/overrides overrides))
```

## Verification

Browser-tested anonymous vs. a city-manager account (Liminka, 425), since the risk here is privilege gating shifting across the nil boundary:

| | anonymous | city-manager |
|---|---|---|
| add-site button on map | hidden | shown |
| newsletter field | empty, typeable | prefilled with account email |

A `Cannot read properties of null (reading 'canvas')` error appears on the map route, but it reproduces on master too (headless `--disable-gpu` + OpenLayers), so it is not from this change.

`clj-kondo` clean, build completes with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)