### PR TITLE
Mask personal data in org management by viewer role

### DIFF
--- a/webapp/src/clj/lipas/backend/auth.clj
+++ b/webapp/src/clj/lipas/backend/auth.clj
@@ -9,19 +9,10 @@
     [lipas.backend.org :as org]
     [lipas.roles :as roles]))
 
-(defn enrich-org-roles
-  "Project the user's org-derived roles and merge them into the user's roles.
-  Both existing and derived roles are conformed to the same (keyword/set) shape
-  and deduped, so a legacy account org role and its derived twin collapse.
-  Derived roles live only in the resulting token — never persisted."
-  [db user]
-  (update-in user [:permissions :roles]
-             (fn [roles]
-               (->> (org/derive-user-org-roles db (:id user))
-                    (concat roles)
-                    roles/conform-roles
-                    distinct
-                    vec))))
+(def enrich-org-roles
+  "See `lipas.backend.org/enrich-org-roles`. Kept as an alias because this is
+  the name every existing caller uses."
+  org/enrich-org-roles)
 
 (defn active?
   "Whether this account may still hold a session.

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1151,6 +1151,40 @@
           uid [(assoc org :members [{:user-id uid :roles [(name template-key)]}])])
         roles/conform-roles)))
 
+(defn site-pii-tier
+  "How much of another person's identity this viewer may see on a given site.
+
+  The org-management PII rule (PM + LIPAS, 2026-09-07): org admins and LIPAS
+  admins see full email addresses; plain org members see them masked. \"Org\"
+  here means an org tied to THIS site — its owner org or an org it has granted
+  edit to — which is exactly the `:org-id` set `roles/site-roles-context`
+  builds, matched by the usual set-intersection.
+
+  - `:full`   `:users/manage` (LIPAS admin), or `:org/manage` on a related org
+  - `:masked` `:org/member` on a related org, or anyone who can edit the site
+              themselves. The second clause is deliberate: a site can be
+              editable through a role-template catalog or a legacy direct
+              permission WITHOUT having an owner org at all (owner-org-id nil,
+              no grants), and such sites do show up in the Kohteet tab. Without
+              it those rows would silently lose every person entry for the very
+              people maintaining them.
+  - `:none`   everyone else. These endpoints are `:require-privilege nil`, so
+              this covers any authenticated LIPAS user asking about any site;
+              they are outside the PM rule and get the most conservative
+              treatment each surface can offer."
+  [user site]
+  (let [rc      (roles/site-roles-context site)
+        org-ids (:org-id rc)
+        in-org? (fn [privilege]
+                  (and (seq org-ids)
+                       (roles/check-privilege user {:org-id org-ids} privilege)))]
+    (cond
+      (roles/check-privilege user {} :users/manage)       :full
+      (in-org? :org/manage)                               :full
+      (in-org? :org/member)                               :masked
+      (roles/check-privilege user rc :site/create-edit)    :masked
+      :else                                               :none)))
+
 (defn site-editors
   "\"Who can edit site Z\" (Q2, design-spec §6): owner org + grantee orgs (off
   the site document) ∪ orgs whose role-template catalog grants editing on this
@@ -1159,9 +1193,17 @@
   roles/check-privilege in this site's context (F16) — so catalog
   city/type/site-manager grants are found, and city/type-scoped templates
   are only listed for matching sites. Legacy direct-user scan is the honest
-  unindexed caveat — deferred."
-  [db lipas-id]
+  unindexed caveat — deferred.
+
+  Person entries (the two legacy-user lists) are rendered at `viewer`'s
+  `site-pii-tier`: full email, masked email, or dropped entirely. `:username`
+  is NOT returned any more — it is an email address for ~25% of accounts, so
+  shipping it alongside a masked `:email` would have handed back the very
+  identifier the mask removes. Org entries are organisation names, not personal
+  data, and are unaffected."
+  [db lipas-id viewer]
   (let [site         (get-sports-site db lipas-id)
+        pii          (site-pii-tier viewer site)
         owner-org-id (some-> site :owner-org-id str)
         grant-ids    (->> (:edit-grants site) (map str) set)
         orgs         (orgs-relevant-to-site db (cons owner-org-id grant-ids))
@@ -1205,16 +1247,18 @@
                                      :lipas-id   (:lipas-id rc)
                                      :activities (:activity rc)})
                                (remove (fn [u] (roles/check-role u :admin))))
+        person       (fn [u] (when-let [e (org/apply-pii-tier pii (:email u))]
+                               {:email e}))
         legacy-users (->> legacy-candidates
                           (filter (fn [u] (roles/check-privilege u rc :site/create-edit)))
-                          (mapv (fn [u] {:email (:email u) :username (:username u)})))
+                          (into [] (keep person)))
         ;; Direct activity-only users: may edit the site's UTP data but not the
         ;; site itself — listed separately so the drawer tags them with the
         ;; same Aktiviteetti label as activity-editor orgs.
         legacy-activity-users (->> legacy-candidates
                                    (remove (fn [u] (roles/check-privilege u rc :site/create-edit)))
                                    (filter (fn [u] (roles/check-privilege u rc :activity/edit)))
-                                   (mapv (fn [u] {:email (:email u) :username (:username u)})))]
+                                   (into [] (keep person)))]
     {:owner-org             owner-org
      :grantee-orgs          (vec grantee-orgs)
      :catalog-editor-orgs   (vec catalog-editor-orgs)
@@ -1227,31 +1271,39 @@
   Reads only event-date/author-id/status — no documents — so it stays light
   even for long-lived sites.
 
-  Two payload modes, branched on `:emails?` (the route gates it on
-  :users/manage), so the FE can branch on which key is present:
-  - :emails? true  → rows {:event-date :status :author} where :author is the
-    editor's email (lipas-admin person view)
-  - otherwise      → rows {:event-date :status :author-role} where
-    :author-role ∈ \"admin\"/\"municipality\"/\"organization\"/\"other\" — a
-    coarse role label, NO person identifier (GDPR, F38; supersedes the F5
-    username mode for this endpoint). The label reflects the author's CURRENT
-    permissions/org membership, not role-at-edit-time (not stored)."
-  ([db lipas-id] (site-edit-history db lipas-id {}))
-  ([db lipas-id {:keys [emails?]}]
-   (let [rows       (db/get-sports-site-edit-history db lipas-id)
+  Three payload modes, branched on `viewer`'s `site-pii-tier`, so the FE can
+  branch on which key is present:
+  - `:full`   → rows {:event-date :status :author} where :author is the
+    editor's email. LIPAS admins and org admins of a related org.
+  - `:masked` → the same {:author} shape, masked (`org/mask-email`). Plain org
+    members and other editors of the site (PM rule, 2026-09-07).
+  - `:none`   → rows {:event-date :status :author-role} where :author-role ∈
+    \"admin\"/\"municipality\"/\"organization\"/\"other\" — a coarse role label, NO
+    person identifier (GDPR, F38; supersedes the F5 username mode). This route
+    is `:require-privilege nil`, so an authenticated user with no relationship
+    to the site still learns nothing about individuals. The label reflects the
+    author's CURRENT permissions/org membership, not role-at-edit-time (not
+    stored).
+
+  Needs the site document (one extra read) only to resolve the viewer's tier;
+  the history rows themselves still carry no documents."
+  ([db lipas-id] (site-edit-history db lipas-id nil))
+  ([db lipas-id viewer]
+   (let [pii        (site-pii-tier viewer (get-sports-site db lipas-id))
+         rows       (db/get-sports-site-edit-history db lipas-id)
          author-ids (map :author_id rows)]
-     (if emails?
-       (let [names (org/resolve-account-names db author-ids true)]
-         (mapv (fn [r]
-                 {:event-date (str (:event_date r))
-                  :status     (:status r)
-                  :author     (get names (str (:author_id r)))})
-               rows))
+     (if (= :none pii)
        (let [labels (org/resolve-author-role-labels db author-ids)]
          (mapv (fn [r]
                  {:event-date  (str (:event_date r))
                   :status      (:status r)
                   :author-role (get labels (str (:author_id r)) "other")})
+               rows))
+       (let [names (org/resolve-account-names db author-ids true)]
+         (mapv (fn [r]
+                 {:event-date (str (:event_date r))
+                  :status     (:status r)
+                  :author     (org/apply-pii-tier pii (get names (str (:author_id r))))})
                rows))))))
 
 (defn search-fields

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -279,11 +279,17 @@
                      {:impersonator-id (str (:id admin))})
     (add-user-event! db admin "impersonated-user"
                      {:target-id (str (:id target))})
-    (merge (dissoc target :password)
-           {:token (jwt/create-token target
-                                     :valid-seconds impersonation-token-valid-seconds
-                                     :extra-claims {:impersonator impersonator})
-            :impersonator impersonator})))
+    ;; Same projection login and refresh apply (org/enrich-org-roles): org
+    ;; membership confers NO stored role, so a token minted from the raw
+    ;; account silently lacks :org/member and :org/manage. An impersonated org
+    ;; member would read as belonging to no organization at all — org endpoints
+    ;; 403, and the org UI does not render.
+    (let [target (org/enrich-org-roles db target)]
+      (merge (dissoc target :password)
+             {:token (jwt/create-token target
+                                       :valid-seconds impersonation-token-valid-seconds
+                                       :extra-claims {:impersonator impersonator})
+              :impersonator impersonator}))))
 
 ;;; Reminders ;;;
 

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1162,7 +1162,10 @@
 
   - `:full`   `:users/manage` (LIPAS admin), or `:org/manage` on a related org
   - `:masked` `:org/member` on a related org, or anyone who can edit the site
-              themselves. The second clause is deliberate: a site can be
+              themselves. \"Masked\" is per-subject, not blanket — see
+              `pii-renderer`: co-members of the viewer's own org stay in full,
+              because the Jäsenet tab already shows the viewer those exact
+              addresses. The second clause is deliberate: a site can be
               editable through a role-template catalog or a legacy direct
               permission WITHOUT having an owner org at all (owner-org-id nil,
               no grants), and such sites do show up in the Kohteet tab. Without
@@ -1185,6 +1188,25 @@
       (roles/check-privilege user rc :site/create-edit)    :masked
       :else                                               :none)))
 
+(defn pii-renderer
+  "Returns `(fn [subject-id email] -> string|nil)` rendering ONE person at the
+  viewer's tier.
+
+  At `:masked`, people who share an org with the viewer are still shown in
+  full: the viewer already sees those exact addresses unmasked in that org's
+  Jäsenet tab, so masking them here would make the same colleague look
+  different in two tabs while protecting nothing. Outsiders — typically the
+  legacy direct editors, who are usually in no org at all — stay masked. The
+  co-member lookup costs one query and runs ONLY at the `:masked` tier."
+  [db viewer tier]
+  (if (= :masked tier)
+    (let [co-members (org/co-member-ids db (:id viewer))]
+      (fn [subject-id email]
+        (if (contains? co-members (str subject-id))
+          email
+          (org/mask-email email))))
+    (fn [_subject-id email] (org/apply-pii-tier tier email))))
+
 (defn site-editors
   "\"Who can edit site Z\" (Q2, design-spec §6): owner org + grantee orgs (off
   the site document) ∪ orgs whose role-template catalog grants editing on this
@@ -1196,7 +1218,8 @@
   unindexed caveat — deferred.
 
   Person entries (the two legacy-user lists) are rendered at `viewer`'s
-  `site-pii-tier`: full email, masked email, or dropped entirely. `:username`
+  `site-pii-tier`, per subject via `pii-renderer`: full email, masked email
+  (except the viewer's own co-members, who stay full), or dropped entirely. `:username`
   is NOT returned any more — it is an email address for ~25% of accounts, so
   shipping it alongside a masked `:email` would have handed back the very
   identifier the mask removes. Org entries are organisation names, not personal
@@ -1204,6 +1227,7 @@
   [db lipas-id viewer]
   (let [site         (get-sports-site db lipas-id)
         pii          (site-pii-tier viewer site)
+        render       (pii-renderer db viewer pii)
         owner-org-id (some-> site :owner-org-id str)
         grant-ids    (->> (:edit-grants site) (map str) set)
         orgs         (orgs-relevant-to-site db (cons owner-org-id grant-ids))
@@ -1247,7 +1271,7 @@
                                      :lipas-id   (:lipas-id rc)
                                      :activities (:activity rc)})
                                (remove (fn [u] (roles/check-role u :admin))))
-        person       (fn [u] (when-let [e (org/apply-pii-tier pii (:email u))]
+        person       (fn [u] (when-let [e (render (:id u) (:email u))]
                                {:email e}))
         legacy-users (->> legacy-candidates
                           (filter (fn [u] (roles/check-privilege u rc :site/create-edit)))
@@ -1275,8 +1299,10 @@
   branch on which key is present:
   - `:full`   → rows {:event-date :status :author} where :author is the
     editor's email. LIPAS admins and org admins of a related org.
-  - `:masked` → the same {:author} shape, masked (`org/mask-email`). Plain org
-    members and other editors of the site (PM rule, 2026-09-07).
+  - `:masked` → the same {:author} shape, masked (`org/mask-email`) — except
+    when the author shares an org with the viewer, who then sees them in full
+    (`pii-renderer`). Plain org members and other editors of the site (PM rule,
+    2026-09-07).
   - `:none`   → rows {:event-date :status :author-role} where :author-role ∈
     \"admin\"/\"municipality\"/\"organization\"/\"other\" — a coarse role label, NO
     person identifier (GDPR, F38; supersedes the F5 username mode). This route
@@ -1299,11 +1325,12 @@
                   :status      (:status r)
                   :author-role (get labels (str (:author_id r)) "other")})
                rows))
-       (let [names (org/resolve-account-names db author-ids true)]
+       (let [names  (org/resolve-account-names db author-ids true)
+             render (pii-renderer db viewer pii)]
          (mapv (fn [r]
                  {:event-date (str (:event_date r))
                   :status     (:status r)
-                  :author     (org/apply-pii-tier pii (get names (str (:author_id r))))})
+                  :author     (render (:author_id r) (get names (str (:author_id r))))})
                rows))))))
 
 (defn search-fields

--- a/webapp/src/clj/lipas/backend/core.clj
+++ b/webapp/src/clj/lipas/backend/core.clj
@@ -1198,17 +1198,25 @@
   "Returns `(fn [subject-id email] -> string|nil)` rendering ONE person at the
   viewer's tier.
 
-  At `:masked`, people who share an org with the viewer are still shown in
-  full: the viewer already sees those exact addresses unmasked in that org's
-  Jäsenet tab, so masking them here would make the same colleague look
-  different in two tabs while protecting nothing. Outsiders — typically the
-  legacy direct editors, who are usually in no org at all — stay masked. The
-  co-member lookup costs one query and runs ONLY at the `:masked` tier."
-  [db viewer tier]
+  At `:masked`, the viewer themselves and anyone sharing one of `org-ids` with
+  them are still shown in full: the viewer already sees those exact addresses
+  unmasked in that org's Jäsenet tab, so masking them here would make the same
+  colleague look different in two tabs while protecting nothing. Outsiders —
+  typically the legacy direct editors, who are usually in no org at all — stay
+  masked.
+
+  `org-ids` is the SITE's orgs (owner + grantees), never every org the viewer
+  happens to belong to: sharing an unrelated org with someone must not unmask
+  them on a site neither org is connected to.
+
+  The co-member lookup costs one query and runs ONLY at the `:masked` tier."
+  [db viewer tier org-ids]
   (if (= :masked tier)
-    (let [co-members (org/co-member-ids db (:id viewer))]
+    (let [co-members (org/co-member-ids db (:id viewer) org-ids)
+          self       (str (:id viewer))]
       (fn [subject-id email]
-        (if (contains? co-members (str subject-id))
+        (if (or (= self (str subject-id))
+                (contains? co-members (str subject-id)))
           email
           (org/mask-email email))))
     (fn [_subject-id email] (org/apply-pii-tier tier email))))
@@ -1233,7 +1241,8 @@
   [db lipas-id viewer]
   (let [site         (get-sports-site db lipas-id)
         pii          (site-pii-tier viewer site)
-        render       (pii-renderer db viewer pii)
+        render       (pii-renderer db viewer pii
+                                   (:org-id (roles/site-roles-context site)))
         owner-org-id (some-> site :owner-org-id str)
         grant-ids    (->> (:edit-grants site) (map str) set)
         orgs         (orgs-relevant-to-site db (cons owner-org-id grant-ids))
@@ -1321,7 +1330,8 @@
   the history rows themselves still carry no documents."
   ([db lipas-id] (site-edit-history db lipas-id nil))
   ([db lipas-id viewer]
-   (let [pii        (site-pii-tier viewer (get-sports-site db lipas-id))
+   (let [site       (get-sports-site db lipas-id)
+         pii        (site-pii-tier viewer site)
          rows       (db/get-sports-site-edit-history db lipas-id)
          author-ids (map :author_id rows)]
      (if (= :none pii)
@@ -1332,7 +1342,8 @@
                   :author-role (get labels (str (:author_id r)) "other")})
                rows))
        (let [names  (org/resolve-account-names db author-ids true)
-             render (pii-renderer db viewer pii)]
+             render (pii-renderer db viewer pii
+                                  (:org-id (roles/site-roles-context site)))]
          (mapv (fn [r]
                  {:event-date (str (:event_date r))
                   :status     (:status r)

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -498,7 +498,10 @@
                       {:status 200
                        :body (org-takeover/preview db (-> req :parameters :body :org-id))})}}]
 
-      ;; --- "Who can edit site Z" (Q2) — transparency, any authenticated user ---
+      ;; --- "Who can edit site Z" (Q2) — transparency, any authenticated user.
+      ;; Person entries are rendered at the caller's core/site-pii-tier: full
+      ;; email for LIPAS/org admins, masked for org members and the site's own
+      ;; editors, dropped for everyone else. ---
         ["/actions/get-site-editors"
          {:post
           {:no-doc true
@@ -507,12 +510,15 @@
            :parameters {:body [:map [:lipas-id #'sports-site-schema/lipas-id]]}
            :handler (fn [req]
                       {:status 200
-                       :body (core/site-editors db (-> req :parameters :body :lipas-id))})}}]
+                       :body (core/site-editors db
+                                                 (-> req :parameters :body :lipas-id)
+                                                 (:identity req))})}}]
 
       ;; --- Site edit history — any authenticated user, surfaced in the org
-      ;; Kohteet drawer for the members maintaining the data. The author is a
-      ;; person identifier (email) ONLY for :users/manage holders; everyone
-      ;; else gets timestamp + a coarse role label (GDPR, F38). ---
+      ;; Kohteet drawer for the members maintaining the data. Same three tiers
+      ;; as get-site-editors: full author email for LIPAS/org admins, masked for
+      ;; org members and the site's own editors, and timestamp + a coarse role
+      ;; label for anyone else (GDPR, F38). ---
         ["/actions/get-site-edit-history"
          {:post
           {:no-doc true
@@ -523,7 +529,7 @@
                       {:status 200
                        :body (core/site-edit-history
                                db (-> req :parameters :body :lipas-id)
-                               {:emails? (roles/check-privilege (:identity req) {} :users/manage)})})}}]
+                               (:identity req))})}}]
 
       ;; --- Commands --------------------------------------------------------
 

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -535,8 +535,8 @@
            :handler (fn [req]
                       {:status 200
                        :body (core/site-editors db
-                                                 (-> req :parameters :body :lipas-id)
-                                                 (:identity req))})}}]
+                                                (-> req :parameters :body :lipas-id)
+                                                (:identity req))})}}]
 
       ;; --- Site edit history — any authenticated user, surfaced in the org
       ;; Kohteet drawer for the members maintaining the data. Same three tiers

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -149,6 +149,24 @@
                                {:org-id #{(str (-> req :parameters :body :org-id))}}
                                :org/member))))
 
+(defn- site-org-member-or-admin?
+  "Boolean privilege fn for POST /actions/get-site-editors: LIPAS admin, or
+  `:org/member` on an org tied to the site named in the body — its owner org or
+  one it has granted edit to.
+
+  That set is exactly `search-meta.editor-org-ids`, which is what the Kohteet
+  tab queries to build its list, so every row a member can see there can also
+  open its drawer, and nothing else can. Before this the route was
+  `:require-privilege nil`: ANY authenticated user could ask who edits ANY
+  lipas-id."
+  [db req]
+  (let [user (:identity req)]
+    (or (roles/check-role user :admin)
+        (let [site    (core/get-sports-site db (-> req :parameters :body :lipas-id))
+              org-ids (:org-id (roles/site-roles-context site))]
+          (boolean (and (seq org-ids)
+                        (roles/check-privilege user {:org-id org-ids} :org/member)))))))
+
 (defn- utp-image-upload-access?
   "Boolean privilege fn for POST /actions/upload-utp-image.
 
@@ -504,15 +522,15 @@
                       {:status 200
                        :body (org-takeover/preview db (-> req :parameters :body :org-id))})}}]
 
-      ;; --- "Who can edit site Z" (Q2) — transparency, any authenticated user.
-      ;; Person entries are rendered at the caller's core/site-pii-tier: full
-      ;; email for LIPAS/org admins, masked for org members and the site's own
-      ;; editors, dropped for everyone else. ---
+      ;; --- "Who can edit site Z" (Q2) — scoped to the site's own orgs: LIPAS
+      ;; admins, plus members of the org that owns the site or has been granted
+      ;; edit on it. Person entries within that are still rendered at the
+      ;; caller's core/site-pii-tier (full email for admins, masked for plain
+      ;; members). ---
         ["/actions/get-site-editors"
          {:post
           {:no-doc true
-           :require-privilege nil
-           :middleware [mw/token-auth mw/auth]
+           :require-privilege (fn [req] (site-org-member-or-admin? db req))
            :parameters {:body [:map [:lipas-id #'sports-site-schema/lipas-id]]}
            :handler (fn [req]
                       {:status 200

--- a/webapp/src/clj/lipas/backend/handler.clj
+++ b/webapp/src/clj/lipas/backend/handler.clj
@@ -463,15 +463,21 @@
         ["/actions/get-org-history"
          {:post
           {:no-doc true
-         ;; History/audit is admin-only (lipas-admin or org-admin), not members.
-         ;; Author identity (email) only for :users/manage; org admins get a
-         ;; coarse role label instead (same GDPR rule as site edit history).
+         ;; History/audit is admin-only (lipas-admin or org-admin), not members —
+         ;; so every caller who gets this far is already at the `:full` tier of
+         ;; the PM PII rule (2026-09-07: "org admin and LIPAS admin see the full
+         ;; emails"). Hence `true` unconditionally.
+         ;;
+         ;; NOTE this REPLACES the earlier F38 behaviour, where org admins saw a
+         ;; coarse :author-role and only :users/manage saw :author-name. That was
+         ;; the conservative placeholder taken "pending data-protection guidance"
+         ;; (docs/organizations.md); this is that guidance. Reverting is a
+         ;; one-word change back to the check-privilege call.
            :require-privilege [org-scope-from-body :org/manage]
            :parameters {:body [:map [:org-id org-schema/org-id]]}
            :handler (fn [req]
                       {:status 200
-                       :body (org/get-history db (-> req :parameters :body :org-id)
-                                              (roles/check-privilege (:identity req) {} :users/manage))})}}]
+                       :body (org/get-history db (-> req :parameters :body :org-id) true)})}}]
 
       ;; --- Bulk contact update candidates (org-only). Read-only candidate
       ;; listing is member-visible (same gate as /actions/get-org-sites) so the

--- a/webapp/src/clj/lipas/backend/org.clj
+++ b/webapp/src/clj/lipas/backend/org.clj
@@ -607,6 +607,29 @@
   [db user-id]
   (derive-org-roles user-id (user-orgs db user-id)))
 
+(defn enrich-org-roles
+  "Project the user's org-derived roles and merge them into the user's roles.
+  Both existing and derived roles are conformed to the same (keyword/set) shape
+  and deduped, so a legacy account org role and its derived twin collapse.
+  Derived roles live only in the resulting token — never persisted.
+
+  Lives here rather than in `lipas.backend.auth` because `auth` requires
+  `core`, so `core` (which mints impersonation tokens) could never call it
+  there. `auth/enrich-org-roles` delegates to this.
+
+  EVERY path that mints a session token must run this. Org membership confers
+  no stored role — skip it and the session silently loses :org/member and
+  :org/manage, which reads as \"this user is in no organization\" rather than as
+  an error."
+  [db user]
+  (update-in user [:permissions :roles]
+             (fn [roles]
+               (->> (derive-user-org-roles db (:id user))
+                    (concat roles)
+                    roles/conform-roles
+                    distinct
+                    vec))))
+
 (comment
   (all-orgs (:lipas/db integrant.repl.state/system))
   (get-org (:lipas/db integrant.repl.state/system) #uuid "d068ec10-0928-4ed1-883a-f40f3c698f32")

--- a/webapp/src/clj/lipas/backend/org.clj
+++ b/webapp/src/clj/lipas/backend/org.clj
@@ -186,17 +186,30 @@
     nil))
 
 (defn co-member-ids
-  "Account ids (as strings) that share at least one org with `user-id`.
+  "Account ids (as strings) that share one of `org-ids` with `user-id`.
 
-  These are exactly the people whose addresses the user ALREADY sees unmasked
-  in that org's Jäsenet tab (`get-org-users` is gated at `org-member-or-admin?`
-  and returns full `:email`), so masking them elsewhere protects nothing while
-  making the same person look different in two tabs. One query — the same
-  reverse jsonb-containment `user-orgs` uses."
-  [db user-id]
-  (if-let [uid (utils/->uuid-safe user-id)]
-    (->> (user-orgs db uid) (mapcat :members) (keep :user-id) (map str) set)
-    #{}))
+  These are the people whose addresses the user ALREADY sees unmasked in that
+  org's Jäsenet tab (`get-org-users` is gated at `org-member-or-admin?` and
+  returns full `:email`), so masking them elsewhere protects nothing while
+  making the same person look different in two tabs.
+
+  `org-ids` MUST be scoped to the resource being viewed — for a site, its owner
+  org plus any grantees. An earlier version collected members of every org the
+  viewer belonged to, which meant sharing some entirely unrelated org with
+  someone unmasked them on a site neither org had anything to do with. The
+  Jäsenet argument technically still held, but the result was baffling in the
+  UI. Empty `org-ids` ⇒ nobody. One query, the same reverse jsonb-containment
+  `user-orgs` uses."
+  [db user-id org-ids]
+  (let [wanted (set (map str org-ids))]
+    (if-let [uid (and (seq wanted) (utils/->uuid-safe user-id))]
+      (->> (user-orgs db uid)
+           (filter (fn [o] (contains? wanted (str (:id o)))))
+           (mapcat :members)
+           (keep :user-id)
+           (map str)
+           set)
+      #{})))
 
 (defn resolve-account-names
   "Batch-resolve account ids → display label in one query. Returns a map keyed

--- a/webapp/src/clj/lipas/backend/org.clj
+++ b/webapp/src/clj/lipas/backend/org.clj
@@ -151,6 +151,40 @@
 
 ;;; account-name resolution (shared by org history + site edit history) ;;;
 
+(defn mask-email
+  "Partially redact an email for viewers who may learn THAT someone has access
+  without learning WHO: `matti.meikalainen@example.fi` becomes
+  `m...............n@example.fi`.
+
+  First and last character of the local part survive so a colleague who already
+  knows the address can still recognise it; the domain is kept whole because it
+  identifies the organisation, not the individual. Local parts of 1-2 characters
+  carry no recognisable middle, so they are masked entirely. Anything without a
+  domain part is masked whole rather than passed through — this function must
+  never return an unredacted identifier for input it does not understand."
+  [email]
+  (when-let [s (some-> email str str/trim not-empty)]
+    (let [[local domain] (str/split s #"@" 2)
+          dots           #(apply str (repeat % \.))]
+      (if (str/blank? domain)
+        (dots (count s))
+        (str (if (<= (count local) 2)
+               (dots (count local))
+               (str (first local) (dots (- (count local) 2)) (last local)))
+             "@" domain)))))
+
+(defn apply-pii-tier
+  "Render one account's person identifier at the viewer's `tier`:
+  `:full` → the email, `:masked` → `mask-email` of it, anything else → nil.
+  Callers MUST drop the surrounding entry when this returns nil rather than
+  falling back to another field — `:username` is an email for ~25% of accounts,
+  so it is not a safe stand-in for a redacted address."
+  [tier email]
+  (case tier
+    :full   email
+    :masked (mask-email email)
+    nil))
+
 (defn resolve-account-names
   "Batch-resolve account ids → display label in one query. Returns a map keyed
   by string id (nil when `ids` is empty); ids absent from `account` are simply

--- a/webapp/src/clj/lipas/backend/org.clj
+++ b/webapp/src/clj/lipas/backend/org.clj
@@ -185,6 +185,19 @@
     :masked (mask-email email)
     nil))
 
+(defn co-member-ids
+  "Account ids (as strings) that share at least one org with `user-id`.
+
+  These are exactly the people whose addresses the user ALREADY sees unmasked
+  in that org's Jäsenet tab (`get-org-users` is gated at `org-member-or-admin?`
+  and returns full `:email`), so masking them elsewhere protects nothing while
+  making the same person look different in two tabs. One query — the same
+  reverse jsonb-containment `user-orgs` uses."
+  [db user-id]
+  (if-let [uid (utils/->uuid-safe user-id)]
+    (->> (user-orgs db uid) (mapcat :members) (keep :user-id) (map str) set)
+    #{}))
+
 (defn resolve-account-names
   "Batch-resolve account ids → display label in one query. Returns a map keyed
   by string id (nil when `ids` is empty); ids absent from `account` are simply

--- a/webapp/src/cljs/lipas/ui/org/views.cljs
+++ b/webapp/src/cljs/lipas/ui/org/views.cljs
@@ -789,11 +789,14 @@
 
 (defn site-edit-history-section
   "Per-revision edit history for the expanded site, lazily fetched on expand
-  and cached per lipas-id. Branches on which key the backend sent (GDPR, F38):
-  rows carry `:author` (email, lipas-admins with :users/manage only) OR
-  `:author-role` (coarse role label — admin/municipality/organization/other —
-  no person identifier, everyone else). Capped to the most recent revisions to
-  keep the accordion DOM bounded on long-lived sites."
+  and cached per lipas-id. Branches on which key the backend sent: rows carry
+  `:author` — already rendered at the viewer's tier server-side, a full email
+  for LIPAS/org admins and a masked one for org members and the site's own
+  editors — OR `:author-role` (coarse role label —
+  admin/municipality/organization/other, no person identifier) for viewers with
+  no relationship to the site (GDPR, F38). The FE never decides how much to
+  reveal. Capped to the most recent revisions to keep the accordion DOM bounded
+  on long-lived sites."
   [tr lipas-id]
   (let [history @(rf/subscribe [::subs/site-edit-history lipas-id])
         total   (count history)
@@ -859,14 +862,19 @@
                      {:key (str "act-" (:id a)) :label (:name a)
                       :tag (tr :lipas.org/role-activity)
                       :tooltip (tr :lipas.org/role-activity-tooltip)})
-                   (for [u (:legacy-users editors)]
-                     {:key (str "legacy-" (:email u)) :label (:email u)
+                   ;; Person rows. :email arrives already rendered at the
+                   ;; viewer's tier (full / masked / absent) — the FE never
+                   ;; decides how much to reveal. Keys are positional because a
+                   ;; masked address is not unique (two colleagues on the same
+                   ;; domain with same-length names collapse to one string).
+                   (for [[i u] (map-indexed vector (:legacy-users editors))]
+                     {:key (str "legacy-" i) :label (:email u)
                       :tag (tr :lipas.org/role-direct)
                       :tooltip (tr :lipas.org/role-direct-tooltip)})
                    ;; direct activity-only users: can edit the site's UTP data
                    ;; but not the site itself (same tag as activity orgs)
-                   (for [u (:legacy-activity-users editors)]
-                     {:key (str "legacy-act-" (:email u)) :label (:email u)
+                   (for [[i u] (map-indexed vector (:legacy-activity-users editors))]
+                     {:key (str "legacy-act-" i) :label (:email u)
                       :tag (tr :lipas.org/role-activity)
                       :tooltip (tr :lipas.org/role-direct-activity-tooltip)}))]
         [:> Box {:sx {:p 2 :bgcolor "action.hover"}}

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1598,11 +1598,19 @@
                             :owner-org-id (str org-id))
                      (assoc-in [:location :city :city-code] city)
                      (assoc-in [:type :type-code] 1530))
-        _        (core/upsert-sports-site!* db admin site)]
+        _        (core/upsert-sports-site!* db admin site)
+        ;; a direct editor who is ALSO a member of the owning org: the viewer's
+        ;; colleague, whose address they already see in the Jäsenet tab
+        colleague (test-utils/gen-city-manager-user city :db-component db)
+        _         (backend-org/add-member! db org-id (:id colleague) {:roles []} nil)
+        ;; ...and a revision authored by them, so the history has a co-member author
+        _         (core/upsert-sports-site!* db colleague
+                                             (assoc site :event-date "2026-02-02T00:00:00.000Z"))]
     {:db     db
      :lid    lid
      :admin  admin
-     ;; the one person entry the who-can-edit list should carry
+     :colleague colleague
+     ;; a direct editor in no org at all — the outsider who must stay masked
      :direct (test-utils/gen-city-manager-user city :db-component db)
      :oadmin (test-utils/gen-org-admin-user org-id :db-component db)
      :member (test-utils/gen-org-user org-id :db-component db :permissions {:roles []})
@@ -1621,7 +1629,7 @@
   (testing "Who-can-edit renders person entries at the viewer's tier (PM rule
             2026-09-07): full email for LIPAS/org admins, masked for org
             members, dropped for viewers unrelated to the site"
-    (let [{:keys [lid admin direct oadmin member outsider]} (pii-fixture)
+    (let [{:keys [lid admin direct colleague oadmin member outsider]} (pii-fixture)
           real   (:email direct)
           masked (backend-org/mask-email real)
           call   #(post-json "/api/actions/get-site-editors" {:lipas-id lid} %)
@@ -1636,10 +1644,19 @@
 
       (testing "plain org member"
         (let [body (call member)]
-          (is (contains? (emails body) masked) "sees the masked address")
-          (is (not (contains? (emails body) real)) "never the real one")
+          (is (contains? (emails body) masked) "sees an outsider's address masked")
+          (is (not (contains? (emails body) real)) "never the outsider's real one")
           (is (not (str/includes? (pr-str body) real))
               "and it appears nowhere else in the payload either")))
+
+      (testing "org member sees their OWN org's members in full"
+        ;; the Jäsenet tab already shows them these addresses unmasked; masking
+        ;; the same colleague here would differ between two tabs for nothing
+        (let [body (call member)]
+          (is (contains? (emails body) (:email colleague))
+              "a co-member's address is not masked")
+          (is (not (contains? (emails body) (backend-org/mask-email (:email colleague))))
+              "and is not ALSO present in masked form")))
 
       (testing "viewer unrelated to the site"
         (let [body (call outsider)]
@@ -1657,7 +1674,7 @@
 (deftest site-edit-history-pii-tier-test
   (testing "Site edit history follows the same three tiers; the unrelated viewer
             keeps the coarse role label (F38) rather than gaining a masked email"
-    (let [{:keys [lid admin oadmin member outsider]} (pii-fixture)
+    (let [{:keys [lid admin colleague oadmin member outsider]} (pii-fixture)
           real    (:email admin)
           masked  (backend-org/mask-email real)
           call    #(post-json "/api/actions/get-site-edit-history" {:lipas-id lid} %)
@@ -1668,8 +1685,11 @@
           "Org admin of the owning org sees the author's full address")
 
       (let [body (call member)]
-        (is (contains? (authors body) masked) "Plain org member sees it masked")
-        (is (not (str/includes? (pr-str body) real)) "never the real address"))
+        (is (contains? (authors body) masked)
+            "Plain org member sees an outsider author masked")
+        (is (not (str/includes? (pr-str body) real)) "never that real address")
+        (is (contains? (authors body) (:email colleague))
+            "but a co-member author stays in full"))
 
       (let [body (call outsider)]
         (is (every? :author-role body) "Unrelated viewer gets coarse role labels")

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1762,6 +1762,29 @@
       (is (not (contains? authors (:email author)))
           "and the real address is absent"))))
 
+(deftest impersonation-projects-org-roles-test
+  (testing "An impersonated session carries the target's ORG roles.
+
+            Org membership confers no stored role — it is projected at login
+            (org/enrich-org-roles). impersonate! minted its token from the raw
+            account, so an impersonated org member silently belonged to no
+            organization: org endpoints 403, and with the rollout gate the org
+            UI does not render at all."
+    (let [db       (test-db)
+          [org1 _] (create-test-orgs)
+          org-id   (:id org1)
+          admin    (test-utils/gen-admin-user :db-component db)
+          member   (test-utils/gen-org-user org-id :db-component db :permissions {:roles []})
+          ;; the route passes the id as a JSON string; get-user! lowercases
+          ;; its argument, which blows up on a raw uuid
+          body     (core/impersonate! db admin (str (:id member)))
+          claims   (jwt/unsign (:token body))
+          roles    (update-in claims [:permissions :roles] roles/conform-roles)]
+      (is (= (:email member) (:email claims)) "sanity: impersonating the right user")
+      (is (roles/check-privilege roles {:org-id #{(str org-id)}} :org/member)
+          "the impersonated token grants :org/member on the target's org")
+      (is (some? (:impersonator body)) "and still records the impersonator"))))
+
 (deftest mask-email-test
   (testing "mask-email keeps first/last of the local part and the whole domain"
     (is (= "v................n@gmail.com"

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1671,7 +1671,7 @@
         ;; it is an email address for ~25% of accounts, so returning it beside a
         ;; masked :email would have handed back the identifier the mask removes
         (doseq [[who body] [[:admin (call admin)] [:member (call member)]]]
-          (is (not (str/includes? (pr-str body) ":username")) (str who))))))) 
+          (is (not (str/includes? (pr-str body) ":username")) (str who)))))))
 
 (deftest site-edit-history-pii-tier-test
   (testing "Site edit history follows the same three tiers; the unrelated viewer

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1728,6 +1728,40 @@
       (is (not (contains? authors (:email admin-outside)))
           "and their real address does not appear"))))
 
+(deftest site-edit-history-sole-member-test
+  (testing "Exact lipas-dev scenario: an org whose ONLY member is a plain
+            org-user, a site it owns, and a LIPAS admin author who is not a
+            member of anything. The admin's address must be masked."
+    (let [db       (test-db)
+          [org1 _] (create-test-orgs)
+          org-id   (:id org1)
+          city     841
+          lid      9992097
+          site     (-> (test-utils/gen-sports-site)
+                       (assoc :status "active" :lipas-id lid :owner-org-id (str org-id))
+                       (assoc-in [:location :city :city-code] city)
+                       (assoc-in [:type :type-code] 1530))
+          author   (test-utils/gen-admin-user :db-component db)
+          _        (core/upsert-sports-site!* db author
+                                              (assoc site :event-date "2026-04-01T00:00:00.000Z"))
+          ;; the one and only member, a plain org-user (no reserved "admin" role)
+          member   (test-utils/gen-org-user org-id :db-component db :permissions {:roles []})
+          members  (:members (backend-org/get-org db org-id))
+          ;; conform as the token path does (auth/enrich-org-roles and the
+          ;; token-auth backend both do) — raw generator output carries org-id
+          ;; as a vector, which the set-intersection matcher will not match
+          tier     (core/site-pii-tier
+                     (update-in member [:permissions :roles] roles/conform-roles)
+                     (core/get-sports-site db lid))
+          authors  (set (map :author (post-json "/api/actions/get-site-edit-history"
+                                                {:lipas-id lid} member)))]
+      (is (= 1 (count members)) "sanity: the org has exactly one member")
+      (is (= :masked tier) "a plain sole member resolves to the :masked tier")
+      (is (contains? authors (backend-org/mask-email (:email author)))
+          "the admin author's address is masked")
+      (is (not (contains? authors (:email author)))
+          "and the real address is absent"))))
+
 (deftest mask-email-test
   (testing "mask-email keeps first/last of the local part and the whole domain"
     (is (= "v................n@gmail.com"

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1697,6 +1697,37 @@
         (is (not (str/includes? (pr-str body) "@"))
             "no email-shaped string anywhere — masked or otherwise")))))
 
+(deftest site-edit-history-admin-author-test
+  (testing "A LIPAS admin author is not special: what unmasks them for a plain
+            member is ORG MEMBERSHIP, nothing about being an admin"
+    (let [db       (test-db)
+          [org1 _] (create-test-orgs)
+          org-id   (:id org1)
+          city     839
+          lid      9992095
+          site     (-> (test-utils/gen-sports-site)
+                       (assoc :status "active" :lipas-id lid :owner-org-id (str org-id))
+                       (assoc-in [:location :city :city-code] city)
+                       (assoc-in [:type :type-code] 1530))
+          ;; two LIPAS admins author a revision each; one is ALSO a member of
+          ;; the org whose member is doing the viewing, the other is not
+          admin-member  (test-utils/gen-admin-user :db-component db)
+          _             (backend-org/add-member! db org-id (:id admin-member) {:roles []} nil)
+          admin-outside (test-utils/gen-admin-user :db-component db)
+          _             (core/upsert-sports-site!* db admin-member
+                                                   (assoc site :event-date "2026-03-01T00:00:00.000Z"))
+          _             (core/upsert-sports-site!* db admin-outside
+                                                   (assoc site :event-date "2026-03-02T00:00:00.000Z"))
+          member  (test-utils/gen-org-user org-id :db-component db :permissions {:roles []})
+          authors (set (map :author (post-json "/api/actions/get-site-edit-history"
+                                               {:lipas-id lid} member)))]
+      (is (contains? authors (:email admin-member))
+          "admin who IS a member of the viewer's org: shown in full (co-member rule)")
+      (is (contains? authors (backend-org/mask-email (:email admin-outside)))
+          "admin who is NOT a member: masked like anyone else")
+      (is (not (contains? authors (:email admin-outside)))
+          "and their real address does not appear"))))
+
 (deftest mask-email-test
   (testing "mask-email keeps first/last of the local part and the whole domain"
     (is (= "v................n@gmail.com"

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1409,7 +1409,7 @@
                                           :edit-grants  [(str grantee-id)]
                                           :activities   {:melonta {}}))
           _                    (core/upsert-sports-site!* (test-db) admin site)
-          editors              (core/site-editors (test-db) lid)]
+          editors              (core/site-editors (test-db) lid admin)]
       (is (= (str owner-id) (:id (:owner-org editors))) "Owner org resolved")
       (is (contains? (set (map :id (:grantee-orgs editors))) (str grantee-id)) "Grantee org listed")
       (is (contains? (set (map :id (:activity-editor-orgs editors))) (str grantee-id))
@@ -1428,7 +1428,7 @@
           editor (test-utils/gen-city-manager-user city :db-component (test-db)) ; direct edit role for the city
           other  (test-utils/gen-city-manager-user 91 :db-component (test-db))   ; different city
           admin2 (test-utils/gen-admin-user :db-component (test-db))             ; admin (must be excluded)
-          emails (set (map :email (:legacy-users (core/site-editors (test-db) lid))))
+          emails (set (map :email (:legacy-users (core/site-editors (test-db) lid admin))))
           ;; exhaustive oracle: scan every active user with the exact matcher
           rc     (roles/site-roles-context (core/get-sports-site (test-db) lid))
           naive  (->> (core/get-users (test-db))
@@ -1466,7 +1466,7 @@
                           :activities {:melonta {}})
                    (assoc-in [:location :city :city-code] city))
           _       (core/upsert-sports-site!* (test-db) admin site)
-          editors (core/site-editors (test-db) lid)]
+          editors (core/site-editors (test-db) lid admin)]
       (is (contains? (set (map :id (:catalog-editor-orgs editors))) (str cm-org-id))
           "Org whose catalog grants city-manager for the site's city is a (full) editor
            (old code never found catalog city/type/site-managers — fails on old)")
@@ -1496,7 +1496,7 @@
                       (assoc-in [:type :type-code] 4412)
                       (dissoc :activities))
           _       (core/upsert-sports-site!* (test-db) admin site)
-          editors (core/site-editors (test-db) lid)]
+          editors (core/site-editors (test-db) lid admin)]
       (is (contains? (set (map :id (:activity-editor-orgs editors))) (str org-id))
           "Org whose catalog grants activities-manager(cycling) is listed even though
            the document has no UTP data yet (fails on old: :activity ctx was nil)")
@@ -1515,7 +1515,7 @@
                                            :db-component (test-db)
                                            :permissions {:roles [{:role "activities-manager"
                                                                   :activity ["cycling"]}]}})
-            editors' (core/site-editors (test-db) lid)]
+            editors' (core/site-editors (test-db) lid admin)]
         (is (contains? (set (map :email (:legacy-activity-users editors')))
                        (:email direct))
             "Direct activity-only user listed as activity editor (fails on old: key absent)")
@@ -1548,7 +1548,10 @@
                                            [city-auth  "2026-01-03T00:00:00.000Z"]
                                            [org-auth   "2026-01-04T00:00:00.000Z"]]]
                         (core/upsert-sports-site!* db author (assoc base :event-date ts)))
-          regular     (test-utils/gen-regular-user :db-component db)
+          ;; roles pinned empty: gen-user generates RANDOM permissions, and a
+          ;; generated city/type role that happened to match this site would
+          ;; lift the viewer out of the :none tier and flake this test
+          regular     (test-utils/gen-regular-user :db-component db :permissions {:roles []})
           admin       (test-utils/gen-admin-user :db-component db)
           call        (fn [user]
                         (let [resp (test-app (-> (mock/request :post "/api/actions/get-site-edit-history")
@@ -1577,6 +1580,115 @@
           ":users/manage caller keeps the person view (emails) — unchanged")
       (is (not-any? :author-role body2)
           "Admin rows are the person view, not role labels"))))
+
+(defn- pii-fixture
+  "An org-owned site plus one legacy direct editor, and the four viewer tiers
+  that look at it. Returns everything the PII tests need."
+  []
+  (let [db       (test-db)
+        admin    (test-utils/gen-admin-user :db-component db)
+        [org1 _] (create-test-orgs)
+        org-id   (:id org1)
+        city     837
+        lid      9992090
+        site     (-> (test-utils/gen-sports-site)
+                     (assoc :event-date (utils/timestamp) :status "active" :lipas-id lid
+                            :owner-org-id (str org-id))
+                     (assoc-in [:location :city :city-code] city)
+                     (assoc-in [:type :type-code] 1530))
+        _        (core/upsert-sports-site!* db admin site)]
+    {:db     db
+     :lid    lid
+     :admin  admin
+     ;; the one person entry the who-can-edit list should carry
+     :direct (test-utils/gen-city-manager-user city :db-component db)
+     :oadmin (test-utils/gen-org-admin-user org-id :db-component db)
+     :member (test-utils/gen-org-user org-id :db-component db :permissions {:roles []})
+     ;; no relationship to the site at all; roles pinned so a randomly
+     ;; generated city/type match can't lift them out of the :none tier
+     :outsider (test-utils/gen-regular-user :db-component db :permissions {:roles []})}))
+
+(defn- post-json [uri body user]
+  (-> (test-app (-> (mock/request :post uri)
+                    (mock/content-type "application/json")
+                    (mock/body (test-utils/->json body))
+                    (test-utils/token-header (jwt/create-token user))))
+      test-utils/safe-parse-json))
+
+(deftest site-editors-pii-tier-test
+  (testing "Who-can-edit renders person entries at the viewer's tier (PM rule
+            2026-09-07): full email for LIPAS/org admins, masked for org
+            members, dropped for viewers unrelated to the site"
+    (let [{:keys [lid admin direct oadmin member outsider]} (pii-fixture)
+          real   (:email direct)
+          masked (backend-org/mask-email real)
+          call   #(post-json "/api/actions/get-site-editors" {:lipas-id lid} %)
+          emails #(set (map :email (:legacy-users %)))]
+      (is (not= real masked) "sanity: the mask actually changes the address")
+
+      (testing "LIPAS admin"
+        (is (contains? (emails (call admin)) real) "sees the full address"))
+
+      (testing "org admin of the owning org"
+        (is (contains? (emails (call oadmin)) real) "sees the full address"))
+
+      (testing "plain org member"
+        (let [body (call member)]
+          (is (contains? (emails body) masked) "sees the masked address")
+          (is (not (contains? (emails body) real)) "never the real one")
+          (is (not (str/includes? (pr-str body) real))
+              "and it appears nowhere else in the payload either")))
+
+      (testing "viewer unrelated to the site"
+        (let [body (call outsider)]
+          (is (empty? (:legacy-users body)) "gets no person entries at all")
+          (is (empty? (:legacy-activity-users body)))
+          (is (some? (:owner-org body))
+              "but still sees the orgs — an org name is not personal data")))
+
+      (testing ":username is gone from every tier"
+        ;; it is an email address for ~25% of accounts, so returning it beside a
+        ;; masked :email would have handed back the identifier the mask removes
+        (doseq [[who body] [[:admin (call admin)] [:member (call member)]]]
+          (is (not (str/includes? (pr-str body) ":username")) (str who))))))) 
+
+(deftest site-edit-history-pii-tier-test
+  (testing "Site edit history follows the same three tiers; the unrelated viewer
+            keeps the coarse role label (F38) rather than gaining a masked email"
+    (let [{:keys [lid admin oadmin member outsider]} (pii-fixture)
+          real    (:email admin)
+          masked  (backend-org/mask-email real)
+          call    #(post-json "/api/actions/get-site-edit-history" {:lipas-id lid} %)
+          authors #(set (map :author %))]
+      (is (contains? (authors (call admin)) real)
+          "LIPAS admin sees the author's full address")
+      (is (contains? (authors (call oadmin)) real)
+          "Org admin of the owning org sees the author's full address")
+
+      (let [body (call member)]
+        (is (contains? (authors body) masked) "Plain org member sees it masked")
+        (is (not (str/includes? (pr-str body) real)) "never the real address"))
+
+      (let [body (call outsider)]
+        (is (every? :author-role body) "Unrelated viewer gets coarse role labels")
+        (is (not-any? :author body) "and no person identifier")
+        (is (not (str/includes? (pr-str body) "@"))
+            "no email-shaped string anywhere — masked or otherwise")))))
+
+(deftest mask-email-test
+  (testing "mask-email keeps first/last of the local part and the whole domain"
+    (is (= "v................n@gmail.com"
+           (backend-org/mask-email "valtteri.harmainen@gmail.com")))
+    (is (= "s........a@saarijarvi.fi"
+           (backend-org/mask-email "suvi.puura@saarijarvi.fi")))
+    (is (= "a.c@x.fi" (backend-org/mask-email "abc@x.fi"))))
+  (testing "short local parts keep nothing — there is no recognisable middle"
+    (is (= "..@x.fi" (backend-org/mask-email "ab@x.fi")))
+    (is (= ".@x.fi" (backend-org/mask-email "a@x.fi"))))
+  (testing "input it does not understand is masked whole, never passed through"
+    (is (= "............" (backend-org/mask-email "not-an-email")))
+    (is (nil? (backend-org/mask-email "")))
+    (is (nil? (backend-org/mask-email nil)))))
 
 (deftest enrich-denormalizes-owner-org-name-test
   (testing "Enriched ES doc carries the owner org's name in search-meta (F15)"

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1658,12 +1658,14 @@
           (is (not (contains? (emails body) (backend-org/mask-email (:email colleague))))
               "and is not ALSO present in masked form")))
 
-      (testing "viewer unrelated to the site"
-        (let [body (call outsider)]
-          (is (empty? (:legacy-users body)) "gets no person entries at all")
-          (is (empty? (:legacy-activity-users body)))
-          (is (some? (:owner-org body))
-              "but still sees the orgs — an org name is not personal data")))
+      (testing "viewer unrelated to the site is refused outright"
+        ;; the route is no longer :require-privilege nil — it is scoped to the
+        ;; site's own orgs, so there is no redacted body to hand back
+        (let [resp (test-app (-> (mock/request :post "/api/actions/get-site-editors")
+                                 (mock/content-type "application/json")
+                                 (mock/body (test-utils/->json {:lipas-id lid}))
+                                 (test-utils/token-header (jwt/create-token outsider))))]
+          (is (= 403 (:status resp)))))
 
       (testing ":username is gone from every tier"
         ;; it is an email address for ~25% of accounts, so returning it beside a
@@ -1784,6 +1786,69 @@
       (is (roles/check-privilege roles {:org-id #{(str org-id)}} :org/member)
           "the impersonated token grants :org/member on the target's org")
       (is (some? (:impersonator body)) "and still records the impersonator"))))
+
+(deftest co-membership-is-scoped-to-the-site-test
+  (testing "Sharing an UNRELATED org with someone does not unmask them.
+
+            Reported from lipas-dev: a tester saw a LIPAS admin's full address
+            on a site owned by an org the admin had nothing to do with, because
+            the two happened to share a different org."
+    (let [db          (test-db)
+          [org-a org-b] (create-test-orgs)
+          city        843
+          lid         9992099
+          site        (-> (test-utils/gen-sports-site)
+                          (assoc :status "active" :lipas-id lid
+                                 :owner-org-id (str (:id org-a)))
+                          (assoc-in [:location :city :city-code] city)
+                          (assoc-in [:type :type-code] 1530))
+          ;; author edits the site and shares ONLY org-b with the viewer
+          author      (test-utils/gen-city-manager-user city :db-component db)
+          _           (backend-org/add-member! db (:id org-b) (:id author) {:roles []} nil)
+          _           (core/upsert-sports-site!* db author
+                                                 (assoc site :event-date "2026-05-01T00:00:00.000Z"))
+          ;; viewer is a plain member of BOTH orgs; only org-a owns the site
+          viewer      (test-utils/gen-org-user (:id org-a) :db-component db :permissions {:roles []})
+          _           (backend-org/add-member! db (:id org-b) (:id viewer) {:roles []} nil)
+          viewer      (assoc-in viewer [:permissions :roles]
+                                (backend-org/derive-user-org-roles db (:id viewer)))
+          authors     (set (map :author (post-json "/api/actions/get-site-edit-history"
+                                                   {:lipas-id lid} viewer)))]
+      (is (contains? authors (backend-org/mask-email (:email author)))
+          "masked: the shared org (org-b) has nothing to do with this site")
+      (is (not (contains? authors (:email author)))
+          "the real address does not appear")))
+
+  (testing "sharing the site's OWN org still unmasks"
+    (let [db       (test-db)
+          [org1 _] (create-test-orgs)
+          city     845
+          lid      9992100
+          site     (-> (test-utils/gen-sports-site)
+                       (assoc :status "active" :lipas-id lid :owner-org-id (str (:id org1)))
+                       (assoc-in [:location :city :city-code] city)
+                       (assoc-in [:type :type-code] 1530))
+          author   (test-utils/gen-city-manager-user city :db-component db)
+          _        (backend-org/add-member! db (:id org1) (:id author) {:roles []} nil)
+          _        (core/upsert-sports-site!* db author
+                                              (assoc site :event-date "2026-05-02T00:00:00.000Z"))
+          viewer   (test-utils/gen-org-user (:id org1) :db-component db :permissions {:roles []})
+          authors  (set (map :author (post-json "/api/actions/get-site-edit-history"
+                                                {:lipas-id lid} viewer)))]
+      (is (contains? authors (:email author))
+          "unmasked: they are a colleague in the org that owns this site"))))
+
+(deftest get-site-editors-scope-test
+  (testing "get-site-editors is scoped to the site's own orgs"
+    (let [{:keys [lid admin member outsider]} (pii-fixture)
+          call (fn [user]
+                 (:status (test-app (-> (mock/request :post "/api/actions/get-site-editors")
+                                        (mock/content-type "application/json")
+                                        (mock/body (test-utils/->json {:lipas-id lid}))
+                                        (test-utils/token-header (jwt/create-token user))))))]
+      (is (= 200 (call admin)) "LIPAS admin: unrestricted")
+      (is (= 200 (call member)) "member of the owning org: allowed")
+      (is (= 403 (call outsider)) "no relationship to the site: refused"))))
 
 (deftest mask-email-test
   (testing "mask-email keeps first/last of the local part and the whole domain"

--- a/webapp/test/clj/lipas/backend/org_test.clj
+++ b/webapp/test/clj/lipas/backend/org_test.clj
@@ -1228,9 +1228,14 @@
       (is (= 403 (:status (call regular-tok))) "Non-member may not see history"))))
 
 (deftest org-history-author-privacy-test
-  (testing "Org admins see a coarse role label for revision authors, never the
-            author's email; LIPAS admins (:users/manage) keep the person view
-            (same GDPR rule as site edit history, F38)"
+  (testing "Org admins AND LIPAS admins both see revision authors by email.
+
+            This REVERSES the earlier F38 behaviour, where an org admin saw only
+            a coarse :author-role. That was the conservative placeholder taken
+            \"pending data-protection guidance\" (docs/organizations.md); the PM
+            rule of 2026-09-07 is that guidance — org admins are a `:full` tier
+            viewer. The org history tab is already :org/manage-gated, so nobody
+            below that tier can reach this endpoint at all."
     (let [org-id      (catalog-org! editor+ptv-catalog)
           lipas-admin (test-utils/gen-admin-user :db-component (test-db))
           ;; an authored revision: the lipas-admin adds a member
@@ -1247,14 +1252,11 @@
           oadmin-hist (call (jwt/create-token oadmin))
           admin-hist  (call (jwt/create-token lipas-admin))
           authored    (fn [rows k] (->> rows (keep k) set))]
-      ;; org-admin mode: role labels only, no author identifiers anywhere
-      (is (contains? (authored oadmin-hist :author-role) "admin")
-          "Org admin sees the author's coarse role label")
-      (is (empty? (authored oadmin-hist :author-name))
-          "Org admin response carries no :author-name")
-      (is (not-any? #(str/includes? (str %) (:email lipas-admin))
-                    (map :author-name oadmin-hist))
-          "The lipas-admin author's email never appears for org admins")
+      ;; org-admin mode: person view, same as lipas-admin (PM rule 2026-09-07)
+      (is (contains? (authored oadmin-hist :author-name) (:email lipas-admin))
+          "Org admin sees the author's email")
+      (is (empty? (authored oadmin-hist :author-role))
+          "Org admin response carries no :author-role any more")
       ;; member references in change summaries stay readable (own-org members)
       (is (some (fn [rev] (some #(str/includes? % (:email member)) (:changes rev)))
                 oadmin-hist)


### PR DESCRIPTION
Implements the PM rule of 2026-09-07: **org admins and LIPAS admins see full email addresses; org members see them masked** — except for their own co-members, who are already visible in full on the Jäsenet tab.

`docs/organizations.md` listed this as an open item — *"currently administrators only, pending data-protection guidance"*. That held only because the org UI was admin-gated; the endpoints themselves never enforced it. `core/site-editors` read `:email` straight off the account rows and the FE rendered it as the row label, with no privilege branch anywhere in the path, on a `:require-privilege nil` route.

## One tier function

`core/site-pii-tier` decides how much of another person's identity a viewer may see on a given site:

| tier | who |
|---|---|
| `:full` | `:users/manage` (LIPAS admin), or `:org/manage` on an org tied to the site (owner org or grantee) |
| `:masked` | `:org/member` on such an org, **or** anyone who can edit the site themselves |
| `:none` | everyone else |

That second `:masked` clause is load-bearing: a site can be editable via a role-template catalog or a legacy direct permission with **no owner org at all**, and such sites appear in the Kohteet tab. Without it those rows would lose every person entry for exactly the people maintaining them.

| surface | `:full` | `:masked` | `:none` |
|---|---|---|---|
| who-can-edit | email | masked email | entry dropped |
| site edit history | `:author` email | `:author` masked | `:author-role` coarse label |

The `:none` branch of the history deliberately keeps F38's role label rather than "upgrading" an unrelated viewer to a masked address.

`:masked` is per subject, not per viewer. At that tier, anyone who shares one of the **site's own** orgs (owner or grantee) with the viewer is shown in full, because `get-org-members` already hands the viewer those exact addresses one tab over; masking them here protected nothing and made the same colleague render two ways. Everyone else — in practice the legacy direct editors, who are usually in no org at all — stays masked. Sharing an *unrelated* org does not unmask anyone (a lipas-dev tester hit exactly that before the scoping was tightened). The co-member lookup is one GIN-indexed jsonb query and runs only at `:masked`.

Masking keeps the first and last character of the local part plus the whole domain — `valtteri.harmainen@gmail.com` → `v................n@gmail.com`. A colleague who already knows the address can still recognise it; the domain identifies the organisation, not the person. Anything `mask-email` cannot parse is masked whole, never passed through.

## Endpoint gating

`/actions/get-site-editors` was `:require-privilege nil`: any authenticated user could ask who edits any `lipas-id`. It now requires LIPAS admin or `:org/member` on an org tied to that site — the same `search-meta.editor-org-ids` set the Kohteet tab queries — so every row a member sees there can still open its drawer and nothing else can. Unrelated callers get 403, so the `:none` tier is unreachable on this route.

`/actions/get-site-edit-history` stays open to any authenticated user on purpose: its `:none` tier returns only the coarse `:author-role` label, which is the intended transparency behaviour.


## Three things worth a second look

**`:username` was leaking the address.** `site-editors` returned `:username` beside `:email`; it is an email address for **580 of 2342 accounts (25%)** in the production snapshot, so returning it next to a masked `:email` would hand straight back the identifier the mask removes. It is no longer returned at all.

**Impersonation tokens now carry org roles.** `core/impersonate!` minted from the raw account while login and refresh go through `enrich-org-roles`, so an impersonated org member had no `:org/member` and every org endpoint 403'd. Fixed in its own commit; `enrich-org-roles` moved to `lipas.backend.org` to avoid a `core` → `auth` cycle.

**Commit 2 loosens rather than tightens, and is split out so it can be reverted alone.** `/actions/get-org-history` gave org admins a coarse `:author-role` and only LIPAS admins the email. The PM rule puts org admins in `:full`, so they now see author emails. The endpoint is already `:org/manage`-gated, so no one below that tier can reach it. Revert instructions are in the commit message.

## Verification

`lipas.backend.org-test`: 80 tests / 391 assertions green, including the new `site-editors-pii-tier-test`, `site-edit-history-pii-tier-test`, `get-site-editors-scope-test` and `mask-email-test`.

Also exercised over HTTP against the production snapshot — one site, three real tokens:

```
LIPAS admin        legacy-users: [maija.mallikas@example.fi, +5 others]
the site's editor  legacy-users: [m............s@example.fi, +5 masked]
unrelated user     legacy-users: []          history: author-role "admin"
```

That run predates the gating commit; today the unrelated user gets 403 from `get-site-editors` instead of an empty list (`get-site-editors-scope-test`), and the history line is unchanged.

One existing test was pinned to `{:roles []}` along the way: `gen-user` generates *random* permissions, and a generated city/type role matching the fixture site would have lifted the viewer out of `:none` and flaked the test.

## Known gaps (not addressed here)

- **The Jäsenet tab shows full co-member emails to plain members** (`get-org-members`, gated `org-member-or-admin?`). The per-subject masking above keeps the Kohteet drawer consistent with it, but the tab itself is untouched by this PR.
- **Org members cannot open the history tab at all** (`:org/view-history` is admin-only), so "members see masked" has no effect there today.
- **The mask preserves local-part length**, which is a small length disclosure, and two similar colleagues on one domain can collapse to the same string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

