### PR TITLE
Prepare 2026 subsidies: fold AVI into new issuer LVV

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -339,17 +339,22 @@ curl -X POST "localhost:9209/_aliases?pretty" -H 'Content-Type: application/json
 
 ### Subsidies
 
-OKM and AVI are the two main sports facility related subsidy issuers in Finland. The data from both sources is combined manually to an Excel-file by the Lipas-team.
+OKM and LVV (Lupa- ja valvontavirasto, since 2026; before that AVI, and before 2014 the ELY centres) are the two main sports facility related subsidy issuers in Finland. The data from both sources is combined manually to an Excel-file by the Lipas-team.
 
 The data is updated yearly to Lipas. The updated data contains subsidies considering the current year.
 
 The data is stored to the db and indexed from db to elasticsearch.
 
+Issuer names are normalized to the *current* agency: every ELY and AVI row is stored as `"LVV"` (see `lipas.maintenance/subsidy-issuer-normalization`), so the stats UI shows one continuous regional issuer series. The grant year tells which agency actually issued a subsidy. When the issuer is reorganized again, add the old name to that map, add a migration that rewrites the existing rows (see `20260910120000-subsidy-issuer-avi-to-lvv`), update `lipas.reports/subsidies-issuers` and the default `:selected-issuers` in `lipas.ui.stats.subsidies.db`.
+
 - Acquire the Excel file from the team
-- Save Excel as CSV
+- Save Excel as CSV (UTF-8)
   - The CSV should contain only "new data" (no historical data)
+  - Column headers must match `lipas.maintenance/subsidy-csv-headers` (whitespace differences are tolerated). The sports-site name column is optional.
+- Dry run locally: `(lipas.maintenance/read-subsidies-csv "path.csv")` and validate with `lipas.maintenance/subsidy-db-entries-schema`. Typical failures are municipality names not matching `lipas.data.cities`, unknown type codes and unknown owner labels.
 - Upload the csv to prod server
 - Run `lipas.maintenance/add-subsidies-from-csv!` from the REPL
+  - Writes the rows to the `subsidy` table and rebuilds the whole subsidies ES index from the table
 - Enable current year in the stats -> subsidies UI
   - `lipas.ui.stats.subsidies.views` (year selector valid range)
   - `lipas.ui.stats.subsidies.db` (selected year default value)

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -77,7 +77,7 @@ Broader financial analysis across regions:
 Tracks government subsidies for sports facilities:
 
 - Subsidy amounts by region, type, and year
-- Filtering by issuer (AVI, OKM)
+- Filtering by issuer (LVV, OKM; historical ELY and AVI grants are stored under LVV)
 - Comparison and ranking views
 - Historical data from 2002 onwards
 

--- a/webapp/resources/migrations/20260910120000-subsidy-issuer-avi-to-lvv.down.sql
+++ b/webapp/resources/migrations/20260910120000-subsidy-issuer-avi-to-lvv.down.sql
@@ -1,0 +1,6 @@
+-- Restore the pre-2026 issuer name for rows that were folded into LVV.
+-- Rows from 2026 on were genuinely issued by LVV and are left as-is.
+UPDATE subsidy
+   SET data = jsonb_set(data, '{issuer}', '"AVI"')
+ WHERE data->>'issuer' = 'LVV'
+   AND year < 2026;

--- a/webapp/resources/migrations/20260910120000-subsidy-issuer-avi-to-lvv.up.sql
+++ b/webapp/resources/migrations/20260910120000-subsidy-issuer-avi-to-lvv.up.sql
@@ -1,0 +1,15 @@
+-- Regional State Administrative Agencies (AVI) were abolished at the end of
+-- 2025 and their sports-facility subsidy duties moved to the new national
+-- Lupa- ja valvontavirasto (LVV) from 2026 on.
+--
+-- Subsidy issuer names are normalized to the *current* agency (the same was
+-- done when ELY centres became AVIs: all ELY rows are stored as "AVI"), so
+-- the stats UI shows one continuous issuer series. Fold AVI into LVV.
+-- The grant year still tells which agency actually issued each subsidy.
+--
+-- See lipas.maintenance/subsidy-issuer-normalization. The subsidies ES
+-- index is rebuilt from this table by lipas.maintenance/index-subsidies!,
+-- which must be run after this migration (the yearly import does it).
+UPDATE subsidy
+   SET data = jsonb_set(data, '{issuer}', '"LVV"')
+ WHERE data->>'issuer' = 'AVI';

--- a/webapp/src/clj/lipas/maintenance.clj
+++ b/webapp/src/clj/lipas/maintenance.clj
@@ -165,6 +165,20 @@
    "Myönnetty avustus tuhatta e" :amount
    "Avustuksen selite" :description})
 
+;; Issuer names are normalized to the *current* agency. The regional
+;; sports administration has been reorganized twice: ELY centres
+;; (until 2013) -> AVI (2014-2025) -> LVV, Lupa- ja valvontavirasto
+;; (2026-). Historical rows are folded into the current name so the
+;; UI shows one continuous issuer series instead of three that each
+;; end abruptly. Same for the ministry rename OPM -> OKM.
+(def subsidy-issuer-normalization
+  {"ELY" "LVV"
+   "AVI" "LVV"
+   "OPM" "OKM"})
+
+(defn normalize-subsidy-issuer [issuer]
+  (get subsidy-issuer-normalization issuer issuer))
+
 (defn ->subsidy-db-entry [m]
   (-> m
       (assoc :city-code (-> m :city-name city-lookup))
@@ -172,10 +186,7 @@
       (update :year utils/->int)
       (update :lipas-ids #(-> % (str/split #";") (->> (mapv utils/->int) (remove nil?))))
       (update :owner owner-lookup)
-      (update :issuer #(condp = %
-                         "ELY" "AVI"
-                         "OPM" "OKM"
-                         %))
+      (update :issuer normalize-subsidy-issuer)
       (update :amount utils/->number)))
 
 ;; Subsidies reference the municipality at grant time, so abolished
@@ -190,26 +201,37 @@
    [:city-code subsidy-city-code-schema]
    [:type-codes types-schema/type-codes-with-legacy]
    [:owner sports-site-schema/owner]
-   [:issuer [:enum "AVI" "OKM"]]
+   [:issuer (into [:enum] (distinct (vals subsidy-issuer-normalization)))]
    [:receiver-name {:optional true} [:string]]
    [:description {:optional true} [:string]]
    [:lipas-ids {:optional true} [:sequential sports-site-schema/lipas-id]]])
 
 (def subsidy-db-entries-schema [:sequential subsidy-db-entry-schema])
 
+(defn- normalize-csv-header
+  "Excel exports tend to carry stray whitespace in header cells (e.g.
+  \"tuhatta  e\" with a double space), which would silently leave the
+  column unmatched in `subsidy-csv-headers`."
+  [s]
+  (-> s str/trim (str/replace #"\s+" " ")))
+
+(defn read-subsidies-csv
+  "Reads and parses a subsidies CSV into db entries. Pure; does not
+  touch the db, so it doubles as a dry run for validating a new sheet."
+  [csv-path]
+  (let [[header & rows] (->> csv-path slurp csv/read-csv)]
+    (->> (cons (map normalize-csv-header header) rows)
+         utils/csv-data->maps
+         (map #(set/rename-keys % subsidy-csv-headers))
+         (map ->subsidy-db-entry))))
+
 (defn add-subsidies-from-csv!
   [{:keys [db] :as system} csv-path]
 
   (log/info "Reading subsidies from csv" csv-path)
 
-  (let [ms (->> csv-path
-                slurp
-                csv/read-csv
-                utils/csv-data->maps
-                (map #(set/rename-keys % subsidy-csv-headers))
-                (map ->subsidy-db-entry))]
+  (let [ms (read-subsidies-csv csv-path)]
 
-    ;; TODO add malli schema or spec for entries
     (log/info "Validating" (count ms) "subsidy entries")
     ;; Validate that all columns names were matched
     ;; Note: :target (sports-site name) is not available in all sheets
@@ -329,8 +351,8 @@
                       (map walk/keywordize-keys))
         stats-map (->city-stats-map csv-data year)]
 
-    ;; Validate that all columns names were matched
     ;; TODO add malli schema or spec for entries
+    ;; Validate that all columns names were matched
     (log/info "Validating" (count csv-data) "city finance entries")
     (assert (= (into #{} (map keyword) city-finance-csv-headers)
                (into #{} (mapcat keys) csv-data)))

--- a/webapp/src/cljc/lipas/reports.cljc
+++ b/webapp/src/cljc/lipas/reports.cljc
@@ -386,10 +386,12 @@
              :se "Typ"
              :en "Type"}}))
 
+;; Historical ELY and AVI subsidies are stored under "LVV" (see
+;; lipas.maintenance/subsidy-issuer-normalization), hence the hint.
 (def subsidies-issuers
-  {"AVI" {:fi "AVI"
-          :se "AVI"
-          :en "AVI"}
+  {"LVV" {:fi "LVV (ent. AVI)"
+          :se "LVV (f.d. RFV)"
+          :en "LVV (formerly AVI)"}
    "OKM" {:fi "OKM"
           :se "OKM"
           :en "OKM"}})

--- a/webapp/src/cljs/lipas/ui/stats/subsidies/db.cljs
+++ b/webapp/src/cljs/lipas/ui/stats/subsidies/db.cljs
@@ -5,8 +5,8 @@
   {:selected-view     "chart"
    :selected-cities   [] ; whole country
    :selected-types    [] ; all types
-   :selected-issuers  ["AVI" "OKM"]
-   :selected-years    [2025]
+   :selected-issuers  ["LVV" "OKM"]
+   :selected-years    [2026]
    :groupings         reports/subsidies-groupings
    :issuers           reports/subsidies-issuers
    :selected-grouping "avi"

--- a/webapp/src/cljs/lipas/ui/stats/subsidies/views.cljs
+++ b/webapp/src/cljs/lipas/ui/stats/subsidies/views.cljs
@@ -101,7 +101,7 @@
        [:> Grid {:item true}
         [years-selector
          {:tr        tr
-          :years     (range 2002 (inc 2025))
+          :years     (range 2002 (inc 2026))
           :value     years
           :on-change #(==> [::events/select-years %])}]]
 

--- a/webapp/test/clj/lipas/maintenance_test.clj
+++ b/webapp/test/clj/lipas/maintenance_test.clj
@@ -1,0 +1,51 @@
+(ns lipas.maintenance-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [lipas.maintenance :as maint]
+            [malli.core :as m]))
+
+(deftest subsidy-issuer-normalization-test
+  (testing "historical issuers fold into the current agency"
+    (is (= "LVV" (maint/normalize-subsidy-issuer "ELY")))
+    (is (= "LVV" (maint/normalize-subsidy-issuer "AVI")))
+    (is (= "OKM" (maint/normalize-subsidy-issuer "OPM"))))
+  (testing "current issuers pass through"
+    (is (= "LVV" (maint/normalize-subsidy-issuer "LVV")))
+    (is (= "OKM" (maint/normalize-subsidy-issuer "OKM"))))
+  (testing "db schema accepts exactly the normalized issuers"
+    (doseq [issuer (distinct (vals maint/subsidy-issuer-normalization))]
+      (is (m/validate (m/schema [:enum "LVV" "OKM"]) issuer)))))
+
+(defn- csv-file [header rows]
+  (let [f (java.io.File/createTempFile "subsidies" ".csv")]
+    (.deleteOnExit f)
+    (with-open [w (io/writer f)]
+      (.write w (str header "\n"))
+      (doseq [r rows] (.write w (str r "\n"))))
+    (.getPath f)))
+
+(deftest read-subsidies-csv-test
+  (let [;; Header as exported from the 2026 sheet: trailing/double spaces.
+        header (str "Avustuksen myöntäjä ,Tyyppikoodi (numero),Lipas-ID,"
+                    "\"Saajataho, luokiteltu (Lipas-luokitus omistaja)\","
+                    "Avustuksen saaja,Avustuksen selite,Kunta myöntövuonna,"
+                    "Myöntövuosi,Myönnetty avustus tuhatta  e")
+        rows ["LVV,3110;2210,505864;88919,Kunta,Ylitornion kunta,Uimahalli,Ylitornio,2026,600"
+              "AVI,1120,,Kunta,Vantaan kaupunki,,Vantaa,2025,135"
+              "OKM,1220,75921,Säätiö,Stadion-säätiö sr,Perusparannus,Helsinki,2026,324.34"]
+        entries (maint/read-subsidies-csv (csv-file header rows))]
+    (testing "header whitespace is tolerated"
+      (is (every? (comp number? :amount) entries))
+      (is (every? #(contains? % :issuer) entries)))
+    (testing "entries validate against the db schema"
+      (is (m/validate maint/subsidy-db-entries-schema entries)
+          (pr-str (m/explain maint/subsidy-db-entries-schema entries))))
+    (testing "field parsing"
+      (let [[a b c] entries]
+        (is (= {:issuer "LVV" :type-codes #{3110 2210} :lipas-ids [505864 88919]
+                :city-code 976 :owner "city" :year 2026 :amount 600}
+               (select-keys a [:issuer :type-codes :lipas-ids :city-code :owner :year :amount])))
+        (is (= "LVV" (:issuer b)) "AVI folds into LVV")
+        (is (= [] (:lipas-ids b)))
+        (is (= {:issuer "OKM" :owner "foundation" :amount 324.34}
+               (select-keys c [:issuer :owner :amount])))))))


### PR DESCRIPTION
## Summary

Yearly sports facility subsidy update for 2026. AVIs were abolished at the end of 2025 and the new issuer is **LVV** (Lupa- ja valvontavirasto). This applies the same pattern used when ELY centres became AVIs: historical issuer names are normalized to the current agency, so the stats UI shows one continuous regional issuer series.

- `lipas.maintenance`: `subsidy-issuer-normalization` (ELY/AVI → LVV, OPM → OKM), issuer enum derived from it, pure `read-subsidies-csv` for dry runs, CSV headers tolerate stray whitespace (the 2026 sheet has a double space in the amount header)
- Migration `20260910120000-subsidy-issuer-avi-to-lvv`: rewrites existing AVI rows to LVV (3212 rows in a prod-like DB); down restores AVI for years < 2026
- UI: issuers `LVV (ent. AVI)` + `OKM`, defaults LVV+OKM / 2026, year selector to 2026
- Unit test for the loader; ops/reports docs updated

## Verification

- 2026 CSV (70 rows: 55 LVV, 15 OKM, 14 939.56 k€) validates against `subsidy-db-entries-schema`; all municipalities, type codes, owners and 28 lipas-ids resolve
- Migration up/down rehearsed in a rolled-back transaction on a local prod-like DB
- `bb check` clean on changed files, CLJS builds with 0 warnings, `lipas.maintenance-test` passes

## Deploy notes

1. Deploy runs the migration from the jar.
2. Then run the import from the prod REPL with the 2026 CSV (`add-subsidies-from-csv!`). It rebuilds the whole subsidies ES index, so the AVI→LVV rename reaches ES in the same step.
3. Open question for the team: Vantaa has two identical LVV rows (1340;1130, 238 k€), presumably two separate grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XECHCdDYgzAPguznzMoGnW
